### PR TITLE
hotfix for failed SOAP calls crashing application

### DIFF
--- a/gemutils/include/gem/utils/soap/GEMSOAPToolBox.h
+++ b/gemutils/include/gem/utils/soap/GEMSOAPToolBox.h
@@ -63,7 +63,7 @@ namespace gem {
                                 xdaq::ApplicationDescriptor* destDsc
                                 // log4cplus::Logger* logger
                                 )
-          throw (gem::utils::exception::Exception);
+          throw (gem::utils::exception::SOAPException);
 
         /**
          * @param cmd command to send to a TCDS application (which requires a special header)
@@ -79,7 +79,7 @@ namespace gem {
                                     xdaq::ApplicationDescriptor* destDsc
                                     // log4cplus::Logger* logger
                                     )
-          throw (gem::utils::exception::Exception);
+          throw (gem::utils::exception::SOAPException);
 
         /**
          * @param parameter is a vector of strings, contaning the parameter name, value, and the xsd type for the SOAP transaction
@@ -97,7 +97,7 @@ namespace gem {
                                   // log4cplus::Logger* logger,
                                   // std::string const& param
                                   )
-          throw (gem::utils::exception::Exception);
+          throw (gem::utils::exception::SOAPException);
 
         static std::pair<std::string,std::string> extractCommandWithParameter(xoap::MessageReference const& msg);
 
@@ -114,7 +114,7 @@ namespace gem {
                                              xdaq::ApplicationDescriptor* srcDsc,
                                              xdaq::ApplicationDescriptor* destDsc
                                              )
-          throw (gem::utils::exception::Exception);
+          throw (gem::utils::exception::SOAPException);
 
          /**
          * @param cmd Name of the Command to send to the destination application
@@ -130,7 +130,7 @@ namespace gem {
                                                 xdaq::ApplicationDescriptor* srcDsc,
                                                 xdaq::ApplicationDescriptor* destDsc
                                                 )
-          throw (gem::utils::exception::Exception);
+          throw (gem::utils::exception::SOAPException);
 
          /**
          * @param parName Name of the parameter in the destination application info space
@@ -148,7 +148,7 @@ namespace gem {
                                              xdaq::ApplicationDescriptor* srcDsc,
                                              xdaq::ApplicationDescriptor* destDsc
                                              )
-          throw (gem::utils::exception::Exception);
+          throw (gem::utils::exception::SOAPException);
 
          /**
          * @param bagName Name of the parameter bag in the destination application info space
@@ -165,7 +165,7 @@ namespace gem {
                                                   xdaq::ApplicationDescriptor* srcDsc,
                                                   xdaq::ApplicationDescriptor* destDsc
                                                   )
-          throw (gem::utils::exception::Exception) {
+          throw (gem::utils::exception::SOAPException) {
           log4cplus::Logger m_gemLogger(log4cplus::Logger::getInstance("GEMSOAPToolBoxLogger"));
           try {
             xoap::MessageReference msg = xoap::createMessage(), answer;

--- a/gemutils/src/common/soap/GEMSOAPToolBox.cc
+++ b/gemutils/src/common/soap/GEMSOAPToolBox.cc
@@ -109,7 +109,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommand(std::string const& cmd,
                                                    // log4cplus::Logger* logger,
                                                    // std::string const& param
                                                    )
-  throw (gem::utils::exception::Exception)
+  throw (gem::utils::exception::SOAPException)
 {
   log4cplus::Logger m_gemLogger(log4cplus::Logger::getInstance("GEMSOAPToolBoxLogger"));
   try {
@@ -137,6 +137,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommand(std::string const& cmd,
     // xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
     msg->writeTo(tool);
     DEBUG("::sendCommand '" << cmd << "': SOAP " << tool);
+    // BUG FIXME: if this throws, we get a terminate, why???
     xoap::MessageReference reply = appCxt->postSOAP(msg, *srcDsc, *destDsc);
     tool.clear();
     // xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
@@ -165,7 +166,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendTCDSCommand(std::string const& cmd,
                                                        // log4cplus::Logger* logger,
                                                        // std::string const& param
                                                        )
-  throw (gem::utils::exception::Exception)
+  throw (gem::utils::exception::SOAPException)
 {
   log4cplus::Logger m_gemLogger(log4cplus::Logger::getInstance("GEMSOAPToolBoxLogger"));
   try {
@@ -218,7 +219,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendParameter(std::vector<std::string> co
                                                      xdaq::ApplicationDescriptor* destDsc
                                                      // log4cplus::Logger* logger
                                                      )
-  throw (gem::utils::exception::Exception)
+  throw (gem::utils::exception::SOAPException)
 {
   log4cplus::Logger m_gemLogger(log4cplus::Logger::getInstance("GEMSOAPToolBoxLogger"));
   if (parameter.size() != 3)
@@ -294,7 +295,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameter(std::string cons
                                                                 xdaq::ApplicationDescriptor* srcDsc,
                                                                 xdaq::ApplicationDescriptor* destDsc
                                                                 )
-  throw (gem::utils::exception::Exception)
+  throw (gem::utils::exception::SOAPException)
 {
   log4cplus::Logger m_gemLogger(log4cplus::Logger::getInstance("GEMSOAPToolBoxLogger"));
   try {
@@ -333,7 +334,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(std::string c
                                                                    xdaq::ApplicationDescriptor* srcDsc,
                                                                    xdaq::ApplicationDescriptor* destDsc
                                                                    )
-  throw (gem::utils::exception::Exception) {
+  throw (gem::utils::exception::SOAPException) {
   log4cplus::Logger m_gemLogger(log4cplus::Logger::getInstance("GEMSOAPToolBoxLogger"));
   try {
     xoap::MessageReference msg = xoap::createMessage(), reply;
@@ -422,7 +423,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendApplicationParameter(std::string cons
                                                                 xdaq::ApplicationDescriptor* srcDsc,
                                                                 xdaq::ApplicationDescriptor* destDsc
                                                                 )
-  throw (gem::utils::exception::Exception)
+  throw (gem::utils::exception::SOAPException)
 {
   log4cplus::Logger m_gemLogger(log4cplus::Logger::getInstance("GEMSOAPToolBoxLogger"));
   try {
@@ -476,7 +477,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendApplicationParameter(std::string cons
 //                                                                    xdaq::ApplicationDescriptor* srcDsc,
 //                                                                    xdaq::ApplicationDescriptor* destDsc
 //                                                                    )
-//   throw (gem::utils::exception::Exception)
+//   throw (gem::utils::exception::SOAPException)
 // {
 //   try {
 //     xoap::MessageReference msg = xoap::createMessage(), reply;


### PR DESCRIPTION
* Changed throw specifier so that ```std::unexpected``` is not called,
* fixes cms-gem-daq-project/cmsgemos#117