### PR TITLE
Update vfat_user_functions_uhal.py

### DIFF
--- a/gempython/tools/vfat_user_functions_uhal.py
+++ b/gempython/tools/vfat_user_functions_uhal.py
@@ -24,6 +24,7 @@ class parameters:
         "IShaper":      130,
         "IShaperFeed":   87,
         "IComp":        101,
+        "VCal":           0,
         # ["VThreshold1":   25,
         "VThreshold2": 0x00,
         "CalPhase":    0x00


### PR DESCRIPTION
Re-add `VCal` into the `defaultValues` map, as per #125, hotfix for compatibility, **to be revisited**
