### PR TITLE
Set `TTS_OVERRIDE` in `resetDAQLink` function

### DIFF
--- a/gemhardware/include/gem/hw/HwGenericAMC.h
+++ b/gemhardware/include/gem/hw/HwGenericAMC.h
@@ -379,8 +379,9 @@ namespace gem {
         /**
          * @brief reset the DAQ link and write the DAV timout
          * @param davTO value to use for the DAV timeout
+         * @param ttsOverride value to use for the TTS override
          */
-        virtual void resetDAQLink(uint32_t const& davTO=0x3d090);
+        virtual void resetDAQLink(uint32_t const& davTO=0x3d090, uint32_t const& ttsOverride=0x0);
 
         /**
          * @returns Returns the 32 bit word corresponding to the DAQ link control register

--- a/gemhardware/src/common/HwGenericAMC.cc
+++ b/gemhardware/src/common/HwGenericAMC.cc
@@ -463,7 +463,7 @@ void gem::hw::HwGenericAMC::disableDAQLink()
   writeReg(getDeviceBaseNode(), "DAQ.CONTROL.DAQ_ENABLE",        0x0);
 }
 
-void gem::hw::HwGenericAMC::resetDAQLink(uint32_t const& davTO)
+void gem::hw::HwGenericAMC::resetDAQLink(uint32_t const& davTO, uint32_t const& ttsOverride=0x0)
 {
   writeReg(getDeviceBaseNode(), "DAQ.CONTROL.RESET", 0x1);
   writeReg(getDeviceBaseNode(), "DAQ.CONTROL.RESET", 0x0);
@@ -472,7 +472,7 @@ void gem::hw::HwGenericAMC::resetDAQLink(uint32_t const& davTO)
   // set each link input timeout to 0x30d4 (160MHz clock cycles, 0xc35 40MHz clock cycles)
   setDAQLinkInputTimeout(0x30d4);
   // setDAQLinkInputTimeout(davTO);
-  writeReg(getDeviceBaseNode(), "DAQ.CONTROL.TTS_OVERRIDE", 0x8);/*HACK to be fixed?*/
+  writeReg(getDeviceBaseNode(), "DAQ.CONTROL.TTS_OVERRIDE", ttsOverride);/*HACK to be fixed?*/
 }
 
 uint32_t gem::hw::HwGenericAMC::getDAQLinkControl()

--- a/gemhardware/src/common/HwGenericAMC.cc
+++ b/gemhardware/src/common/HwGenericAMC.cc
@@ -463,7 +463,7 @@ void gem::hw::HwGenericAMC::disableDAQLink()
   writeReg(getDeviceBaseNode(), "DAQ.CONTROL.DAQ_ENABLE",        0x0);
 }
 
-void gem::hw::HwGenericAMC::resetDAQLink(uint32_t const& davTO, uint32_t const& ttsOverride=0x0)
+void gem::hw::HwGenericAMC::resetDAQLink(uint32_t const& davTO, uint32_t const& ttsOverride)
 {
   writeReg(getDeviceBaseNode(), "DAQ.CONTROL.RESET", 0x1);
   writeReg(getDeviceBaseNode(), "DAQ.CONTROL.RESET", 0x0);


### PR DESCRIPTION
Remove hardcoded `0x8` and add parameter to function, default value of `0x0

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `resetDAQLink` function previously had hardcoded a value that the CTP7 firmware required, but is now no longer the case.
Adding an optional argument `ttsOverride` in the event that this register needs to have a non-zero value

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Addressing #136
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
