### PR TITLE
Update vfat_info_uhal.py

### DIFF
--- a/gempython/tests/vfat_info_uhal.py
+++ b/gempython/tests/vfat_info_uhal.py
@@ -203,7 +203,7 @@ print
 print "--===== Last BX Latency Counter =========--"
 print
 counts = []
-writeAllVFATs(ohboard, options.gtx, "VThreshold1", 100)
+# writeAllVFATs(ohboard, options.gtx, "VThreshold1", 100)
 for i in range(24):
     baseNode = "GEM_AMC.OH.OH%d.COUNTERS"%(options.gtx)
     writeRegister(ohboard,"%s.VFAT%d_LAT_BX.RESET"%(baseNode,i),0x1)


### PR DESCRIPTION
Remove hard-coded setting of `VThreshold1` from historical reasons

### Types of changes
- [x] Removes hard-coded  (non-breaking change enhances flexibility)

## Motivation and Context
Calling this script would set all VFATs to have `VThreshold1` of 100, which is problematic if a measurement is ongoing

## How Has This Been Tested?
It hasn't, but the change is trivial