### PR TITLE
Update vfat_user_functions_uhal.py

### DIFF
--- a/gempython/tools/vfat_user_functions_uhal.py
+++ b/gempython/tools/vfat_user_functions_uhal.py
@@ -306,8 +306,9 @@ def displayChipInfo(device, gtx, regkeys, mask=0xff000000, debug=False):
     perslot  = "%3d"
     perchip  = "0x%04x"
     perreg   = "0x%02x"
-    registerList = [
-	"ContReg0","ContReg1","ContReg2","ContReg3",
+    perset   = "%4d"
+    registerList = ["ContReg0","ContReg1","ContReg2","ContReg3"]
+    settingList = [
 	"Latency",
 	"IPreampIn","IPreampFeed","IPreampOut",
 	"IShaper","IShaperFeed",
@@ -331,6 +332,15 @@ def displayChipInfo(device, gtx, regkeys, mask=0xff000000, debug=False):
         regValues = readAllVFATs(device, gtx, reg, mask, debug)
         regmap = map(lambda chip: perreg%(chip&0xff), regValues)
         msg = "%11s::  %s"%(reg, '   '.join(map(str, regmap)))
+        # vfatlogger.info(colormsg(msg,logging.INFO))
+        print msg
+        pass
+
+    for setting in settingList:
+        # setmap = map(lambda chip: perset%(readVFAT(device, gtx, chip, setting)&0xff), regkeys.keys())
+        settingValues = readAllVFATs(device, gtx, setting, mask, debug)
+        setmap = map(lambda chip: perset%(chip&0xff), settingValues)
+        msg = "%11s::  %s"%(setting, '   '.join(map(str, setmap)))
         # vfatlogger.info(colormsg(msg,logging.INFO))
         print msg
         pass

--- a/gempython/tools/vfat_user_functions_uhal.py
+++ b/gempython/tools/vfat_user_functions_uhal.py
@@ -307,41 +307,36 @@ def displayChipInfo(device, gtx, regkeys, mask=0xff000000, debug=False):
     perchip  = "0x%04x"
     perreg   = "0x%02x"
     perset   = "%4d"
-    registerList = ["ContReg0","ContReg1","ContReg2","ContReg3"]
-    settingList = [
-	"Latency",
-	"IPreampIn","IPreampFeed","IPreampOut",
-	"IShaper","IShaperFeed",
-	"IComp",
-	"VCal",
-	"VThreshold1",
-	"VThreshold2",
-	"CalPhase",
-        ]
+    registerList = {perreg: ["ContReg0","ContReg1","ContReg2","ContReg3"],
+                    perset: [
+            "Latency",
+            "IPreampIn","IPreampFeed","IPreampOut",
+            "IShaper","IShaperFeed",
+            "IComp",
+            "VCal",
+            "VThreshold1",
+            "VThreshold2",
+            "CalPhase",
+            ]
+                    }
 
     slotmap = map(lambda slotID: perslot%(slotID), regkeys.keys())
     msg = "%s   %s%s%s"%(slotbase,colors.GREEN,'    '.join(map(str, slotmap)),colors.ENDC)
     # vfatlogger.info(colormsg(msg,logging.INFO))
-    print msg
+    print(msg)
     chipmap = map(lambda chipID: perchip%(regkeys[chipID]), regkeys.keys())
     msg = "%s%s%s%s"%(base,colors.CYAN,' '.join(map(str, chipmap)),colors.ENDC)
     # vfatlogger.info(colormsg(msg,logging.INFO))
-    print msg
-    for reg in registerList:
-        # regmap = map(lambda chip: perreg%(readVFAT(device, gtx, chip,reg)&0xff), regkeys.keys())
-        regValues = readAllVFATs(device, gtx, reg, mask, debug)
-        regmap = map(lambda chip: perreg%(chip&0xff), regValues)
-        msg = "%11s::  %s"%(reg, '   '.join(map(str, regmap)))
-        # vfatlogger.info(colormsg(msg,logging.INFO))
-        print msg
-        pass
+    print(msg)
 
-    for setting in settingList:
-        # setmap = map(lambda chip: perset%(readVFAT(device, gtx, chip, setting)&0xff), regkeys.keys())
-        settingValues = readAllVFATs(device, gtx, setting, mask, debug)
-        setmap = map(lambda chip: perset%(chip&0xff), settingValues)
-        msg = "%11s::  %s"%(setting, '   '.join(map(str, setmap)))
-        # vfatlogger.info(colormsg(msg,logging.INFO))
-        print msg
+    for key in registerList:
+        for reg in registerList[key]:
+            # regmap = map(lambda chip: perreg%(readVFAT(device, gtx, chip,reg)&0xff), regkeys.keys())                                                                                                                                                                            
+            regValues = readAllVFATs(device, gtx, reg, mask, debug)
+            regmap = map(lambda chip: key%(chip&0xff), regValues)
+            msg = "%11s::  %s"%(reg, '   '.join(map(str, regmap)))
+            # vfatlogger.info(colormsg(msg,logging.INFO))                                                                                                                                                                                                                         
+            print msg
+            pass
         pass
     return


### PR DESCRIPTION
## Description
Possible response to #145, printing VFAT settings in `dec` representation rather than `hex`

### Types of changes
- [x] Redesign of feature

## Motivation and Context
Semantically, control registers and bias/setting registers have different uses
* For bias/setting registers, a decimal representation is more semantically correct
* For a control register, a `hex` representation is more semantically correct
This PR simply applies a change that has been on the back burner for a very long time

## How Has This Been Tested?
Produces output:
```bash
GEB0 SlotID::     0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18     19     20     21     22     23
     ChipID::0xf69f 0xff24 0xfa28 0xff60 0xfa40 0xfa17 0xf75b 0xff2c 0xfeeb 0xf99b 0xffe7 0xff4c 0xf747 0xff87 0xff40 0xff6b 0xfa20 0xffcb 0xff48 0xfa2c 0xff9b 0xffdc 0xff83 0xf6bc
   ContReg0::  0x36   0x36   0x36   0x36   0x02   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36   0x36
   ContReg1::  0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00
   ContReg2::  0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30   0x30
   ContReg3::  0x04   0x01   0x01   0x03   0x03   0x02   0x03   0x02   0x00   0x01   0x00   0x01   0x00   0x00   0x01   0x03   0x01   0x02   0x00   0x01   0x00   0x00   0x00   0x00
    Latency::   169    169    169    169    169    169    169    169    169    169    169    169    169    169    169    169    169    169      0    169    169    169    169    169
  IPreampIn::   144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144    144
IPreampFeed::    69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69     69
 IPreampOut::   129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129    129
    IShaper::   130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130    130
IShaperFeed::    87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87     87
      IComp::   101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101    101
       VCal::     0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0
VThreshold1::   104     51     70     82    110    113    119    139     38     42      0     54     58     60     74    111     56     54      0     60      0      0      0      0
VThreshold2::     0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0
   CalPhase::     0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0      0
```
