### PR TITLE
Suppressing echo statements from setup scripts for shell sourcing compatibility

### DIFF
--- a/setup/paths.sh
+++ b/setup/paths.sh
@@ -1,14 +1,14 @@
-#export BUILD_HOME=<your path>/cmsgemos/../
+# export BUILD_HOME=<your path>/cmsgemos/../
 if [[ -n "$GEM_OS_PROJECT" ]]; then
-    echo GEM_OS_PROJECT $GEM_OS_PROJECT
+    ; # echo GEM_OS_PROJECT $GEM_OS_PROJECT
 else
     echo "GEM_OS_PROJECT not set, setting to 'cmsgemos'"
     export GEM_OS_PROJECT=cmsgemos
-    echo GEM_OS_PROJECT $GEM_OS_PROJECT
+    ; # echo GEM_OS_PROJECT $GEM_OS_PROJECT
 fi
 
 if [[ -n "$BUILD_HOME" ]]; then
-    echo BUILD_HOME $BUILD_HOME
+    ; #echo BUILD_HOME $BUILD_HOME
 else
     echo "BUILD_HOME not set, please set BUILD_HOME to the directory above the root of your repository"
     echo " (export BUILD_HOME=<your path>/cmsgemos/../) and then rerun this script"
@@ -19,20 +19,20 @@ fi
 # to guess the OS
 
 if [[ -n "$XDAQ_OS" ]]; then
-    echo XDAQ_OS $XDAQ_OS
+    ; # echo XDAQ_OS $XDAQ_OS
 else
     if [[ $(uname -s) = "Linux" ]]; then
         XDAQ_OS=linux
     elif [[ $(uname -s) = "Darwin" ]]; then
         XDAQ_OS=macosx
     fi
-    echo XDAQ_OS $XDAQ_OS
+    ; # echo XDAQ_OS $XDAQ_OS
     export XDAQ_OS
 fi
 
 ## The platform is not set. Let's guess it
 if [[ -n "$XDAQ_PLATFORM" ]]; then
-    echo XDAQ_PLATFORM $XDAQ_PLATFORM
+    ; # echo XDAQ_PLATFORM $XDAQ_PLATFORM
 else
     if [[ $(uname -m) = "i386" ]]; then
         XDAQ_PLATFORM=x86
@@ -50,7 +50,7 @@ else
         XDAQ_PLATFORM=ppc
     fi
     XDAQ_PLATFORM=${XDAQ_PLATFORM}_$(source $XDAQ_ROOT/config/checkos.sh)
-    echo XDAQ_PLATFORM $XDAQ_PLATFORM
+    ; # echo XDAQ_PLATFORM $XDAQ_PLATFORM
     export XDAQ_PLATFORM
 fi
 
@@ -61,7 +61,6 @@ export LD_LIBRARY_PATH=${BUILD_HOME}/${GEM_OS_PROJECT}/gemhardware/lib/${XDAQ_OS
 export LD_LIBRARY_PATH=${BUILD_HOME}/${GEM_OS_PROJECT}/gemsupervisor/lib/${XDAQ_OS}/${XDAQ_PLATFORM}:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH=${BUILD_HOME}/${GEM_OS_PROJECT}/gemHwMonitor/lib/${XDAQ_OS}/${XDAQ_PLATFORM}:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-echo LD_LIBRARY_PATH $LD_LIBRARY_PATH
 export GEM_ADDRESS_TABLE_PATH=${BUILD_HOME}/${GEM_OS_PROJECT}/setup/etc/addresstables
 export GEM_PYTHON_PATH=${BUILD_HOME}/${GEM_OS_PROJECT}
 export PYTHONPATH=${GEM_PYTHON_PATH}:${PYTHONPATH}


### PR DESCRIPTION
* `echo`s in environment setup scripts are often problematic, removing for now in favour of a shell function to print the environment
* `echo`s in cases of a failure will remain
