### PR TITLE
New Feature: Adding setAllChannelRegisters to HwVFAT

### DIFF
--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -118,14 +118,16 @@ class HwVFAT:
         else:
             return vfatVal
 
-    def setChannelRegister(self, chip, chan, mask=0x0, pulse=0x0, trimARM=0x0, trimZCC=0x0, debug=False):
+    def setChannelRegister(self, chip, chan, mask=0x0, pulse=0x0, trimARM=0x0, trimARMPol=0x0, trimZCC=0x0, trimZCCPol=0x0, debug=False):
         """
         chip - VFAT to write
         chan - channel on vfat
         mask - channel mask
         pulse - cal pulse enabled
         trimARM - v2b (v3) electronics trimDAC (arm comparator trim)
+        trimARMPol - v3 electroncis only, polarity of the trimDAC for the arming comparator
         trimZCC - v3 electronics only, zero crossing comparator trim
+        trimZZPol - as trimARMPol but for the zero crossing comparator
         """
 
         # Invalid channel check
@@ -136,9 +138,11 @@ class HwVFAT:
         # Write registers
         if self.parentOH.parentAMC.fwVersion > 2:
             self.writeVFAT(chip, "VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_AMPLITUDE"%(chan), trimARM)
+            self.writeVFAT(chip, "VFAT_CHANNELS.CHANNEL%d.ARM_TRIM_POLARITY"%(chan), trimARMPol)
             self.writeVFAT(chip, "VFAT_CHANNELS.CHANNEL%d.CALPULSE_ENABLE"%(chan), pulse)
             self.writeVFAT(chip, "VFAT_CHANNELS.CHANNEL%d.MASK"%(chan), mask)
             self.writeVFAT(chip, "VFAT_CHANNELS.CHANNEL%d.ZCC_TRIM_AMPLITUDE"%(chan), trimZCC)
+            self.writeVFAT(chip, "VFAT_CHANNELS.CHANNEL%d.ZCC_TRIM_POLARITY"%(chan), trimZCCPol)
         else:
             chanReg = ((pulse&0x1) << 6)|((mask&0x1) << 5)|(trimARM&0x1f)
             self.writeVFAT(chip, "VFATChannels.ChanReg%d"%(chan),chanReg)

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -148,10 +148,10 @@ class HwVFAT:
             self.writeVFAT(chip, "VFATChannels.ChanReg%d"%(chan),chanReg)
         return
 
-    def setChannelRegisterAll(self, chan, chMask=0x0, pulse=0x0, trimARM=0x0, trimZCC=0x0, vfatMask=0x0, debug=False):
+    def setChannelRegisterAll(self, chan, chMask=0x0, pulse=0x0, trimARM=0x0, trimARMPol=0x0, trimZCC=0x0, trimZCCPol=0x0, vfatMask=0x0, debug=False):
         for vfat in range(0,self.parentOH.nVFATs):
             if (vfatMask >> vfat) & 0x1: continue
-            self.setChannelRegister(vfat, chan, chMask, pulse, trimARM, trimZCC, debug)
+            self.setChannelRegister(vfat, chan, chMask, pulse, trimARM, trimARMPol, trimZCC, trimZCCPol, debug)
         return
 
     def setDebug(self, debug):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Requires: 
- https://github.com/cms-gem-daq-project/ctp7_modules/pull/31
- https://github.com/cms-gem-daq-project/xhal/pull/56

Renamed `setChannelRegisterAll()` to `setSpecificChannelAllRegisters()` to be less ambiguous (this function sets the channel `X` registers for all 24 `vfat`s). 

Provided new method, now named `setAllChannelRegisters ()` which sets the channel registers for all 3072 channels.  This method uses a dedicated `xhal` and `ctp7_module` (linked above) for execution and is significantly improved in speed.

@jsturdy @mexanick @BenjaminRS 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Looping over all channels and trying to call the old `setChannelRegisterAll()` method, which executed six RPC calls per channel, was exceptionally slow (e.g. about an hour).  New functionality processes in less than a second.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Performed during v3 trimming studies.

### Screenshots (if appropriate):

![vfat0_pruned_summary_untrimmed](https://user-images.githubusercontent.com/6432141/38319785-fd6e1066-3832-11e8-8b15-f80cfc52a9b5.png)
![vfat0_pruned_summary_trimmed](https://user-images.githubusercontent.com/6432141/38319784-fd4bd14a-3832-11e8-807b-52b359491c0d.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
