### PR TITLE
New Feature: Get Channel Registers for VFAT3 [V3]

### DIFF
--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -88,7 +88,7 @@ class HwVFAT(object):
     def getAllChipIDs(self, mask=0x0):
         return self.readAllVFATs("HW_CHIP_ID",mask)
 
-    def getAllChannelRegisters(self, mask=0x0)
+    def getAllChannelRegisters(self, mask=0x0):
         chanRegData = (c_uint32 * 3072)()
 
         rpcResp = self.getChannelRegistersVFAT3(self.parentOH.link, mask, chanRegData)

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -22,6 +22,11 @@ class HwVFAT(object):
         self.confVFAT3s.argTypes = [ c_uint, c_uint ]
         self.confVFAT3s.restype = c_uint
 
+        # Get all channel regs
+        self.getChannelRegistersVFAT3 = self.parentOH.parentAMC.lib.getChannelRegistersVFAT3
+        self.getChannelRegistersVFAT3.argTypes = [ c_uint, c_uint, POINTER(c_uint32) ]
+        self.getChannelRegistersVFAT3.restype = c_uint
+
         # Turn off calpulses
         self.stopCalPulses2AllChannels = self.parentOH.parentAMC.lib.stopCalPulse2AllChannels
         self.stopCalPulses2AllChannels.argTypes = [ c_uint, c_uint, c_uint, c_uint ]
@@ -82,6 +87,14 @@ class HwVFAT(object):
 
     def getAllChipIDs(self, mask=0x0):
         return self.readAllVFATs("HW_CHIP_ID",mask)
+
+    def getAllChannelRegisters(self, mask=0x0)
+        chanRegData = (c_uint32 * 3072)()
+
+        rpcResp = self.getChannelRegistersVFAT3(self.parentOH.link, mask, chanRegData)
+        if rpcResp != 0:
+            raise Exception("RPC response was non-zero, failed to get channel data for OH{0}".format(self.parentOH.link))
+        return chanRegData
 
     def readAllVFATs(self, reg, mask=0x0):
         vfatVals = self.parentOH.broadcastRead(reg,mask)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`HwVFAT` class now has a method for returning channel registers.

Returns an array of size 3072 where each element is the 16 bit channel register of a given channel.  The array index goes as `idx = 128 * vfat + chan`. 

Requires: 
- https://github.com/cms-gem-daq-project/xhal/pull/81/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Right now there is no way to easily readback channel registers once they are written.  The user has to issue a large number of atomic transactions to get this information.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See [this elog post](http://cmsonline.cern.ch/cms-elog/1055032).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
