### PR TITLE
New Feature: Local SBIT Readout and DAC Monitoring [V3]

### DIFF
--- a/gempython/tests/getVFATMask.py
+++ b/gempython/tests/getVFATMask.py
@@ -1,0 +1,19 @@
+#!/bin/env python                                                                                                                                                                                                                       
+
+if __name__ == '__main__':
+    from gempython.tools.amc_user_functions_xhal import *
+    
+    from optparse import OptionParser
+    
+    parser = OptionParser()
+    parser.add_option("-c", "--cardName", type="string", dest="cardName", default=None,
+            help="hostname of the AMC you are connecting too, e.g. 'eagle64'", metavar="cardName")
+    parser.add_option("-g", "--gtx", type="int", dest="gtx",
+            help="GTX on the AMC", metavar="gtx", default=0)
+    (options, args) = parser.parse_args()
+    
+    amcboard = HwAMC(options.cardName)
+
+    mask = str(hex(amcboard.getLinkVFATMask(options.gtx))).strip('L')
+
+    print("The VFAT Mask you should use for OH{0} is: {1}".format(options.gtx,mask))  

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -38,6 +38,11 @@ class HwAMC(object):
         self.ttcGenToggle.restype = c_uint
         self.ttcGenToggle.argtypes = [c_uint, c_bool]
 
+        # Define SBIT Local Readout
+        self.readSBits = self.lib.sbitReadOut
+        self.readSBits.restype = c_uint
+        self.readSBits.argtypes = [c_uint, c_uint, c_char_p]
+
         # Parse XML
         parseXML()
         #global nodes
@@ -49,6 +54,18 @@ class HwAMC(object):
         print "My FW release major = ", self.fwVersion
 
         return
+
+    def acquireSBits(self, ohN, outFilePath, acquireTime=300):
+        """
+        Using the SBIT_MONITOR acquire sbit data for time in seconds given
+        by acquireTime and write the data to the directory specified by outFilePath
+
+        ohN - optohybrid to monitor
+        outFilePath - filepath created data files will be written too
+        acquireTime - time in seconds to acquire data for
+        """
+
+        return self.readSBits(ohN, acquireTime, outFilePath)
 
     def blockL1A(self):
         """

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -37,7 +37,7 @@ class HwAMC(object):
         self.confDacMonitorMulti.restype = c_uint
 
         self.readADCsMulti = self.lib.readVFAT3ADCMultiLink
-        self.readADCsMulti.argTypes = [ c_uint, POINTER(c_uint32), c_uint, c_uint ]
+        self.readADCsMulti.argTypes = [ c_uint, POINTER(c_uint32), POINTER(c_uint), c_bool ]
         self.readADCsMulti.restype = c_uint
 
         # Define Get OH Mask functionality
@@ -210,7 +210,7 @@ class HwAMC(object):
         else:
             return vfatMaskArray
 
-    def readAllADCsMulti(self, adcDataAll, useExtRefADC=False, ohMask=0xFFF):
+    def readAllADCsMulti(self, adcDataAll, useExtRefADC=False, ohMask=0xFFF, debug=False):
         """
         Reads the ADC value from all unmasked VFATs
 
@@ -220,7 +220,17 @@ class HwAMC(object):
                  having a 1 in the N^th bit means to query the N^th optohybrid
         """
 
+        if debug:
+            print("getting vfatmasks for each OH")
+
         ohVFATMaskArray = self.getMultiLinkVFATMask(ohMask)
+        if debug:
+            print("| ohN | vfatmask |")
+            print("| :-: | :------: |")
+            for ohN in range(0,12):
+                mask = str(hex(ohVFATMaskArray[ohN])).strip('L')
+                print("| {0} | {1} |".format(ohN, mask))
+
         return self.readADCsMulti(ohMask,ohVFATMaskArray, adcDataAll, useExtRefADC)
 
     def readBlock(register, nwords, debug=False):

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -41,9 +41,9 @@ class HwAMC(object):
         self.readADCsMulti.restype = c_uint
 
         # Define Get OH Mask functionality
-        self.self.lib.getOHVFATMask = self.lib.getOHVFATMask
-        self.self.lib.getOHVFATMask.argTypes = [ c_uint ]
-        self.self.lib.getOHVFATMask.restype = c_uint
+        self.getOHVFATMask = self.lib.getOHVFATMask
+        self.getOHVFATMask.argTypes = [ c_uint ]
+        self.getOHVFATMask.restype = c_uint
 
         self.getOHVFATMaskMultiLink = self.lib.getOHVFATMaskMultiLink
         self.getOHVFATMaskMultiLink.argTypes = [ c_uint, POINTER(c_uint32) ]
@@ -182,7 +182,7 @@ class HwAMC(object):
             return os.EX_USAGE
 
         mask = self.getOHVFATMask(ohN)
-        if mask = 0xffffffff:
+        if mask == 0xffffffff:
             raise Exception("RPC response was overflow, failed to determine VFAT mask for OH{0}".format(ohN))
         else:
             return mask

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -380,7 +380,7 @@ class HwAMC(object):
         if rpcResp != 0:
             raise Exception("RPC response was non-zero, reading Sysmon Monitoring Data from OH's in ohMask = {0} failed".format(str(hex(args.ohMask)).strip('L')))
 
-        return scaMonData
+        return sysmonData
 
     def toggleTTCGen(self, ohN, enable):
         """

--- a/gempython/utils/nesteddict.py
+++ b/gempython/utils/nesteddict.py
@@ -1,4 +1,24 @@
 from collections import defaultdict as cdict
+from collections import MutableMapping
+
+def flatten(ndict, parent_key='', sep='_'):
+    """
+    flattens a nesteddict to one dimension, allows for easily
+    determining the number of elements in the nesteddict
+
+    keys of the dictionary and all it's nested dictionaries
+    must be convertable to strings
+
+    ## from https://stackoverflow.com/questions/6027558/flatten-nested-python-dictionaries-compressing-keys
+    """
+    items = []
+    for key, value in ndict.items():
+        new_key = parent_key + sep + str(key) if parent_key else str(key)
+        if isinstance(value, MutableMapping):
+            items.extend(flatten(value, new_key, sep=sep).items())
+        else:
+            items.append((new_key, value))
+    return dict(items)
 
 class nesteddict(dict):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Based off of the [legacyPreBoost](https://github.com/cms-gem-daq-project/xhal/tree/legacyPreBoost) branch of XHAL.

Provides functionality for:

Changes specific to `HwAMC`:
- Configuring ADC monitoring on all VFATs on all OH's on a given AMC.
- Reading ADC's on all VFATs on all OH's on a given AMC.
- Reading temperatures and voltages from all SCA's on all OH's on a given AMC.
- Getting VFAT mask for a specific OH on a given AMC.
- Getting unique VFAT mask for each unmasked OH on a given AMC.
- Reading out SBITs using the SBIT Monitor block in the CTP7 FW for single OH.

Changes specific to `HwOptohybrid`:
- Provide functionality for getting and setting the vfatmask in the OH trigger block.
- Returns the VFAT mask for all VFATs on this OH

Changes specific to `HwVFAT`:
- Enables configuring of ADC Monitoring for each VFAT on a given OH.
- Enables readback of ADC monitoring for each VFAT on a given OH.

### Supporting Changes
Provided new test script `getVFATMask.py`.  Very simple script, takes an AMC network alias and an OH number on the link and returns the VFAT mask for this device (supported for v3 electronics only).

Example call:

```
% getVFATMask.py -c eagle26 -g2
Open pickled address table if available  /opt/cmsgemos/etc/maps/amc_address_table_top.pickle...
Initializing AMC eagle26
My FW release major =  3
The VFAT Mask you should use for OH2 is: 0x809
```

Provides a utility function `flatten()` which flattens a `nesteddict` object into a single "1D" (un-nested) dictionary.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Required tools for configuring ADC monitoring of VFATs for determining temperature measurements.

Required tools for SBIT readout in a local mode for qualifying electronics.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
SBIT Readout functionality has been tested extensively in: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/199

Configuring and reading out ADC monitoring, along with OH multi link mask functionality, has been tested in: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/202

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
