### PR TITLE
[WIP] New Feature:  AMC13 Readout Script

### DIFF
--- a/gempython/tests/amc13ReadOut.py
+++ b/gempython/tests/amc13ReadOut.py
@@ -115,6 +115,7 @@ if __name__ == '__main__':
     amc13board.reset()
     amc13board.configureInputs(args.slotList)
     trigCount = readAllL1ACounters(amc13board, dict_amcs, "INITIAL")
+    amc13board.device.monBufBackPressEnable(False)
 
     # Enable triggers to amc's
     for slot,amc in dict_amcs.iteritems():

--- a/gempython/tests/amc13ReadOut.py
+++ b/gempython/tests/amc13ReadOut.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     # create the parser
     import argparse
     parser = argparse.ArgumentParser(description="Script to readout data with the AMC13.  Presently uFEDKIT is not used. Arguments to supply to amc13ReadOut.py are given below")
-    
+
     # Positional arguments
     from reg_utils.reg_interface.common.reg_xml_parser import parseInt
     parser.add_argument("shelf", type=int, help="uTCA shelf number", metavar="shelf")

--- a/gempython/tests/amc13ReadOut.py
+++ b/gempython/tests/amc13ReadOut.py
@@ -1,0 +1,179 @@
+#!/bin/env python
+
+def readAllL1ACounters(amc13board, amcs, key="Initial", trigCounts=None):
+    """
+    Reads the L1A counters from amc13board and all AMCs in amcs.
+    Returns the L1A counters in a nesteddict trigCounts
+
+    amc13board - instance of the AMC13manager class
+    amcs - dictionary of uhal devices where key is the slot number in the uTCA crate
+    key - key to add to or insert in trigCounts
+    trigCounts - either None or a nesteddict
+    """
+    from gempython.utils.nesteddict import nesteddict
+    if trigCounts is None:
+        trigCounts = nesteddict()
+
+    trigCounts[key]["AMC13"] = (amc13board.device.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_HI") << 32) | (amc13board.device.read(amc13board.Board.T1, "STATUS.GENERAL.L1A_COUNT_LO"))
+
+    from gempython.tools.amc_user_functions_uhal import getL1ACount
+    for slot,amc in amcs.iteritems():
+        trigCounts[key]["AMC{0}".format(slot)] = getL1ACount(amc)
+
+    return trigCounts
+
+def startDataTaking(amc13board, outFile):
+    """
+    Start data taking
+
+    amc13board - instance of the AMC13manager class
+    outFile - filename to use for data taking
+    """
+
+    amc13board.startDataTaking(outFile)
+    return
+
+def stopDataTaking(amc13board,acquireTime=60):
+    """
+    Stop data taking after acquireTime seconds
+
+    amc13board - instance of the AMC13manager class
+    acquireTime - time in seconds to wait before stopping data taking
+    """
+    from time import sleep
+
+    sleep(acquireTime)
+    amc13board.stopDataTaking()
+    return
+
+if __name__ == '__main__':
+    """
+    Script to readout amc13
+    By: Brian Dorney (brian.l.dorney@cern.ch)
+    """
+
+    # create the parser
+    import argparse
+    parser = argparse.ArgumentParser(description="Arguments to supply to amc13ReadOut.py")
+    
+    # Positional arguments
+    from reg_utils.reg_interface.common.reg_xml_parser import parseInt
+    parser.add_argument("shelf", type=int, help="uTCA shelf number", metavar="shelf")
+    parser.add_argument("slotList", type=str, help="Comma and dash separated list of AMC slots to readout, e.g. '1,3-5,7", metavar="slotList")
+    parser.add_argument("acquireTime", type=int, help="time in seconds to acquire data", metavar="acquireTime")
+    parser.add_argument("filename", type=str, help="Filename to write data too", metavar="filename")
+    
+    # Optional arguments
+    parser.add_argument("--debug", action="store_true", dest="debug",
+            help="print additional debugging information")
+    parserTrigGroup = parser.add_mutually_exclusive_group()
+    parserTrigGroup.add_argument("--t3trig", action="store_true", dest="t3trig",
+            help="Set up for using AMC13 T3 trigger inpiut")
+    parserTrigGroup.add_argument("--internal", action="store_true", dest="internal",
+            help="Configure the amc13 to generate local triggers")
+
+    args = parser.parse_args()
+    options = vars(args)
+    
+    # Get the amc13
+    from gempython.tools.xdaq.amc13manager import AMC13manager
+    amc13base  = "gem.shelf%02d.amc13"%(args.shelf)
+    amc13board = AMC13manager(amc13base,args.debug)
+    
+    # Get the slots
+    from gempython.tools.amc_user_functions_uhal import *
+    dict_amcs = {}
+    slotList = args.slotList.split(',')
+    for slotRange in slotList:
+        if "-" in slotRange:
+            slotsInRange = [int(slot) for slot in slotRange.split("-")]
+            for slot in range(min(slotsInRange),max(slotsInRange)+1):
+                dict_amcs[slot] = getAMCObject(slot,shelf=args.shelf,debug=args.debug)
+        else:
+            dict_amcs[slotRange] = getAMCObject(slotRange,shelf=args.shelf,debug=args.debug)
+
+    # Define the parallel processes
+    from multiprocessing import Process
+    dataTaking = Process(target=startDataTaking, args=(amc13board,args.filename))
+    halt = Process(target=stopDataTaking, args=(amc13board,args.acquireTime))
+
+    # Stop Triggers
+    for slot,amc in dict_amcs.iteritems():
+        amc.blockL1A()
+    amc13board.device.enableLocalL1A(False)
+
+    # Setup for data-taking and get L1A counters
+    amc13board.reset()
+    amc13board.configureInputs(args.slotList)
+    trigCount = readAllL1ACounters(amc13board, dict_amcs, "INITIAL")
+    
+
+    # Enable triggers to amc's
+    for slot,amc in dict_amcs.iteritems():
+        amc.enableL1A()
+    amc13board.device.enableLocalL1A(True)
+    amc13board.configureTrigger(ena=args.internal,t3trig=args.t3trig)
+    if args.internal:
+        amc13board.configureCalPulse()
+
+    # Take data
+    try:
+        dataTaking.start()
+        halt.start()
+        halt.join()
+        print("Data Taking has completed")
+    except KeyboardInterrupt:
+        amc13board.stopDataTaking()
+        halt.terminate()
+
+        # Disable triggers & get final L1A counters
+        for slot,amc in dict_amcs.iteritems():
+            amc.blockL1A()
+        amc13board.device.enableLocalL1A(False)
+        trigCount = readAllL1ACounters(amc13board, dict_amcs, "FINAL", trigCount)
+
+        # Calculate difference in L1A Counters
+        print("| Board | L1A Count |")
+        print("| :---: | :-------: |")
+        for slot in trigCount["INITIAL"].keys():
+            print("| {0} | {1} |".format(
+                slot,
+                trigCount["FINAL"][slot] - trigCount["INITIAL"][slot]))
+        
+        print("Data Taking has completed")
+    except Exception as e:
+        print("Caught Exception {0}, terminating workers".format(e))
+        amc13board.stopDataTaking()
+        halt.terminate()
+
+        # Disable triggers & get final L1A counters
+        for slot,amc in dict_amcs.iteritems():
+            amc.blockL1A()
+        amc13board.device.enableLocalL1A(False)
+        trigCount = readAllL1ACounters(amc13board, dict_amcs, "FINAL", trigCount)
+
+        # Calculate difference in L1A Counters
+        print("| Board | L1A Count |")
+        print("| :---: | :-------: |")
+        for slot in trigCount["INITIAL"].keys():
+            print("| {0} | {1} |".format(
+                slot,
+                trigCount["FINAL"][slot] - trigCount["INITIAL"][slot]))
+        
+        print("Data Taking has completed")
+
+    # Disable triggers & get final L1A counters
+    for slot,amc in dict_amcs.iteritems():
+        amc.blockL1A()
+    amc13board.device.enableLocalL1A(False)
+    trigCount = readAllL1ACounters(amc13board, dict_amcs, "FINAL", trigCount)
+
+    # Calculate difference in L1A Counters
+    print("| Board | L1A Count |")
+    print("| :---: | :-------: |")
+    for slot in trigCount["INITIAL"].keys():
+        print("| {0} | {1} |".format(
+            slot,
+            trigCount["FINAL"][slot] - trigCount["INITIAL"][slot]))
+
+    print("amc13ReadOut.py has exited successfully")

--- a/gempython/tests/amc13ReadOut.py
+++ b/gempython/tests/amc13ReadOut.py
@@ -123,8 +123,13 @@ if __name__ == '__main__':
 
     # Update DAQ Input Enable Mask for each AMC and turn on ZS if requested
     for slot,amc in dict_amcs.iteritems():
+        # Zero suppression
         if args.zeroSup:
             writeRegister(amc,"GEM_AMC.DAQ.CONTROL.ZERO_SUPPRESSION_EN",0x1)
+        else:
+            writeRegister(amc,"GEM_AMC.DAQ.CONTROL.ZERO_SUPPRESSION_EN",0x0)
+
+        # DAQ Link Enable and input mask
         if args.ohMask < 0:
             scaRdy = readRegister(amc,"GEM_AMC.SLOW_CONTROL.SCA.STATUS.READY")
             enableDAQLink(amc,scaRdy)

--- a/gempython/tests/amc13ReadOut.py
+++ b/gempython/tests/amc13ReadOut.py
@@ -140,6 +140,7 @@ if __name__ == '__main__':
         amc13board.configureCalPulse()
 
     # Take data
+    import sys
     try:
         #dataTaking.start()
         dataTaking.run()
@@ -166,6 +167,7 @@ if __name__ == '__main__':
                 trigCount["FINAL"][slot] - trigCount["INITIAL"][slot]))
         
         print("Data Taking has completed")
+        sys.exit()
     except Exception as e:
         print("Caught Exception {0}, terminating workers".format(e))
         amc13board.stopDataTaking()

--- a/gempython/tests/amc13ReadOut.py
+++ b/gempython/tests/amc13ReadOut.py
@@ -23,13 +23,16 @@ def readAllL1ACounters(amc13board, amcs, key="Initial", trigCounts=None):
     return trigCounts
 
 def startDataTaking(amc13board, outFile):
+#def startDataTaking(queue, outFile):
     """
     Start data taking
 
-    amc13board - instance of the AMC13manager class
+    #amc13board - instance of the AMC13manager class
+    queue - instance of multiprocessing.Queue which contains an amc13board
     outFile - filename to use for data taking
     """
 
+    #amc13board = queue.get()
     amc13board.startDataTaking(outFile)
     return
 
@@ -183,4 +186,6 @@ if __name__ == '__main__':
             slot,
             trigCount["FINAL"][slot] - trigCount["INITIAL"][slot]))
 
+    print("dataTaking.is_alive() = {0}".format(dataTaking.is_alive()))
+    print("halt.is_alive() = {0}".format(halt.is_alive()))
     print("amc13ReadOut.py has exited successfully")

--- a/gempython/tools/amc_user_functions_uhal.py
+++ b/gempython/tools/amc_user_functions_uhal.py
@@ -162,7 +162,11 @@ def enableDAQLink(device, linkEnableMask=0x1, doReset=False):
     writeRegister(device, "GEM_AMC.DAQ.CONTROL.TTS_OVERRIDE",      0x8)
     writeRegister(device, "GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK", linkEnableMask)
     writeRegister(device, "GEM_AMC.DAQ.CONTROL.DAV_TIMEOUT",       0x30D40)
+
+    NGTX = readRegister(device,"GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH")
     for olink in range(NGTX):
+        if( (linkEnableMask >> olink) & 0x0):
+            continue
         # in 160MHz clock cycles, so multiply by 4 to get in terms of BX
         # 0xc35 -> 781 BX
         writeRegister(device,"GEM_AMC.DAQ.OH%d.CONTROL.EOE_TIMEOUT"%(olink),0x30D4)

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -74,6 +74,7 @@ class AMC13manager:
         datastring += packer.pack(word)
       with open (ofile+"_chunk_"+str(cnt)+".dat", "wb") as compdata:
         compdata.write(datastring)
+      compdata.close()
       cnt += 1;
       time.sleep(5)
 

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -60,6 +60,7 @@ class AMC13manager:
       self.device.startRun()
       self.device.enableLocalL1A(True)
     #submit work loop here
+    self.device.fakeDataEnable(True)
     self.isRunning = True
     datastring = ''
     packer = struct.Struct('Q')
@@ -85,5 +86,6 @@ class AMC13manager:
       self.device.stopContinuousL1A()
     elif self.t3trig:
       self.device.enableLocalL1A(False)
+    self.device.fakeDataEnable(False)
     #submit work loop here
     self.isRunning = False

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -11,6 +11,8 @@ import time
 
 class AMC13manager:
   def __init__(self):
+    self.localTrigger = False
+    self.tr3trig = False
     pass
 
   def connect(self,cardname,verbosity):
@@ -31,9 +33,10 @@ class AMC13manager:
     mask = self.device.parseInputEnableList(inlist, True)
     self.device.AMCInputEnable(mask)
 
-  def configureTrigger(self, ena, mode = 0, burst = 1, rate = 10, rules = 0):
+  def configureTrigger(self, ena, t3trig=False, mode = 0, burst = 1, rate = 10, rules = 0):
   # see http://cactus.web.cern.ch/cactus/release/amc13/1.1/api/html/d5/df6/classamc13_1_1_a_m_c13.html#a800843bf6119f6aaeb470e406778a9b2
     self.localTrigger = ena
+    self.tr3trig = t3trig
     if self.localTrigger:
       self.device.configureLocalL1A(ena, mode, burst, rate, rules)
 
@@ -52,6 +55,10 @@ class AMC13manager:
   def startDataTaking(self, ofile):
     if self.localTrigger:
       self.device.startContinuousL1A()
+    elif self.t3trig:
+      self.device.write(self.device.Board.T1, 'CONF.TTC.T3_TRIG', 0x1)
+      self.device.startRun()
+      self.device.enableLocalL1A(True)
     #submit work loop here
     self.isRunning = True
     datastring = ''
@@ -76,5 +83,7 @@ class AMC13manager:
   def stopDataTaking(self):
     if self.localTrigger:
       self.device.stopContinuousL1A()
+    elif self.t3trig:
+      self.device.enableLocalL1A(False)
     #submit work loop here
     self.isRunning = False

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -12,11 +12,11 @@ import time
 class AMC13manager:
   def __init__(self):
     self.localTrigger = False
-    self.tr3trig = False
+    self.t3trig = False
     pass
 
   def connect(self,cardname,verbosity):
-    self.connection = os.getenv("GEM_ADDRESS_TABLE_PATH")+"connections.xml"
+    self.connection = "{0}/connections.xml".format(os.getenv("GEM_ADDRESS_TABLE_PATH"))
     self.verbosity = verbosity
     self.device = amc13.AMC13(self.connection, cardname+".T1", cardname+".T2") # connect to amc13. Should work like this, but has to be tested
     #reset amc13
@@ -36,7 +36,7 @@ class AMC13manager:
   def configureTrigger(self, ena, t3trig=False, mode = 0, burst = 1, rate = 10, rules = 0):
   # see http://cactus.web.cern.ch/cactus/release/amc13/1.1/api/html/d5/df6/classamc13_1_1_a_m_c13.html#a800843bf6119f6aaeb470e406778a9b2
     self.localTrigger = ena
-    self.tr3trig = t3trig
+    self.t3trig = t3trig
     if self.localTrigger:
       self.device.configureLocalL1A(ena, mode, burst, rate, rules)
 

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -25,7 +25,7 @@ class AMC13manager:
 
   def reset(self):
     self.device.reset(self.device.Board.T1)
-    self.device.reset(self.device.Board.T2)
+    #self.device.reset(self.device.Board.T2)
     self.device.resetCounters()
     self.device.resetDAQ()
 
@@ -59,7 +59,8 @@ class AMC13manager:
       #self.device.startRun()
       self.device.enableLocalL1A(True)
     #submit work loop here
-    #self.device.fakeDataEnable(True)
+    self.device.fakeDataEnable(True)
+    self.device.startRun()
     self.isRunning = True
     datastring = ''
     packer = struct.Struct('Q')
@@ -83,6 +84,7 @@ class AMC13manager:
       self.device.stopContinuousL1A()
     elif self.t3trig:
       self.device.enableLocalL1A(False)
-    #self.device.fakeDataEnable(False)
+    self.device.fakeDataEnable(False)
     #submit work loop here
+    self.device.endRun()
     self.isRunning = False

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -51,16 +51,15 @@ class AMC13manager:
     bx = 500+delay
     self.device.configureBGOShort(0,0x14,bx,prescale,repeat)
 
-  #def startDataTaking(self, ofile, nevents):
   def startDataTaking(self, ofile):
     if self.localTrigger:
       self.device.startContinuousL1A()
     elif self.t3trig:
       self.device.write(self.device.Board.T1, 'CONF.TTC.T3_TRIG', 0x1)
-      self.device.startRun()
+      #self.device.startRun()
       self.device.enableLocalL1A(True)
     #submit work loop here
-    self.device.fakeDataEnable(True)
+    #self.device.fakeDataEnable(True)
     self.isRunning = True
     datastring = ''
     packer = struct.Struct('Q')
@@ -69,13 +68,11 @@ class AMC13manager:
     cnt = 0
     while self.isRunning:
       nevt = self.device.read(self.device.Board.T1, 'STATUS.MONITOR_BUFFER.UNREAD_BLOCKS')
-      #nevt = self.device.read(self.device.Board.T1, 'STATUS.MONITOR_BUFFER.UNREAD_EVENTS')
       print "Trying to read %s events" % nevt
       for i in range(nevt):
         pEvt += read_event()
       for word in pEvt:
         datastring += packer.pack(word)
-      #if nevt > 0:
       with open (ofile+"_chunk_"+str(cnt)+".dat", "wb") as compdata:
         compdata.write(datastring)
       cnt += 1;
@@ -86,6 +83,6 @@ class AMC13manager:
       self.device.stopContinuousL1A()
     elif self.t3trig:
       self.device.enableLocalL1A(False)
-    self.device.fakeDataEnable(False)
+    #self.device.fakeDataEnable(False)
     #submit work loop here
     self.isRunning = False

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -71,7 +71,8 @@ class AMC13manager:
       for i in range(nevt):
         pEvt += read_event()
       for word in pEvt:
-        datastring += packer.pack(word)
+        #datastring += packer.pack(word) # pretty sure "+=" duplicates events...
+        datastring = packer.pack(word)
       with open (ofile+"_chunk_"+str(cnt)+".dat", "wb") as compdata:
         compdata.write(datastring)
       compdata.close()

--- a/gempython/tools/xdaq/amc13manager.py
+++ b/gempython/tools/xdaq/amc13manager.py
@@ -56,10 +56,8 @@ class AMC13manager:
       self.device.startContinuousL1A()
     elif self.t3trig:
       self.device.write(self.device.Board.T1, 'CONF.TTC.T3_TRIG', 0x1)
-      #self.device.startRun()
       self.device.enableLocalL1A(True)
     #submit work loop here
-    self.device.fakeDataEnable(True)
     self.device.startRun()
     self.isRunning = True
     datastring = ''
@@ -84,7 +82,6 @@ class AMC13manager:
       self.device.stopContinuousL1A()
     elif self.t3trig:
       self.device.enableLocalL1A(False)
-    self.device.fakeDataEnable(False)
     #submit work loop here
     self.device.endRun()
     self.isRunning = False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New tool for reading out data from the AMC13

```
% amc13ReadOut.py -h                                                                                                     
usage: amc13ReadOut.py [-h] [-d] [--ohMask ohMask] [-z]
                       [--t3trig | --internal]
                       shelf slotList acquireTime filename

Script to readout data with the AMC13. Presently uFEDKIT is not used.
Arguments to supply to amc13ReadOut.py are given below

positional arguments:
  shelf            uTCA shelf number
  slotList         Comma and dash separated list of AMC slots to readout, e.g.
                   '1,3-5,7
  acquireTime      time in seconds to acquire data
  filename         Filename to write data too

optional arguments:
  -h, --help       show this help message and exit
  -d, --debug      print additional debugging information
  --ohMask ohMask  DAQ Link Enable mask to apply to all AMCs in slotList. If
                   less than 0 (default) this is determined automatically.
                   Otherwise provide a bit mask where a 1 in the N^th bit
                   indicates to readout the N^th OH
  -z, --zeroSup    Enable zero suppression in each AMC given by slotList
  --t3trig         Set up for using AMC13 T3 trigger input
  --internal       Configure the amc13 to generate local triggers
```

The parameter `--ohMask` defaults to less than zero and is determine automatically from `GEM_AMC.SLOW_CONTROL.SCA.STATUS.READY` for each AMC in `slotList`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Needed a quick way to readout with the full data path.  Particularly for the v3 electronics.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
http://cmsonline.cern.ch/cms-elog/1060765

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
