### PR TITLE
New Feature: DAC Scans

### DIFF
--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -144,7 +144,7 @@ class HwAMC(object):
         # Open RPC Connection
         print "Initializing AMC", self.name
         rpc_connect(self.name)
-        self.nOHs = readRegister("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH")
+        self.nOHs = self.readRegister("GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH")
         self.fwVersion = self.readRegister("GEM_AMC.GEM_SYSTEM.RELEASE.MAJOR")
         if debug:
             print "My FW release major = ", self.fwVersion

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -303,7 +303,7 @@ class HwAMC(object):
         """
 
         # Check we are v3 electronics
-        if self.parentAMC.fwVersion < 3:
+        if self.fwVersion < 3:
             print("HwAMC::performDacScanMultiLink(): No support for v2b electronics")
             exit(os.EX_USAGE)
 
@@ -321,8 +321,8 @@ class HwAMC(object):
 
         # Check length of results container
         lenExpected = nUnmaskedOHs * (maxVfat3DACSize[dacSelect][0] - 0+1)*24 / dacStep
-        if (len(outData) != lenExpected):
-            print("HwAMC::performDacScanMultiLink(): I expected container of lenght {0} but provided 'outData' has length {1}",format(lenExpected, len(outData)))
+        if (len(dacDataAll) != lenExpected):
+            print("HwAMC::performDacScanMultiLink(): I expected container of lenght {0} but provided 'dacDataAll' has length {1}",format(lenExpected, len(dacDataAll)))
             exit(os.EX_USAGE)
 
         return self.dacScanMulti(ohMask, nUnmaskedOHs, dacSelect, dacStep, useExtRefADC, dacDataAll)

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -11,6 +11,37 @@ import logging
 gMAX_RETRIES = 5
 gRetries = 5
 
+maxVfat3DACSize = {
+        #ADC Measures Current
+        0:(0x3f, "CFG_IREF"),
+        #1:???
+        2:(0xff,"CFG_BIAS_PRE_I_BIT"),
+        3:(0x3f,"CFG_BIAS_PRE_I_BLCC"),
+        #4:???
+        5:(0xff,"CFG_BIAS_SH_I_BFCAS"),
+        6:(0xff,"CFG_BIAS_SH_I_BDIFF"),
+        7:(0xff,"CFG_BIAS_SD_I_BDIFF"),
+        8:(0xff,"CFG_BIAS_SD_I_BFCAS"),
+        9:(0x3f,"CFG_BIAS_SD_I_BSF"),
+        10:(0x3f,"CFG_BIAS_CFD_DAC_1"),
+        11:(0x3f,"CFG_BIAS_CFD_DAC_2"),
+        12:(0x3f,"CFG_HYST"),
+        #13:???
+        14:(0xff,"CFG_THR_ARM_DAC"),
+        15:(0xff,"CFG_THR_ZCC_DAC"),
+        #16:???
+
+        #ADC Measures Voltage
+        #32:???
+        #33:???
+        34:(0xff,"CFG_BIAS_PRE_VREF"),
+        35:(0xff,"CFG_THR_ARM_DAC"),
+        36:(0xff,"CFG_THR_ZCC_DAC"),
+        39:(0x3,"CFG_ADC_VREF")
+        #40:???
+        #41:???
+        }
+
 ohBoardTempArray = c_uint32 * 9 # Temperature Array
 class SCAMonitorParams(Structure):
     _fields_ = [
@@ -72,6 +103,10 @@ class HwAMC(object):
         self.readADCsMulti = self.lib.readVFAT3ADCMultiLink
         self.readADCsMulti.argTypes = [ c_uint, POINTER(c_uint32), POINTER(c_uint), c_bool ]
         self.readADCsMulti.restype = c_uint
+
+        self.dacScanMulti = self.lib.dacScanMultiLink
+        self.dacScanMulti.argTypes = [ c_uint, c_uint, c_uint, c_uint, c_bool, POINTER(c_uint) ]
+        self.dacScanMulti.restype = c_uint
 
         # Define SCA & Sysmon Monitoring
         self.getmonOHSCAmain = self.lib.getmonOHSCAmain


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides functionality to `HwAMC` for scanning a given DAC on all VFATs for a specific OH, or all VFATs on all unmasked OH's.

Requires:

- https://github.com/cms-gem-daq-project/xhal/pull/93
- https://github.com/cms-gem-daq-project/ctp7_modules/pull/53

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/203

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See: https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/203

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
