### PR TITLE
Removing possibility to scan CFG_IREF from dac scans

### DIFF
--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -13,7 +13,7 @@ gRetries = 5
 
 maxVfat3DACSize = {
         #ADC Measures Current
-        0:(0x3f, "CFG_IREF"),
+        #0:(0x3f, "CFG_IREF"), # This should never be scanned per VFAT3 Team's Instructions
         #1:???
         2:(0xff,"CFG_BIAS_PRE_I_BIT"),
         3:(0x3f,"CFG_BIAS_PRE_I_BLCC"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
VFAT3 Team reports we shouldn't scan `CFG_IREF` during dac scans because:

1. this can only be scanned with an external ADC, not the VFAT3's internal ADCs, and
2. Setting this register below 0x20 or above 0x32 may cause damage to the ASIC.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Breaking because removing `CFG_IREF` from DAC scans. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
