### PR TITLE
change <TYPE> logging macros to CMSGEMOS_<TYPE>

### DIFF
--- a/gembase/src/common/GEMApplication.cc
+++ b/gembase/src/common/GEMApplication.cc
@@ -54,9 +54,9 @@ gem::base::GEMApplication::GEMApplication(xdaq::ApplicationStub *stub)
   m_stepSize(0),
   m_nScanTriggers(0)
 {
-  DEBUG("GEMApplication::called gem::base::GEMApplication constructor");
-  INFO("GEMApplication GIT_VERSION:" << GIT_VERSION);
-  INFO("GEMApplication developer:"   << GEMDEVELOPER);
+  CMSGEMOS_DEBUG("GEMApplication::called gem::base::GEMApplication constructor");
+  CMSGEMOS_INFO("GEMApplication GIT_VERSION:" << GIT_VERSION);
+  CMSGEMOS_INFO("GEMApplication developer:"   << GEMDEVELOPER);
 
   //p_gemWebInterface = new GEMWebApplication(this);
 
@@ -77,14 +77,14 @@ gem::base::GEMApplication::GEMApplication(xdaq::ApplicationStub *stub)
                                                                                                      p_appInfoSpace,
                                                                                                      // p_gemMonitor,
                                                                                                      false));
-  DEBUG("GEMApplication::application infospace has name: " << p_appInfoSpace->name());
-  DEBUG(m_urn);
+  CMSGEMOS_DEBUG("GEMApplication::application infospace has name: " << p_appInfoSpace->name());
+  CMSGEMOS_DEBUG(m_urn);
   toolbox::net::URN monISURN(m_urn+toolbox::toString(":monitoring-infospace"));
   if (xdata::getInfoSpaceFactory()->hasItem(monISURN.toString())) {
-    DEBUG("GEMApplication::GEMApplication::infospace " << monISURN.toString() << " already exists, getting");
+    CMSGEMOS_DEBUG("GEMApplication::GEMApplication::infospace " << monISURN.toString() << " already exists, getting");
     p_monitorInfoSpace = xdata::getInfoSpaceFactory()->get(monISURN.toString());
   } else {
-    DEBUG("GEMApplication::GEMApplication::infospace " << monISURN.toString() << " does not exist, creating");
+    CMSGEMOS_DEBUG("GEMApplication::GEMApplication::infospace " << monISURN.toString() << " does not exist, creating");
     p_monitorInfoSpace = xdata::getInfoSpaceFactory()->create(monISURN.toString());
   }
   p_monitorInfoSpaceToolBox = std::shared_ptr<utils::GEMInfoSpaceToolBox>(new utils::GEMInfoSpaceToolBox(this,
@@ -93,10 +93,10 @@ gem::base::GEMApplication::GEMApplication(xdaq::ApplicationStub *stub)
                                                                                                          false));
   toolbox::net::URN cfgISURN(m_urn+toolbox::toString(":config-infospace"));
   if (xdata::getInfoSpaceFactory()->hasItem(cfgISURN.toString())) {
-    DEBUG("GEMApplication::GEMApplication::infospace " << cfgISURN.toString() << " already exists, getting");
+    CMSGEMOS_DEBUG("GEMApplication::GEMApplication::infospace " << cfgISURN.toString() << " already exists, getting");
     p_configInfoSpace = xdata::getInfoSpaceFactory()->get(cfgISURN.toString());
   } else {
-    DEBUG("GEMApplication::GEMApplication::infospace " << cfgISURN.toString() << " does not exist, creating");
+    CMSGEMOS_DEBUG("GEMApplication::GEMApplication::infospace " << cfgISURN.toString() << " does not exist, creating");
     p_configInfoSpace = xdata::getInfoSpaceFactory()->create(cfgISURN.toString());
   }
   p_configInfoSpaceToolBox = std::shared_ptr<utils::GEMInfoSpaceToolBox>(new utils::GEMInfoSpaceToolBox(this,
@@ -104,7 +104,7 @@ gem::base::GEMApplication::GEMApplication(xdaq::ApplicationStub *stub)
                                                                                                         // p_gemMonitor,
                                                                                                         false));
 
-  DEBUG("GEMApplication::GEM application has infospace named " << p_appInfoSpace->name());
+  CMSGEMOS_DEBUG("GEMApplication::GEM application has infospace named " << p_appInfoSpace->name());
   xgi::framework::deferredbind(this, this, &GEMApplication::xgiDefault, "Default"    );
   xgi::framework::deferredbind(this, this, &GEMApplication::xgiMonitor, "monitorView");
   xgi::framework::deferredbind(this, this, &GEMApplication::xgiExpert,  "expertView" );
@@ -159,13 +159,13 @@ gem::base::GEMApplication::GEMApplication(xdaq::ApplicationStub *stub)
   p_appInfoSpace->addItemChangedListener( "ScanMax",       this);
   p_appInfoSpace->addItemChangedListener( "StepSize",      this);
 
-  DEBUG("GEMApplication::gem::base::GEMApplication constructed");
+  CMSGEMOS_DEBUG("GEMApplication::gem::base::GEMApplication constructed");
 }
 
 
 gem::base::GEMApplication::~GEMApplication()
 {
-  DEBUG("GEMApplication::gem::base::GEMApplication destructor called");
+  CMSGEMOS_DEBUG("GEMApplication::gem::base::GEMApplication destructor called");
 }
 
 std::string gem::base::GEMApplication::getFullURL()
@@ -184,9 +184,9 @@ void gem::base::GEMApplication::actionPerformed(xdata::Event& event)
   // followed by a call to gem::base::GEMApplication::actionPerformed(event)
   /*
     if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("GEMApplication::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("GEMApplication::actionPerformed() setDefaultValues" <<
     "Default configuration values have been loaded from xml profile");
-    // DEBUG("GEMApplication::actionPerformed()   --> starting monitoring");
+    // CMSGEMOS_DEBUG("GEMApplication::actionPerformed()   --> starting monitoring");
     // monitorP_->startMonitoring();
     }
   */
@@ -195,34 +195,34 @@ void gem::base::GEMApplication::actionPerformed(xdata::Event& event)
 
   if (event.type() == "ItemRetrieveEvent" ||
       event.type() == "urn:xdata-event:ItemRetrieveEvent") {
-    DEBUG("GEMApplication::actionPerformed() ItemRetrieveEvent"
+    CMSGEMOS_DEBUG("GEMApplication::actionPerformed() ItemRetrieveEvent"
           << "");
   } else if (event.type() == "ItemGroupRetrieveEvent" ||
              event.type() == "urn:xdata-event:ItemGroupRetrieveEvent") {
-    DEBUG("GEMApplication::actionPerformed() ItemGroupRetrieveEvent"
+    CMSGEMOS_DEBUG("GEMApplication::actionPerformed() ItemGroupRetrieveEvent"
           << "");
   }
   // item is changed, update it
   if (event.type() == "ItemChangedEvent" ||
       event.type() == "urn:xdata-event:ItemChangedEvent") {
-    DEBUG("GEMApplication::actionPerformed() ItemChangedEvent"
+    CMSGEMOS_DEBUG("GEMApplication::actionPerformed() ItemChangedEvent"
           << "m_runNumber:" << m_runNumber
           << " getInteger64(\"RunNumber\"):" << p_appInfoSpaceToolBox->getInteger64("RunNumber"));
 
     /*
-    INFO("GEMApplication::actionPerformed() ItemChangedEvent"
+    CMSGEMOS_INFO("GEMApplication::actionPerformed() ItemChangedEvent"
           << "m_RUNTYPE:" << m_RUNTYPE
           << " getInteger(\"ScanType\"):" << p_appInfoSpaceToolBox->getInteger("ScanType"));
 
-    INFO("GEMApplication::actionPerformed() ItemChangedEvent"
+    CMSGEMOS_INFO("GEMApplication::actionPerformed() ItemChangedEvent"
           << "m_Min:" << m_Min
           << " getInteger(\"Min\"):" << p_appInfoSpaceToolBox->getInteger("Min"));
 
-    INFO("GEMApplication::actionPerformed() ItemChangedEvent"
+    CMSGEMOS_INFO("GEMApplication::actionPerformed() ItemChangedEvent"
           << "m_Max:" << m_Max
           << " getInteger(\"Max\"):" << p_appInfoSpaceToolBox->getInteger("Max"));
 
-    INFO("GEMApplication::actionPerformed() ItemChangedEvent"
+    CMSGEMOS_INFO("GEMApplication::actionPerformed() ItemChangedEvent"
           << "m_StepSize:" << m_StepSize
           << " getInteger(\"StepSize\"):" << p_appInfoSpaceToolBox->getInteger("StepSize"));
     */
@@ -235,7 +235,7 @@ void gem::base::GEMApplication::actionPerformed(xdata::Event& event)
        try {
        getMonitorInfospace()->fireItemGroupChanged(names, this);
        } catch (xcept::Exception& e) {
-       ERROR(xcept::stdformat_exception_history(e));
+       CMSGEMOS_ERROR(xcept::stdformat_exception_history(e));
        }
     */
   }

--- a/gembase/src/common/GEMFSM.cc
+++ b/gembase/src/common/GEMFSM.cc
@@ -28,7 +28,7 @@ gem::base::GEMFSM::GEMFSM(GEMFSMApplication* const gemAppP) :
   p_gemApp(gemAppP),
   m_gemLogger(gemAppP->getApplicationLogger())
 {
-  DEBUG("GEMFSM::ctor begin");
+  CMSGEMOS_DEBUG("GEMFSM::ctor begin");
 
   // Create the underlying Finite State Machine itself.
   std::stringstream commandLoopName;
@@ -192,7 +192,7 @@ gem::base::GEMFSM::GEMFSM(GEMFSMApplication* const gemAppP) :
   p_gemfsm->reset();
 
   m_gemFSMState = p_gemfsm->getStateName(p_gemfsm->getCurrentState());
-  DEBUG("GEMFSM::GEMFSM current state is " << m_gemFSMState.toString());
+  CMSGEMOS_DEBUG("GEMFSM::GEMFSM current state is " << m_gemFSMState.toString());
 
   p_gemApp->getAppISToolBox()->createString("FSMState", m_gemFSMState.toString(), &m_gemFSMState,
                                             utils::GEMInfoSpaceToolBox::PROCESS);
@@ -214,7 +214,7 @@ gem::base::GEMFSM::~GEMFSM()
 
 void gem::base::GEMFSM::fireEvent(toolbox::Event::Reference const &event)
 {
-  INFO("GEMFSM::fireEvent(" << event->type() << ")");
+  CMSGEMOS_INFO("GEMFSM::fireEvent(" << event->type() << ")");
   try {
     p_gemfsm->fireEvent(event);
   } catch (toolbox::fsm::exception::Exception & ex) {
@@ -224,7 +224,7 @@ void gem::base::GEMFSM::fireEvent(toolbox::Event::Reference const &event)
 
 xoap::MessageReference gem::base::GEMFSM::changeState(xoap::MessageReference msg)
 {
-  INFO("GEMFSM::changeState()");
+  CMSGEMOS_INFO("GEMFSM::changeState()");
   if (msg.isNull()) {
     XCEPT_RAISE(xoap::exception::Exception, "Null message received!");
   }
@@ -232,10 +232,10 @@ xoap::MessageReference gem::base::GEMFSM::changeState(xoap::MessageReference msg
   std::string commandName = "undefined";
   try {
     commandName = gem::utils::soap::GEMSOAPToolBox::extractFSMCommandName(msg);
-    INFO("GEMFSM::received command " << commandName);
+    CMSGEMOS_INFO("GEMFSM::received command " << commandName);
   } catch(xoap::exception::Exception& err) {
     std::string msgBase = toolbox::toString("Unable to extract command from GEMFSM SOAP message");
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::base::utils::exception::SOAPTransitionProblem, top,
                          toolbox::toString("%s.", msgBase.c_str()), err);
     p_gemApp->notifyQualified("error", top);
@@ -250,17 +250,17 @@ xoap::MessageReference gem::base::GEMFSM::changeState(xoap::MessageReference msg
     return reply;
   }
 
-  DEBUG("GEMFSM::changeState() received command '" <<  commandName.c_str() << "'.");
+  CMSGEMOS_DEBUG("GEMFSM::changeState() received command '" <<  commandName.c_str() << "'.");
 
   try {
     toolbox::Event::Reference event(new toolbox::Event(commandName, this));
-    INFO("Firing GEMFSM for event " << commandName);
-    INFO("initial state is: " << p_gemfsm->getStateName(p_gemfsm->getCurrentState()));
+    CMSGEMOS_INFO("Firing GEMFSM for event " << commandName);
+    CMSGEMOS_INFO("initial state is: " << p_gemfsm->getStateName(p_gemfsm->getCurrentState()));
     p_gemfsm->fireEvent(event);
-    INFO("new state is: " << p_gemfsm->getStateName(p_gemfsm->getCurrentState()));
+    CMSGEMOS_INFO("new state is: " << p_gemfsm->getStateName(p_gemfsm->getCurrentState()));
   } catch(toolbox::fsm::exception::Exception& err) {
     std::string msgBase = toolbox::toString("Problem executing the GEMFSM '%s' command", commandName.c_str());
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::base::utils::exception::SOAPTransitionProblem, top,
                          toolbox::toString("%s.", msgBase.c_str()), err);
     p_gemApp->notifyQualified("error", top);
@@ -278,14 +278,14 @@ xoap::MessageReference gem::base::GEMFSM::changeState(xoap::MessageReference msg
   // Once we get here, the state transition has been triggered.
   // Notify the requestor of the new state.
   try {
-    INFO("changeState::sending command " << commandName << " newStateName " << newStateName);
+    CMSGEMOS_INFO("changeState::sending command " << commandName << " newStateName " << newStateName);
     return
       gem::utils::soap::GEMSOAPToolBox::makeFSMSOAPReply(commandName,
                                                          p_gemfsm->getStateName(p_gemfsm->getCurrentState()));
   } catch(xcept::Exception& err) {
     std::string msgBase = toolbox::toString("Failed to create GEMFSM SOAP reply for command '%s'",
                                             commandName.c_str());
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::base::utils::exception::SoftwareProblem,
                          top, toolbox::toString("%s.", msgBase.c_str()), err);
     p_gemApp->notifyQualified("error", top);
@@ -300,37 +300,37 @@ xoap::MessageReference gem::base::GEMFSM::changeState(xoap::MessageReference msg
 
 std::string gem::base::GEMFSM::getCurrentState() const
 {
-  DEBUG("GEMFSM::getCurrentState()");
+  CMSGEMOS_DEBUG("GEMFSM::getCurrentState()");
   return p_gemfsm->getStateName(p_gemfsm->getCurrentState());
 }
 
 toolbox::fsm::State gem::base::GEMFSM::getCurrentFSMState() const
 {
-  DEBUG("GEMFSM::getCurrentFSMState()");
+  CMSGEMOS_DEBUG("GEMFSM::getCurrentFSMState()");
   return p_gemfsm->getCurrentState();
 }
 
 std::string gem::base::GEMFSM::getStateName(toolbox::fsm::State const& state) const
 {
-  DEBUG("GEMFSM::getStateName()");
+  CMSGEMOS_DEBUG("GEMFSM::getStateName()");
   return p_gemfsm->getStateName(state);
 }
 
 /* moved into GEMSupervisor, as only the supervisor global state should be reported to RCMS
 void gem::base::GEMFSM::notifyRCMS(toolbox::fsm::FiniteStateMachine &fsm, std::string const msg)
 {
-  INFO("GEMFSM::notifyRCMS()");
+  CMSGEMOS_INFO("GEMFSM::notifyRCMS()");
   // Notify RCMS of a state change.
   // NOTE: Should only be used for state _changes_.
 
   // toolbox::fsm::State currentState = fsm.getCurrentState();
   // std::string stateName            = fsm.getStateName(currentState);
   std::string stateName = fsm.getStateName(fsm.getCurrentState());
-  DEBUG("notifyRCMS() called with msg = " << msg);
+  CMSGEMOS_DEBUG("notifyRCMS() called with msg = " << msg);
   try {
     m_gemRCMSNotifier.stateChanged(stateName, msg);
   } catch(xcept::Exception& err) {
-    ERROR("GEMFSM::Failed to notify RCMS of state change: "
+    CMSGEMOS_ERROR("GEMFSM::Failed to notify RCMS of state change: "
           << xcept::stdformat_exception_history(err));
     XCEPT_DECLARE_NESTED(gem::base::utils::exception::RCMSNotificationError, top,
                          "Failed to notify RCMS of state change.", err);
@@ -341,7 +341,7 @@ void gem::base::GEMFSM::notifyRCMS(toolbox::fsm::FiniteStateMachine &fsm, std::s
 
 void gem::base::GEMFSM::stateChanged(toolbox::fsm::FiniteStateMachine &fsm)
 {
-  DEBUG("GEMFSM::stateChanged() begin");
+  CMSGEMOS_DEBUG("GEMFSM::stateChanged() begin");
   try {
     m_gemFSMState = fsm.getStateName(fsm.getCurrentState());
     p_gemApp->getAppISToolBox()->setString("FSMState",  m_gemFSMState.toString());
@@ -349,27 +349,27 @@ void gem::base::GEMFSM::stateChanged(toolbox::fsm::FiniteStateMachine &fsm)
   } catch (toolbox::fsm::exception::Exception & ex) {
     std::stringstream msg;
     msg << "Problem updating state after stateChanged " << ex.what();
-    FATAL(msg.str());
+    CMSGEMOS_FATAL(msg.str());
     XCEPT_DECLARE_NESTED(gem::utils::exception::SoftwareProblem, top, msg.str(), ex);
   } catch(xcept::Exception& ex) {
     std::stringstream msg;
     msg << "Problem updating state after stateChanged " << ex.what();
-    FATAL(msg.str());
+    CMSGEMOS_FATAL(msg.str());
     XCEPT_DECLARE_NESTED(gem::utils::exception::SoftwareProblem, top, msg.str(), ex);
     p_gemApp->notifyQualified("fatal", top);
   } catch (std::exception& ex) {
     std::stringstream msg;
     msg << "Problem updating state after stateChanged " << ex.what();
-    FATAL(msg.str());
+    CMSGEMOS_FATAL(msg.str());
     XCEPT_RAISE(gem::utils::exception::SoftwareProblem, msg.str());
   } catch (...) {
     std::stringstream msg;
     msg << "Problem updating state after stateChanged";
-    FATAL(msg.str());
+    CMSGEMOS_FATAL(msg.str());
     XCEPT_RAISE(gem::utils::exception::SoftwareProblem, msg.str());
   }
-  INFO("GEMFSM::stateChanged:Current state is: [" << m_gemFSMState.toString() << "]");
-  DEBUG("GEMFSM::stateChanged:stateChanged() end");
+  CMSGEMOS_INFO("GEMFSM::stateChanged:Current state is: [" << m_gemFSMState.toString() << "]");
+  CMSGEMOS_DEBUG("GEMFSM::stateChanged:stateChanged() end");
 }
 
 
@@ -378,7 +378,7 @@ void gem::base::GEMFSM::invalidAction(toolbox::Event::Reference event)
   /* what's the point of this action?
    * should we go to failed or try to ensure no action is taken and the initial state is preserved?
    */
-  INFO("GEMFSM::invalidAction(" << event->type() << ")");
+  CMSGEMOS_INFO("GEMFSM::invalidAction(" << event->type() << ")");
   toolbox::fsm::InvalidInputEvent& invalidInputEvent = dynamic_cast<toolbox::fsm::InvalidInputEvent&>(*event);
   std::string initialState   = p_gemfsm->getStateName(invalidInputEvent.getFromState());
   std::string requestedState = invalidInputEvent.getInput();
@@ -386,37 +386,37 @@ void gem::base::GEMFSM::invalidAction(toolbox::Event::Reference event)
   std::string message = toolbox::toString("An invalid state transition has been received:"
                                           " requested transition to '%s' from '%s'.",
                                           requestedState.c_str(), initialState.c_str());
-  ERROR("GEMFSM::" << message);
+  CMSGEMOS_ERROR("GEMFSM::" << message);
   gotoFailed(message);
 }
 
 void gem::base::GEMFSM::gotoFailed(std::string const reason)
 {
-  DEBUG("GEMFSM::gotoFailed(std::string)");
-  ERROR("GEMFSM::Going to 'Failed' state. Reason: '" << reason << "'.");
+  CMSGEMOS_DEBUG("GEMFSM::gotoFailed(std::string)");
+  CMSGEMOS_ERROR("GEMFSM::Going to 'Failed' state. Reason: '" << reason << "'.");
   XCEPT_RAISE(toolbox::fsm::exception::Exception, reason);
 }
 
 void gem::base::GEMFSM::gotoFailed(xcept::Exception& err)
 {
-  DEBUG("GEMFSM::gotoFailed(xcept::Exception&)");
+  CMSGEMOS_DEBUG("GEMFSM::gotoFailed(xcept::Exception&)");
   std::string reason = err.message();
   gotoFailed(reason);
 }
 
 void gem::base::GEMFSM::gotoFailedAsynchronously(xcept::Exception& err)
 {
-  DEBUG("GEMFSM::gotoFailedAsynchronously(xcept::Exception&)");
+  CMSGEMOS_DEBUG("GEMFSM::gotoFailedAsynchronously(xcept::Exception&)");
   std::string reason = err.message();
   // p_appStateInfoSpaceHandler->setFSMState("Failed", reason);
-  ERROR("GEMFSM::Going to 'Failed' state. Reason: " << reason);
+  CMSGEMOS_ERROR("GEMFSM::Going to 'Failed' state. Reason: " << reason);
   try {
     toolbox::Event::Reference event(new toolbox::Event("Fail", this));
     p_gemfsm->fireEvent(event);
   } catch(xcept::Exception& error) {
     std::stringstream msg;
     msg << "Cannot initiate asynchronous 'Fail' transition.";
-    FATAL(msg.str());
+    CMSGEMOS_FATAL(msg.str());
     XCEPT_DECLARE_NESTED(gem::utils::exception::SoftwareProblem, top, msg.str(), error);
     p_gemApp->notifyQualified("fatal", top);
   }

--- a/gembase/src/common/GEMFSMApplication.cc
+++ b/gembase/src/common/GEMFSMApplication.cc
@@ -54,12 +54,12 @@ gem::base::GEMFSMApplication::GEMFSMApplication(xdaq::ApplicationStub* stub)
   m_web_semaphore(toolbox::BSem::FULL),
   m_infspc_semaphore(toolbox::BSem::FULL)
 {
-  DEBUG("GEMFSMApplication::ctor begin");
+  CMSGEMOS_DEBUG("GEMFSMApplication::ctor begin");
 
   // These bindings expose the state machine to the hyperdaq world. The
   // xgi<Action> callback simply creates a SOAP message that then triggers the usual
   // state transition
-  DEBUG("GEMFSMApplication::Creating xgi bindings...");
+  CMSGEMOS_DEBUG("GEMFSMApplication::Creating xgi bindings...");
   xgi::framework::deferredbind(this, this, &GEMFSMApplication::xgiInitialize, "Initialize");
   xgi::framework::deferredbind(this, this, &GEMFSMApplication::xgiConfigure,  "Configure" );
   xgi::framework::deferredbind(this, this, &GEMFSMApplication::xgiStart,      "Start"     );
@@ -70,7 +70,7 @@ gem::base::GEMFSMApplication::GEMFSMApplication(xdaq::ApplicationStub* stub)
   xgi::framework::deferredbind(this, this, &GEMFSMApplication::xgiReset,      "Reset"     );
   // bindings for various functionality
   xgi::bind(this, &GEMFSMApplication::jsonStateUpdate, "stateUpdate");
-  DEBUG("GEMFSMApplication::Created xgi bindings");
+  CMSGEMOS_DEBUG("GEMFSMApplication::Created xgi bindings");
 
   // These bindings expose the state machine to the outside world. The
   // changeState() method simply forwards the calls to the GEMFSM
@@ -83,7 +83,7 @@ gem::base::GEMFSMApplication::GEMFSMApplication(xdaq::ApplicationStub* stub)
   xoap::bind(this, &GEMFSMApplication::changeState, "Resume",     XDAQ_NS_URI);
   xoap::bind(this, &GEMFSMApplication::changeState, "Halt",       XDAQ_NS_URI);
   xoap::bind(this, &GEMFSMApplication::changeState, "Reset",      XDAQ_NS_URI);
-  DEBUG("GEMFSMApplication::Created xoap bindings");
+  CMSGEMOS_DEBUG("GEMFSMApplication::Created xoap bindings");
 
   // benefit or disadvantage to setting up the workloop signatures this way?
   // hcal has done a forwarding which may be a clever solution, but to what problem?
@@ -95,18 +95,18 @@ gem::base::GEMFSMApplication::GEMFSMApplication(xdaq::ApplicationStub* stub)
   m_resumeSig = toolbox::task::bind(this, &GEMFSMApplication::resume,     "resume"    );
   m_haltSig   = toolbox::task::bind(this, &GEMFSMApplication::halt,       "halt"      );
   m_resetSig  = toolbox::task::bind(this, &GEMFSMApplication::reset,      "reset"     );
-  DEBUG("GEMFSMApplication::Created task bindings");
+  CMSGEMOS_DEBUG("GEMFSMApplication::Created task bindings");
 
   std::stringstream tmpLoopName;
   uint32_t localID = this->getApplicationDescriptor()->getLocalId();
   std::string className   = this->getApplicationDescriptor()->getClassName();
-  DEBUG("GEMFSMApplication::Obtained local ID and class names " << localID << ", " << className);
+  CMSGEMOS_DEBUG("GEMFSMApplication::Obtained local ID and class names " << localID << ", " << className);
 
   // also want to get the name of the GEM FSM aplication to put it into this commandLoopName
   tmpLoopName << "urn:toolbox-task-workloop:"
               << className << ":" << localID;
   workLoopName = tmpLoopName.str();
-  DEBUG("GEMFSMApplication::Created workloop name " << workLoopName);
+  CMSGEMOS_DEBUG("GEMFSMApplication::Created workloop name " << workLoopName);
 
   updateState();
 
@@ -118,10 +118,10 @@ gem::base::GEMFSMApplication::GEMFSMApplication(xdaq::ApplicationStub* stub)
   // p_appStateInfoSpace->addGroupChangedListener( "GEMFSMState", this);
   toolbox::net::URN appStateISURN(m_urn+toolbox::toString(":appState-infospace"));
   if (xdata::getInfoSpaceFactory()->hasItem(appStateISURN.toString())) {
-    DEBUG("GEMFSMApplication::infospace " << appStateISURN.toString() << " already exists, getting");
+    CMSGEMOS_DEBUG("GEMFSMApplication::infospace " << appStateISURN.toString() << " already exists, getting");
     p_appStateInfoSpace = xdata::getInfoSpaceFactory()->get(appStateISURN.toString());
   } else {
-    DEBUG("GEMFSMApplication::infospace " << appStateISURN.toString() << " does not exist, creating");
+    CMSGEMOS_DEBUG("GEMFSMApplication::infospace " << appStateISURN.toString() << " does not exist, creating");
     p_appStateInfoSpace = xdata::getInfoSpaceFactory()->create(appStateISURN.toString());
   }
   p_appStateInfoSpaceToolBox = std::shared_ptr<utils::GEMInfoSpaceToolBox>(new utils::GEMInfoSpaceToolBox(this,
@@ -159,35 +159,35 @@ gem::base::GEMFSMApplication::GEMFSMApplication(xdaq::ApplicationStub* stub)
   p_appInfoSpace->fireItemValueRetrieve("StateProgress");
   // gemAppStateInfoSpace_.setFSMState(m_gemfsm.getCurrentStateName());
 
-  DEBUG("GEMFSMApplication::ctor end");
+  CMSGEMOS_DEBUG("GEMFSMApplication::ctor end");
 }
 
 gem::base::GEMFSMApplication::~GEMFSMApplication()
 {
   std::string msgBase = "[GEMFSMApplication::~GEMFSMApplication] ";
-  DEBUG(msgBase << "Begin");
-  DEBUG(msgBase << "End");
+  CMSGEMOS_DEBUG(msgBase << "Begin");
+  CMSGEMOS_DEBUG(msgBase << "End");
 }
 
 /**hyperdaq callbacks*/
 void gem::base::GEMFSMApplication::xgiInitialize(xgi::Input* in, xgi::Output* out)
 {
   std::string msgBase = "[GEMFSMApplication::xgiInitialize] ";
-  DEBUG(msgBase << "Begin");
+  CMSGEMOS_DEBUG(msgBase << "Begin");
   if (b_accept_web_commands) {
     try {
-      DEBUG("GEMFSMApplication::xgiInitialize::Sending SOAP command to application");
+      CMSGEMOS_DEBUG("GEMFSMApplication::xgiInitialize::Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Initialize", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       std::stringstream msg, errmsg;
       // msg << read in soap fault?
       m_stateMessage = msg.str();
       errmsg << "GEMFSMApplication::xgiInitialize Initialize failed: " << msg;
-      ERROR(errmsg.str());
+      CMSGEMOS_ERROR(errmsg.str());
       XCEPT_RETHROW(xgi::exception::Exception, errmsg.str(), e);
     }
   }
-  DEBUG("GEMFSMApplication::xgiInitialize end");
+  CMSGEMOS_DEBUG("GEMFSMApplication::xgiInitialize end");
 }
 
 void gem::base::GEMFSMApplication::xgiConfigure(xgi::Input* in, xgi::Output* out)
@@ -195,7 +195,7 @@ void gem::base::GEMFSMApplication::xgiConfigure(xgi::Input* in, xgi::Output* out
   std::string msgBase = "[GEMFSMApplication::xgiConfigure] ";
   if (b_accept_web_commands) {
     try {
-      DEBUG(msgBase << "Sending SOAP command to application");
+      CMSGEMOS_DEBUG(msgBase << "Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Configure", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       XCEPT_RETHROW( xgi::exception::Exception, "Configure failed", e );
@@ -208,7 +208,7 @@ void gem::base::GEMFSMApplication::xgiStart(xgi::Input* in, xgi::Output* out)
   std::string msgBase = "[GEMFSMApplication::xgiStart] ";
   if (b_accept_web_commands) {
     try {
-      DEBUG(msgBase << "Sending SOAP command to application");
+      CMSGEMOS_DEBUG(msgBase << "Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Start", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       XCEPT_RETHROW( xgi::exception::Exception, "Start failed", e );
@@ -221,7 +221,7 @@ void gem::base::GEMFSMApplication::xgiStop(xgi::Input* in, xgi::Output* out)
   std::string msgBase = "[GEMFSMApplication::xgiStop] ";
   if (b_accept_web_commands) {
     try {
-      DEBUG(msgBase << "Sending SOAP command to application");
+      CMSGEMOS_DEBUG(msgBase << "Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Stop", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       XCEPT_RETHROW( xgi::exception::Exception, "Stop failed", e );
@@ -234,7 +234,7 @@ void gem::base::GEMFSMApplication::xgiPause(xgi::Input* in, xgi::Output* out)
   std::string msgBase = "[GEMFSMApplication::xgiPause] ";
   if (b_accept_web_commands) {
     try {
-      DEBUG(msgBase << "Sending SOAP command to application");
+      CMSGEMOS_DEBUG(msgBase << "Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Pause", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       XCEPT_RETHROW( xgi::exception::Exception, "Pause failed", e );
@@ -247,7 +247,7 @@ void gem::base::GEMFSMApplication::xgiResume(xgi::Input* in, xgi::Output* out)
   std::string msgBase = "[GEMFSMApplication::xgiResume] ";
   if (b_accept_web_commands) {
     try {
-      DEBUG(msgBase << "Sending SOAP command to application");
+      CMSGEMOS_DEBUG(msgBase << "Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Resume", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       XCEPT_RETHROW( xgi::exception::Exception, "Resume failed", e );
@@ -260,7 +260,7 @@ void gem::base::GEMFSMApplication::xgiHalt(xgi::Input* in, xgi::Output* out)
   std::string msgBase = "[GEMFSMApplication::xgiHalt] ";
   if (b_accept_web_commands) {
     try {
-      DEBUG(msgBase << "Sending SOAP command to application");
+      CMSGEMOS_DEBUG(msgBase << "Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Halt", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       XCEPT_RETHROW( xgi::exception::Exception, "Halt failed", e );
@@ -273,7 +273,7 @@ void gem::base::GEMFSMApplication::xgiReset(xgi::Input* in, xgi::Output* out)
   std::string msgBase = "[GEMFSMApplication::xgiReset] ";
   if (b_accept_web_commands) {
     try {
-      DEBUG(msgBase << "Sending SOAP command to application");
+      CMSGEMOS_DEBUG(msgBase << "Sending SOAP command to application");
       gem::utils::soap::GEMSOAPToolBox::sendCommand("Reset", p_appContext, p_appDescriptor, p_appDescriptor);
     } catch (toolbox::fsm::exception::Exception& e ) {
       XCEPT_RETHROW( xgi::exception::Exception, "Reset failed", e );
@@ -293,12 +293,12 @@ void gem::base::GEMFSMApplication::transitionDriver(toolbox::Event::Reference ev
 {
   std::string msgBase = "[GEMFSMApplication::transitionDriver] ";
   // set a transition message to ""
-  DEBUG(msgBase << "(" << event->type() << ")");
+  CMSGEMOS_DEBUG(msgBase << "(" << event->type() << ")");
   try {
     if (event->type() == "Initialize" || event->type() == "Configure" || event->type() == "Start"  ||
         event->type() == "Stop"       || event->type() == "Pause"     || event->type() == "Resume" ||
         event->type() == "Halt"       || event->type() == "Reset" ) {
-      DEBUG(msgBase << "submitting workloopDriver(" << event->type() << ")");
+      CMSGEMOS_DEBUG(msgBase << "submitting workloopDriver(" << event->type() << ")");
       workloopDriver(event->type());
       // does this preclude the future "success" message at the end of the catch block?
       return;
@@ -306,16 +306,16 @@ void gem::base::GEMFSMApplication::transitionDriver(toolbox::Event::Reference ev
                event->type() == "IsRunning" || event->type() == "IsPaused"     ||
                event->type() == "IsHalted") {
       // report success
-      DEBUG(msgBase << "Recieved confirmation that state changed to " << event->type());
+      CMSGEMOS_DEBUG(msgBase << "Recieved confirmation that state changed to " << event->type());
     } else if (event->type() == "Fail" || event->type() == "fail") {
       // do nothing for the fail action
-      DEBUG(msgBase << "Recieved fail event type");
+      CMSGEMOS_DEBUG(msgBase << "Recieved fail event type");
     } else {
-      DEBUG(msgBase << "Unknown transition command");
+      CMSGEMOS_DEBUG(msgBase << "Unknown transition command");
       XCEPT_RAISE(toolbox::fsm::exception::Exception, "Unknown transition command");
     }
   } catch (gem::utils::exception::Exception& ex) {
-    ERROR(msgBase << "Caught gem::utils::exception::Exception");
+    CMSGEMOS_ERROR(msgBase << "Caught gem::utils::exception::Exception");
     fireEvent("Fail");
     // set a transition message to ex.what()
     XCEPT_RETHROW(toolbox::fsm::exception::Exception, "State Transition Failed", ex);
@@ -336,13 +336,13 @@ void gem::base::GEMFSMApplication::transitionDriver(toolbox::Event::Reference ev
 void gem::base::GEMFSMApplication::workloopDriver(std::string const& command)
 {
   std::string msgBase = "[GEMFSMApplication::workloopDriver] ";
-  DEBUG(msgBase << "workloopDriver begin");
+  CMSGEMOS_DEBUG(msgBase << "workloopDriver begin");
   try {
     toolbox::task::WorkLoopFactory* wlf  = toolbox::task::WorkLoopFactory::getInstance();
-    DEBUG(msgBase << "Trying to access the workloop with name " << workLoopName);
+    CMSGEMOS_DEBUG(msgBase << "Trying to access the workloop with name " << workLoopName);
     toolbox::task::WorkLoop*        loop = wlf->getWorkLoop(workLoopName, "waiting");
     if (!loop->isActive()) loop->activate();
-    DEBUG(msgBase << "Workloop should now be active");
+    CMSGEMOS_DEBUG(msgBase << "Workloop should now be active");
 
     if      (command == "Initialize") loop->submit(m_initSig  );
     else if (command == "Configure")  loop->submit(m_confSig  );
@@ -352,28 +352,28 @@ void gem::base::GEMFSMApplication::workloopDriver(std::string const& command)
     else if (command == "Resume")     loop->submit(m_resumeSig);
     else if (command == "Halt")       loop->submit(m_haltSig  );
     else if (command == "Reset")      loop->submit(m_resetSig );
-    DEBUG(msgBase << "Workloop should now be submitted");
+    CMSGEMOS_DEBUG(msgBase << "Workloop should now be submitted");
   } catch (gem::utils::exception::Exception& e) {
     std::stringstream msg;
     msg << "GEMFSMApplication::workloopDriver Workloop failure (gem::utils::exception)";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RETHROW(gem::utils::exception::Exception, msg.str(), e);
   } catch (toolbox::task::exception::Exception& e) {
     std::stringstream msg;
     msg << "GEMFSMApplication::workloopDriver Workloop failure (toolbox::task::exception)";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RETHROW(gem::utils::exception::Exception, msg.str(), e);
   }
   updateState();
   // gem::base::utils::GEMInfoSpaceToolBox::setString(p_appInfoSpace, "State", m_stateName.toString());
-  DEBUG(msgBase << "workloopDriver end");
+  CMSGEMOS_DEBUG(msgBase << "workloopDriver end");
 }
 
 void gem::base::GEMFSMApplication::resetAction(toolbox::Event::Reference event)
 {
   std::string msgBase = "[GEMFSMApplication::resetAction] ";
   // need to ensure that this is called from every derived class?
-  DEBUG(msgBase << "resetAction(" << event->type() << ")");
+  CMSGEMOS_DEBUG(msgBase << "resetAction(" << event->type() << ")");
   // should only enter this function on reciept of a "Reset" event
 
   // reset the monitor, check for validity?
@@ -387,7 +387,7 @@ void gem::base::GEMFSMApplication::resetAction(toolbox::Event::Reference event)
 
   // should probably do much more than this...
   // really, doe we need this here?
-  INFO(msgBase << "Firing 'IsInitial' into the FSM");
+  CMSGEMOS_INFO(msgBase << "Firing 'IsInitial' into the FSM");
   fireEvent("IsInitial");
   updateState();
   // gem::base::utils::GEMInfoSpaceToolBox::setString(p_appInfoSpace, "State", m_stateName.toString());
@@ -402,7 +402,7 @@ void gem::base::GEMFSMApplication::resetAction(toolbox::Event::Reference event)
 void gem::base::GEMFSMApplication::stateChanged(toolbox::fsm::FiniteStateMachine &fsm)
 {
   std::string msgBase = "[GEMFSMApplication::stateChanged] ";
-  INFO(msgBase << "stateChanged");
+  CMSGEMOS_INFO(msgBase << "stateChanged");
   updateState();
   // gem::base::utils::GEMInfoSpaceToolBox::setString(p_appInfoSpace, "State", m_stateName.toString());
 }
@@ -410,7 +410,7 @@ void gem::base::GEMFSMApplication::stateChanged(toolbox::fsm::FiniteStateMachine
 void gem::base::GEMFSMApplication::transitionFailed(toolbox::Event::Reference event)
 {
   std::string msgBase = "[GEMFSMApplication::transitionFailed] ";
-  WARN(msgBase << "transitionFailed(" <<event->type() << ")");
+  CMSGEMOS_WARN(msgBase << "transitionFailed(" <<event->type() << ")");
   updateState();
   // gem::base::utils::GEMInfoSpaceToolBox::setString(p_appInfoSpace, "State", m_stateName.toString());
 }
@@ -418,7 +418,7 @@ void gem::base::GEMFSMApplication::transitionFailed(toolbox::Event::Reference ev
 void gem::base::GEMFSMApplication::fireEvent(std::string event)
 {
   std::string msgBase = "[GEMFSMApplication::fireEvent] ";
-  INFO(msgBase << "fireEvent(" << event << ")");
+  CMSGEMOS_INFO(msgBase << "fireEvent(" << event << ")");
   try {
     toolbox::Event::Reference e(new toolbox::Event(event, this));
     m_gemfsm.fireEvent(e);
@@ -437,7 +437,7 @@ void gem::base::GEMFSMApplication::fireEvent(std::string event)
 xoap::MessageReference gem::base::GEMFSMApplication::changeState(xoap::MessageReference msg)
 {
   std::string msgBase = "[GEMFSMApplication::changeState] ";
-  DEBUG(msgBase << "changeState");
+  CMSGEMOS_DEBUG(msgBase << "changeState");
   updateState();
   // gem::base::utils::GEMInfoSpaceToolBox::setString(p_appInfoSpace, "State", m_stateName.toString());
   return m_gemfsm.changeState(msg);
@@ -448,26 +448,26 @@ bool gem::base::GEMFSMApplication::initialize(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::initialize] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "initialize called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "initialize called, current state: " << m_gemfsm.getCurrentState());
   // while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_INITIALIZING)) {  // deal with possible race condition
   while ((m_gemfsm.getCurrentFSMState()) != STATE_INITIALIZING) {  // deal with possible race condition
-    DEBUG(msgBase << "not in " << STATE_INITIALIZING << " sleeping (" << m_gemfsm.getCurrentState() << ")");
+    CMSGEMOS_DEBUG(msgBase << "not in " << STATE_INITIALIZING << " sleeping (" << m_gemfsm.getCurrentState() << ")");
     usleep(10);
   }
-  DEBUG(msgBase << "initialize called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "initialize called, current state: " << m_gemfsm.getCurrentState());
 
   p_gemWebInterface->buildCfgWebpage();  // Set up the basic config web page from the GEMWebApplication
 
   m_progress = 0.0;
   try {
-    DEBUG(msgBase << "Calling initializeAction");
+    CMSGEMOS_DEBUG(msgBase << "Calling initializeAction");
     this->initializeAction();
-    DEBUG(msgBase << "Finished initializeAction");
+    CMSGEMOS_DEBUG(msgBase << "Finished initializeAction");
     p_gemWebInterface->buildCfgWebpage();  // complete, so re render the config web page
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "Caught gem::utils::exception: " << ex.what();
-    ERROR(msgBase << msg.str());
+    CMSGEMOS_ERROR(msgBase << msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -475,7 +475,7 @@ bool gem::base::GEMFSMApplication::initialize(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "Caught toolbox::task::exception: " << ex.what();
-    ERROR(msgBase << msg.str());
+    CMSGEMOS_ERROR(msgBase << msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -483,7 +483,7 @@ bool gem::base::GEMFSMApplication::initialize(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "Malformed URN: " << ex.what();
-    ERROR(msgBase << msg.str());
+    CMSGEMOS_ERROR(msgBase << msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -491,7 +491,7 @@ bool gem::base::GEMFSMApplication::initialize(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "Caught std::exception: " << ex.what();
-    ERROR(msgBase << msg.str());
+    CMSGEMOS_ERROR(msgBase << msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -499,7 +499,7 @@ bool gem::base::GEMFSMApplication::initialize(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "Caught other exception";
-    ERROR(msgBase << msg.str());
+    CMSGEMOS_ERROR(msgBase << msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -508,16 +508,16 @@ bool gem::base::GEMFSMApplication::initialize(toolbox::task::WorkLoop *wl)
 
   if (p_gemMonitor && !m_disableMonitoring) {
     // start timers?
-    DEBUG(msgBase << "initialize found p_gemMonitor pointer, starting monitoring");
+    CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, starting monitoring");
     try {
       p_gemMonitor->startMonitoring();
     } catch (toolbox::task::exception::Exception const& ex) {
-      WARN("Unable to start monitoring " << ex.what());
+      CMSGEMOS_WARN("Unable to start monitoring " << ex.what());
     }
   }
   std::stringstream msg;
   msg << "GEMFSMApplication::initialize Firing 'IsHalted' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   m_stateMessage = msg.str();
   m_progress = 1.0;
   fireEvent("IsHalted");
@@ -529,23 +529,23 @@ bool gem::base::GEMFSMApplication::configure(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::configure] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "Called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "Called, current state: " << m_gemfsm.getCurrentState());
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // pause timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
   //   try {
   //     p_gemMonitor->pauseMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to pause monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to pause monitoring " << ex.what());
   //   }
   // }
 
   while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_CONFIGURING)) {  // deal with possible race condition
-    DEBUG(msgBase << "Not in " << STATE_CONFIGURING << " sleeping (" << m_gemfsm.getCurrentState() << ")");
+    CMSGEMOS_DEBUG(msgBase << "Not in " << STATE_CONFIGURING << " sleeping (" << m_gemfsm.getCurrentState() << ")");
     usleep(10);
   }
-  DEBUG(msgBase << "Called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "Called, current state: " << m_gemfsm.getCurrentState());
 
   try {
     m_progress = 0.0;
@@ -555,7 +555,7 @@ bool gem::base::GEMFSMApplication::configure(toolbox::task::WorkLoop *wl)
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "Caught gem::utils::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -563,7 +563,7 @@ bool gem::base::GEMFSMApplication::configure(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "Caught toolbox::task::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -571,7 +571,7 @@ bool gem::base::GEMFSMApplication::configure(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "malformed URN: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -579,7 +579,7 @@ bool gem::base::GEMFSMApplication::configure(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "caught std::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -587,7 +587,7 @@ bool gem::base::GEMFSMApplication::configure(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "caught unknown exception";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -596,17 +596,17 @@ bool gem::base::GEMFSMApplication::configure(toolbox::task::WorkLoop *wl)
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // resume timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
   //   try {
   //     p_gemMonitor->resumeMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to resume monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to resume monitoring " << ex.what());
   //   }
   // }
 
   std::stringstream msg;
   msg << "Firing 'IsConfigured' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   m_stateMessage = msg.str();
   fireEvent("IsConfigured");
   m_wl_semaphore.give();
@@ -617,22 +617,22 @@ bool gem::base::GEMFSMApplication::start(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::start] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "start called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "start called, current state: " << m_gemfsm.getCurrentState());
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // pause timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
   //   try {
   //     p_gemMonitor->pauseMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to pause monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to pause monitoring " << ex.what());
   //   }
   // }
 
   while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_STARTING)) {  // deal with possible race condition
     usleep(10);
   }
-  DEBUG(msgBase << "start called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "start called, current state: " << m_gemfsm.getCurrentState());
 
   try {
     m_progress = 0.0;
@@ -642,7 +642,7 @@ bool gem::base::GEMFSMApplication::start(toolbox::task::WorkLoop *wl)
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::start caught gem::utils::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -650,7 +650,7 @@ bool gem::base::GEMFSMApplication::start(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::start caught toolbox::task::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -658,7 +658,7 @@ bool gem::base::GEMFSMApplication::start(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::start malformed URN: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -666,7 +666,7 @@ bool gem::base::GEMFSMApplication::start(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::start caught std::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -674,7 +674,7 @@ bool gem::base::GEMFSMApplication::start(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "GEMFSMApplication::start caught unknown exception";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -683,7 +683,7 @@ bool gem::base::GEMFSMApplication::start(toolbox::task::WorkLoop *wl)
 
   std::stringstream msg;
   msg << "GEMFSMApplication::start Firing 'IsRunning' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   m_stateMessage = msg.str();
   fireEvent("IsRunning");
   m_wl_semaphore.give();
@@ -694,22 +694,22 @@ bool gem::base::GEMFSMApplication::pause(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::pause] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "pause called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "pause called, current state: " << m_gemfsm.getCurrentState());
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // pause timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
   //   try {
   //     p_gemMonitor->pauseMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to pause monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to pause monitoring " << ex.what());
   //   }
   // }
 
   while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_PAUSING)) {  // deal with possible race condition
     usleep(10);
   }
-  DEBUG(msgBase << "pause called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "pause called, current state: " << m_gemfsm.getCurrentState());
 
   try {
     m_progress = 0.0;
@@ -719,7 +719,7 @@ bool gem::base::GEMFSMApplication::pause(toolbox::task::WorkLoop *wl)
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::pause gem::utils::exception " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -727,7 +727,7 @@ bool gem::base::GEMFSMApplication::pause(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::pause caught toolbox::task::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -735,7 +735,7 @@ bool gem::base::GEMFSMApplication::pause(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::pause malformed URN: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -743,7 +743,7 @@ bool gem::base::GEMFSMApplication::pause(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::pause caught std::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -751,7 +751,7 @@ bool gem::base::GEMFSMApplication::pause(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "GEMFSMApplication::pause caught unknown exception";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -760,17 +760,17 @@ bool gem::base::GEMFSMApplication::pause(toolbox::task::WorkLoop *wl)
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // resume timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
   //   try {
   //     p_gemMonitor->resumeMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to resume monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to resume monitoring " << ex.what());
   //   }
   // }
 
   std::stringstream msg;
   msg << "GEMFSMApplication::pause Firing 'IsPaused' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   m_stateMessage = msg.str();
   fireEvent("IsPaused");
   m_wl_semaphore.give();
@@ -781,22 +781,22 @@ bool gem::base::GEMFSMApplication::resume(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::resume] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "resume called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "resume called, current state: " << m_gemfsm.getCurrentState());
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // pause timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
   //   try {
   //     p_gemMonitor->pauseMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to pause monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to pause monitoring " << ex.what());
   //   }
   // }
 
   while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_RESUMING)) {  // deal with possible race condition
     usleep(10);
   }
-  DEBUG(msgBase << "resume called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "resume called, current state: " << m_gemfsm.getCurrentState());
 
   try {
     m_progress = 0.0;
@@ -806,7 +806,7 @@ bool gem::base::GEMFSMApplication::resume(toolbox::task::WorkLoop *wl)
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::resume gem::utils::exception " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -814,7 +814,7 @@ bool gem::base::GEMFSMApplication::resume(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::resume caught toolbox::task::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -822,7 +822,7 @@ bool gem::base::GEMFSMApplication::resume(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::resume malformed URN: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -830,7 +830,7 @@ bool gem::base::GEMFSMApplication::resume(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::resume caught std::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -838,7 +838,7 @@ bool gem::base::GEMFSMApplication::resume(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "GEMFSMApplication::resume caught unknown exception";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -847,17 +847,17 @@ bool gem::base::GEMFSMApplication::resume(toolbox::task::WorkLoop *wl)
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // resume timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
   //   try {
   //     p_gemMonitor->resumeMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to resume monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to resume monitoring " << ex.what());
   //   }
   // }
 
   std::stringstream msg;
   msg << "GEMFSMApplication::resume Firing 'IsRunning' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   m_stateMessage = msg.str();
   fireEvent("IsRunning");
   m_wl_semaphore.give();
@@ -868,22 +868,22 @@ bool gem::base::GEMFSMApplication::stop(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::stop] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "stop called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "stop called, current state: " << m_gemfsm.getCurrentState());
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // pause timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
   //   try {
   //     p_gemMonitor->pauseMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to pause monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to pause monitoring " << ex.what());
   //   }
   // }
 
   while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_STOPPING)) {  // deal with possible race condition
     usleep(10);
   }
-  DEBUG(msgBase << "stop called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "stop called, current state: " << m_gemfsm.getCurrentState());
 
   try {
     m_progress = 0.0;
@@ -893,7 +893,7 @@ bool gem::base::GEMFSMApplication::stop(toolbox::task::WorkLoop *wl)
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::stop gem::utils::exception " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -901,7 +901,7 @@ bool gem::base::GEMFSMApplication::stop(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::stop caught toolbox::task::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -909,7 +909,7 @@ bool gem::base::GEMFSMApplication::stop(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::stop malformed URN: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -917,7 +917,7 @@ bool gem::base::GEMFSMApplication::stop(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::stop caught std::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -925,7 +925,7 @@ bool gem::base::GEMFSMApplication::stop(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "GEMFSMApplication::stop caught unknown exception";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -934,17 +934,17 @@ bool gem::base::GEMFSMApplication::stop(toolbox::task::WorkLoop *wl)
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // resume timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
   //   try {
   //     p_gemMonitor->resumeMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to resume monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to resume monitoring " << ex.what());
   //   }
   // }
 
   std::stringstream msg;
   msg << "GEMFSMApplication::stop Firing 'IsConfigured' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   m_stateMessage = msg.str();
   fireEvent("IsConfigured");
   m_wl_semaphore.give();
@@ -955,22 +955,22 @@ bool gem::base::GEMFSMApplication::halt(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::halt] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "halt called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "halt called, current state: " << m_gemfsm.getCurrentState());
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // pause timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, pausing monitoring");
   //   try {
   //     p_gemMonitor->pauseMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to pause monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to pause monitoring " << ex.what());
   //   }
   // }
 
   while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_HALTING)) {  // deal with possible race condition
     usleep(10);
   }
-  DEBUG(msgBase << "halt called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "halt called, current state: " << m_gemfsm.getCurrentState());
 
   try {
     m_progress = 0.0;
@@ -980,7 +980,7 @@ bool gem::base::GEMFSMApplication::halt(toolbox::task::WorkLoop *wl)
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::halt gem::utils::exception " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -988,7 +988,7 @@ bool gem::base::GEMFSMApplication::halt(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::halt caught toolbox::task::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -996,7 +996,7 @@ bool gem::base::GEMFSMApplication::halt(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::halt malformed URN: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1004,7 +1004,7 @@ bool gem::base::GEMFSMApplication::halt(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::halt caught std::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1012,7 +1012,7 @@ bool gem::base::GEMFSMApplication::halt(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "GEMFSMApplication::halt caught unknown exception";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1021,17 +1021,17 @@ bool gem::base::GEMFSMApplication::halt(toolbox::task::WorkLoop *wl)
 
   // if (p_gemMonitor && !m_disableMonitoring) {
   //   // resume timers?
-  //   DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
+  //   CMSGEMOS_DEBUG(msgBase << "initialize found p_gemMonitor pointer, resuming monitoring");
   //   try {
   //     p_gemMonitor->resumeMonitoring();
   //   } catch (toolbox::task::exception::Exception const& ex) {
-  //     WARN("Unable to resume monitoring " << ex.what());
+  //     CMSGEMOS_WARN("Unable to resume monitoring " << ex.what());
   //   }
   // }
 
   std::stringstream msg;
   msg << "GEMFSMApplication::halt Firing 'IsHalted' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   m_stateMessage = msg.str();
   fireEvent("IsHalted");
   m_wl_semaphore.give();
@@ -1042,11 +1042,11 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
 {
   std::string msgBase = "[GEMFSMApplication::reset] ";
   m_wl_semaphore.take();
-  INFO(msgBase << "reset called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_INFO(msgBase << "reset called, current state: " << m_gemfsm.getCurrentState());
   while ((m_gemfsm.getCurrentState()) != m_gemfsm.getStateName(STATE_RESETTING)) {  // deal with possible race condition
     usleep(10);
   }
-  DEBUG(msgBase << "reset called, current state: " << m_gemfsm.getCurrentState());
+  CMSGEMOS_DEBUG(msgBase << "reset called, current state: " << m_gemfsm.getCurrentState());
 
   try {
     m_progress = 0.0;
@@ -1057,14 +1057,14 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
     if (p_gemMonitor) {
       // reset the monitor, check for validity?
       // stops timers, removes items from json updates?
-      DEBUG(msgBase << "reset found p_gemMonitor pointer, stopping monitoring");
+      CMSGEMOS_DEBUG(msgBase << "reset found p_gemMonitor pointer, stopping monitoring");
       try {
         // even this prevents the state table from being updated, so either need a
         // separate monitor for the supervisor, or remove this call
         // p_gemMonitor->stopMonitoring();
         // p_gemMonitor->reset();
       } catch (toolbox::task::exception::NotActive const& ex) {
-        WARN("Unable to stop monitoring " << ex.what());
+        CMSGEMOS_WARN("Unable to stop monitoring " << ex.what());
       }
     }
     // reset the info space toolboxes, check for validity?
@@ -1079,7 +1079,7 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
   } catch (gem::utils::exception::Exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::reset gem::utils::exception " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1087,7 +1087,7 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
   } catch (toolbox::task::exception::Exception& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::reset caught toolbox::task::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1095,7 +1095,7 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
   } catch (toolbox::net::exception::MalformedURN const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::reset malformed URN: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1103,7 +1103,7 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
   } catch (std::exception const& ex) {
     std::stringstream msg;
     msg << "GEMFSMApplication::reset caught std::exception: " << ex.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1111,7 +1111,7 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
   } catch (...) {
     std::stringstream msg;
     msg << "GEMFSMApplication::reset caught unknown exception";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     m_stateMessage = msg.str();
     fireEvent("Fail");
     m_wl_semaphore.give();
@@ -1120,7 +1120,7 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
 
   std::stringstream msg;
   msg << "GEMFSMApplication::reset Firing 'IsInitial' into the FSM";
-  INFO(msg.str());
+  CMSGEMOS_INFO(msg.str());
   fireEvent("IsInitial");
   // maybe do a m_gemfsm.reset()?
   m_wl_semaphore.give();
@@ -1143,7 +1143,7 @@ bool gem::base::GEMFSMApplication::reset(toolbox::task::WorkLoop *wl)
 /*
   void gem::base::GEMFSMApplication::initializeAction()
   {
-  DEBUG(std::string("gem::base::GEMFSMApplication::initializeAction Initializing"));
+  CMSGEMOS_DEBUG(std::string("gem::base::GEMFSMApplication::initializeAction Initializing"));
   }
 
   void gem::base::GEMFSMApplication::configureAction() {}

--- a/gembase/src/common/GEMMonitor.cc
+++ b/gembase/src/common/GEMMonitor.cc
@@ -27,7 +27,7 @@ gem::base::GEMMonitor::GEMMonitor(log4cplus::Logger& logger, xdaq::Application* 
   m_timerName = timerName.str();
 
   try {
-    DEBUG("GEMMonitor::Creating timer with name " << m_timerName);
+    CMSGEMOS_DEBUG("GEMMonitor::Creating timer with name " << m_timerName);
     if (toolbox::task::getTimerFactory()->hasTimer(m_timerName))
       p_timer = toolbox::task::getTimerFactory()->getTimer(m_timerName);
     else
@@ -55,7 +55,7 @@ gem::base::GEMMonitor::GEMMonitor(log4cplus::Logger& logger, GEMApplication* gem
   m_timerName = timerName.str();
 
   try {
-    DEBUG("GEMMonitor::Creating timer with name " << m_timerName);
+    CMSGEMOS_DEBUG("GEMMonitor::Creating timer with name " << m_timerName);
     if (toolbox::task::getTimerFactory()->hasTimer(m_timerName))
       p_timer = toolbox::task::getTimerFactory()->getTimer(m_timerName);
     else
@@ -85,7 +85,7 @@ gem::base::GEMMonitor::GEMMonitor(log4cplus::Logger& logger, GEMFSMApplication* 
   m_timerName = timerName.str();
 
   try {
-    DEBUG("GEMMonitor::Creating timer with name " << m_timerName);
+    CMSGEMOS_DEBUG("GEMMonitor::Creating timer with name " << m_timerName);
     if (toolbox::task::getTimerFactory()->hasTimer(m_timerName))
       p_timer = toolbox::task::getTimerFactory()->getTimer(m_timerName);
     else
@@ -102,12 +102,12 @@ gem::base::GEMMonitor::~GEMMonitor()
 
 void gem::base::GEMMonitor::startMonitoring()
 {
-  INFO("GEMMonitor::startMonitoring");
+  CMSGEMOS_INFO("GEMMonitor::startMonitoring");
 
   try {
     p_timer->stop();
   } catch (toolbox::task::exception::NotActive const& ex) {
-    WARN("GEMMonitor::startMonitoring could not stop timer " << ex.what());
+    CMSGEMOS_WARN("GEMMonitor::startMonitoring could not stop timer " << ex.what());
   }
 
   p_timer->start();
@@ -125,13 +125,13 @@ void gem::base::GEMMonitor::startMonitoring()
 
 void gem::base::GEMMonitor::pauseMonitoring()
 {
-  INFO("GEMMonitor::pauseMonitoring");
+  CMSGEMOS_INFO("GEMMonitor::pauseMonitoring");
   p_timer->stop();
 }
 
 void gem::base::GEMMonitor::resumeMonitoring()
 {
-  INFO("GEMMonitor::resumeMonitoring");
+  CMSGEMOS_INFO("GEMMonitor::resumeMonitoring");
   // p_timer->start();
   // updateMonitorables();
   startMonitoring();
@@ -139,7 +139,7 @@ void gem::base::GEMMonitor::resumeMonitoring()
 
 void gem::base::GEMMonitor::stopMonitoring()
 {
-  INFO("GEMMonitor::stopMonitoring");
+  CMSGEMOS_INFO("GEMMonitor::stopMonitoring");
   p_timer->stop();
 }
 
@@ -164,7 +164,7 @@ void gem::base::GEMMonitor::setupMonitoring(bool isFSMApp)
 
 void gem::base::GEMMonitor::timeExpired(toolbox::task::TimerEvent& event)
 {
-  DEBUG("GEMMonitor::timeExpired received event:" << event.type());
+  CMSGEMOS_DEBUG("GEMMonitor::timeExpired received event:" << event.type());
   updateMonitorables();
 }
 
@@ -177,10 +177,10 @@ void gem::base::GEMMonitor::addInfoSpace(std::string const& name,
     std::pair<std::shared_ptr<gem::base::utils::GEMInfoSpaceToolBox>,
     toolbox::TimeInterval> >::const_iterator it = m_infoSpaceMap.find(name);
   if (it != m_infoSpaceMap.end()) {
-    DEBUG("GEMMonitor::addInfoSpace infospace " << name << " already exists in monitor!");
+    CMSGEMOS_DEBUG("GEMMonitor::addInfoSpace infospace " << name << " already exists in monitor!");
     return;
   }
-  DEBUG("GEMMonitor::addInfoSpace adding infospace " << name);
+  CMSGEMOS_DEBUG("GEMMonitor::addInfoSpace adding infospace " << name);
   m_infoSpaceMap.insert(std::make_pair(name, std::make_pair(infoSpace, interval)));
   std::list<std::string> emptyList;
   m_infoSpaceMonitorableSetMap.insert(std::make_pair(name, emptyList));
@@ -194,11 +194,11 @@ void gem::base::GEMMonitor::addMonitorableSet(std::string const& setname, std::s
   // it = m_monitorableSetsMap.find(setname);
   // if (it != m_monitorableSetsMap.end()) {
   if (m_monitorableSetsMap.count(setname)) {
-    DEBUG("GEMMonitor::addMonitorableSet monitorable set '" << setname << "' already exists in monitor!");
+    CMSGEMOS_DEBUG("GEMMonitor::addMonitorableSet monitorable set '" << setname << "' already exists in monitor!");
     return;
   }
 
-  DEBUG("GEMMonitor::addInfoSpace adding monitorable set '" << setname << "' to infospace '" << infoSpaceName << "'");
+  CMSGEMOS_DEBUG("GEMMonitor::addInfoSpace adding monitorable set '" << setname << "' to infospace '" << infoSpaceName << "'");
   std::unordered_map<std::string, GEMMonitorable> emptySet;
   // std::list<std::pair<std::string, GEMMonitorable> > emptySet;
   m_monitorableSetsMap.insert(std::make_pair(setname, emptySet));
@@ -215,13 +215,13 @@ void gem::base::GEMMonitor::addMonitorable(std::string const& setname,
                                            std::string const& format)
 {
   if (m_infoSpaceMap.find(infoSpaceName) == m_infoSpaceMap.end()) {
-    ERROR("GEMMonitor::addMonitorable infoSpace '" << infoSpaceName << "' does not exist in monitor!");
+    CMSGEMOS_ERROR("GEMMonitor::addMonitorable infoSpace '" << infoSpaceName << "' does not exist in monitor!");
     return;
   } else if (m_monitorableSetsMap.find(setname) == m_monitorableSetsMap.end()) {
-    ERROR("GEMMonitor::addMonitorable monitorable set '" << setname << "' does not exist in monitor!");
+    CMSGEMOS_ERROR("GEMMonitor::addMonitorable monitorable set '" << setname << "' does not exist in monitor!");
     return;
   }
-  DEBUG("GEMMonitor::addMonitorable monitorable set '" << setname << "' exists in monitor!");
+  CMSGEMOS_DEBUG("GEMMonitor::addMonitorable monitorable set '" << setname << "' exists in monitor!");
 
   std::shared_ptr<utils::GEMInfoSpaceToolBox> infoSpace = m_infoSpaceMap.find(infoSpaceName)->second.first;
   if (infoSpace->find(monpair.first)) {
@@ -233,7 +233,7 @@ void gem::base::GEMMonitor::addMonitorable(std::string const& setname,
     (*it).second.insert(std::make_pair(monpair.first, monitem));
     // (*it).second.push_back(std::make_pair(monpair.first, monitem));
   } else {
-    ERROR("GEMMonitor::addMonitorable monitorable '" << monpair.first << "' does not exist in infospace '"
+    CMSGEMOS_ERROR("GEMMonitor::addMonitorable monitorable '" << monpair.first << "' does not exist in infospace '"
            << infoSpaceName << "'!");
     return;
   }
@@ -255,7 +255,7 @@ std::list<std::vector<std::string> > gem::base::GEMMonitor::getFormattedItemSet(
   std::list< std::vector<std::string> > result;
   auto itemSet = m_monitorableSetsMap.find(setname);
   if (itemSet == m_monitorableSetsMap.end()) {
-    ERROR("GEMMonitor::Set named " << setname << " does not exist in monitor");
+    CMSGEMOS_ERROR("GEMMonitor::Set named " << setname << " does not exist in monitor");
     return result;
   }
 
@@ -272,7 +272,7 @@ std::list<std::vector<std::string> > gem::base::GEMMonitor::getFormattedItemSet(
     itl.push_back(doc);
     itl.push_back(gemItem.regname);
     result.push_back(itl);
-    DEBUG("GEMMonitor::Set named " << setname << " has members"
+    CMSGEMOS_DEBUG("GEMMonitor::Set named " << setname << " has members"
           << " name: "    << itl.at(0)
           << " val: "     << itl.at(1)
           << " doc: "     << itl.at(2)
@@ -307,20 +307,20 @@ void gem::base::GEMMonitor::jsonUpdateItemSets(xgi::Output *out)
     *out << "\"" << iset->first << "\" : [ " << std::endl;
 
     if (m_monitorableSetsMap.find(iset->first) == m_monitorableSetsMap.end()) {
-      DEBUG("GEMMonitor::Monitorable set " << iset->first << " not found, not exporting as JSON");
+      CMSGEMOS_DEBUG("GEMMonitor::Monitorable set " << iset->first << " not found, not exporting as JSON");
     } else if (m_monitorableSetsMap.find(iset->first)->second.empty()) {
-      DEBUG("GEMMonitor::Monitorable set " << iset->first << " is empty, not exporting as JSON");
+      CMSGEMOS_DEBUG("GEMMonitor::Monitorable set " << iset->first << " is empty, not exporting as JSON");
     } else {
-      DEBUG("GEMMonitor::Found monitorable set " << iset->first << " while updating for JSON export");
+      CMSGEMOS_DEBUG("GEMMonitor::Found monitorable set " << iset->first << " while updating for JSON export");
 
       jsonUpdateItemSet(iset->first, out);
     }
     // can't have a trailing comma for the last entry...
     if (std::distance(iset, end) == 1) {
-      DEBUG("GEMMonitor::Found last monitorable set " << iset->first << ", no trailing comma (])");
+      CMSGEMOS_DEBUG("GEMMonitor::Found last monitorable set " << iset->first << ", no trailing comma (])");
       *out << " ]"  << std::endl;
     } else {
-      DEBUG("GEMMonitor::Found monitorable set " << iset->first << ", trailing comma (],)");
+      CMSGEMOS_DEBUG("GEMMonitor::Found monitorable set " << iset->first << ", trailing comma (],)");
       *out << " ]," << std::endl;
     }
   }
@@ -336,28 +336,28 @@ void gem::base::GEMMonitor::jsonUpdateInfoSpaces(xgi::Output *out)
 void gem::base::GEMMonitor::reset()
 {
   // have to get rid of the timer
-  DEBUG("GEMMonitor::reset");
+  CMSGEMOS_DEBUG("GEMMonitor::reset");
   for (auto infoSpace = m_infoSpaceMap.begin(); infoSpace != m_infoSpaceMap.end(); ++infoSpace) {
-    DEBUG("GEMMonitor::reset removing " << infoSpace->first << " from p_timer");
+    CMSGEMOS_DEBUG("GEMMonitor::reset removing " << infoSpace->first << " from p_timer");
     try {
       p_timer->remove(infoSpace->first);
     } catch (toolbox::task::exception::Exception& te) {
-      ERROR("GEMMonitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
+      CMSGEMOS_ERROR("GEMMonitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
     }
   }
   stopMonitoring();
-  DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
+  CMSGEMOS_DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
   try {
     toolbox::task::getTimerFactory()->removeTimer(m_timerName);
   } catch (toolbox::task::exception::Exception& te) {
-    ERROR("GEMMonitor::Caught exception while removing timer " << m_timerName << " " << te.what());
+    CMSGEMOS_ERROR("GEMMonitor::Caught exception while removing timer " << m_timerName << " " << te.what());
   }
 
   // is this necessary? how to do for some applications and not others?
   // make this simply an interface and force every derived application to implement it properly
   // without this, then the json updates will continue and eventually fail
   /*
-  DEBUG("GEMMonitor::reset - clearing all maps");
+  CMSGEMOS_DEBUG("GEMMonitor::reset - clearing all maps");
   m_infoSpaceMap.clear();
   m_infoSpaceMonitorableSetMap.clear();
   m_monitorableSetInfoSpaceMap.clear();

--- a/gembase/src/common/GEMWebApplication.cc
+++ b/gembase/src/common/GEMWebApplication.cc
@@ -84,13 +84,13 @@ void gem::base::GEMWebApplication::webRedirect(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webDefault(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webDefault");
+  CMSGEMOS_DEBUG("GEMWebApplication::webDefault");
   *out << cgicc::script().set("type", "text/javascript")
     .set("src", "/gemdaq/gembase/html/scripts/gemwebapp.js")
        << cgicc::script() << std::endl;
 
   if (p_gemFSMApp)
-    DEBUG("GEMWebApplication::current state is" << p_gemFSMApp->getCurrentState());
+    CMSGEMOS_DEBUG("GEMWebApplication::current state is" << p_gemFSMApp->getCurrentState());
   *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
 
   if (p_gemFSMApp) {
@@ -142,7 +142,7 @@ void gem::base::GEMWebApplication::webFooterGEM(xgi::Input *in, xgi::Output *out
 void gem::base::GEMWebApplication::controlPanel(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::controlPanel");
+  CMSGEMOS_DEBUG("GEMWebApplication::controlPanel");
   // maybe the control part should only be displayed if the application is not supervised?
   if (p_gemFSMApp) {
     *out << cgicc::script().set("type", "text/javascript")
@@ -156,7 +156,7 @@ void gem::base::GEMWebApplication::controlPanel(xgi::Input *in, xgi::Output *out
 
     try {
       std::string state = dynamic_cast<gem::base::GEMFSMApplication*>(p_gemFSMApp)->getCurrentState();
-      DEBUG("GEMWebApplication::controlPanel:: current state " << state);
+      CMSGEMOS_DEBUG("GEMWebApplication::controlPanel:: current state " << state);
 
       *out << "<table class=\"xdaq-table\">" << std::endl
            << cgicc::thead() << std::endl
@@ -234,10 +234,10 @@ void gem::base::GEMWebApplication::controlPanel(xgi::Input *in, xgi::Output *out
            << "</tbody>"  << std::endl
            << "</table>"  << std::endl;
     } catch (const xgi::exception::Exception& e) {
-      ERROR("GEMWebApplication::Something went wrong displaying web control panel(xgi): " << e.what());
+      CMSGEMOS_ERROR("GEMWebApplication::Something went wrong displaying web control panel(xgi): " << e.what());
       XCEPT_RAISE(xgi::exception::Exception, e.what());
     } catch (const std::exception& e) {
-      ERROR("GEMWebApplication::Something went wrong displaying web control panel(std): " << e.what());
+      CMSGEMOS_ERROR("GEMWebApplication::Something went wrong displaying web control panel(std): " << e.what());
       XCEPT_RAISE(xgi::exception::Exception, e.what());
     }
   }  // only when the GEMFSM has been created
@@ -247,7 +247,7 @@ void gem::base::GEMWebApplication::controlPanel(xgi::Input *in, xgi::Output *out
 void gem::base::GEMWebApplication::monitorPage(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::monitorPage");
+  CMSGEMOS_DEBUG("GEMWebApplication::monitorPage");
   *out << "monitorPage" << std::endl
        << cgicc::br()   << std::endl;
 }
@@ -256,7 +256,7 @@ void gem::base::GEMWebApplication::monitorPage(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::expertPage(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::expertPage");
+  CMSGEMOS_DEBUG("GEMWebApplication::expertPage");
   *out << "expertPage" << std::endl
        << cgicc::br()  << std::endl;
 }
@@ -265,7 +265,7 @@ void gem::base::GEMWebApplication::expertPage(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::applicationPage(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::applicationPage");
+  CMSGEMOS_DEBUG("GEMWebApplication::applicationPage");
   *out << "applicationPage" << std::endl
        << cgicc::br()       << std::endl;
 }
@@ -275,13 +275,13 @@ void gem::base::GEMWebApplication::applicationPage(xgi::Input *in, xgi::Output *
 void gem::base::GEMWebApplication::jsonUpdate(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::jsonUpdate");
+  CMSGEMOS_DEBUG("GEMWebApplication::jsonUpdate");
 }
 */
 void gem::base::GEMWebApplication::jsonStateUpdate(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::jsonStateUpdate");
+  CMSGEMOS_DEBUG("GEMWebApplication::jsonStateUpdate");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " {" << std::endl;
   *out << "   \"name\":\"fsmState\"" << ",\"value\": \""
@@ -293,7 +293,7 @@ void gem::base::GEMWebApplication::jsonStateUpdate(xgi::Input *in, xgi::Output *
 void gem::base::GEMWebApplication::jsonUpdate(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::jsonUpdate");
+  CMSGEMOS_DEBUG("GEMWebApplication::jsonUpdate");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   auto monitor = p_gemFSMApp->p_gemMonitor;
@@ -310,25 +310,25 @@ void gem::base::GEMWebApplication::jsonUpdate(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webInitialize(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webInitialize begin");
+  CMSGEMOS_DEBUG("GEMWebApplication::webInitialize begin");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Initialize");
     } catch( toolbox::fsm::exception::Exception& e) {
       XCEPT_RETHROW(xgi::exception::Exception, "webInitialize failed", e);
     }
   }
-  // DEBUG("GEMWebApplication::webInitialize end");
+  // CMSGEMOS_DEBUG("GEMWebApplication::webInitialize end");
 }
 
 /*To be filled in with the startup (enable) routine*/
 void gem::base::GEMWebApplication::webEnable(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webEnable");
+  CMSGEMOS_DEBUG("GEMWebApplication::webEnable");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Enable");
     } catch( toolbox::fsm::exception::Exception& e) {
@@ -341,9 +341,9 @@ void gem::base::GEMWebApplication::webEnable(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webConfigure(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webConfigure");
+  CMSGEMOS_DEBUG("GEMWebApplication::webConfigure");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Configure");
     } catch( toolbox::fsm::exception::Exception& e) {
@@ -356,9 +356,9 @@ void gem::base::GEMWebApplication::webConfigure(xgi::Input *in, xgi::Output *out
 void gem::base::GEMWebApplication::webStart(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webStart");
+  CMSGEMOS_DEBUG("GEMWebApplication::webStart");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Start");
     } catch( toolbox::fsm::exception::Exception& e) {
@@ -370,9 +370,9 @@ void gem::base::GEMWebApplication::webStart(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webPause(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webPause");
+  CMSGEMOS_DEBUG("GEMWebApplication::webPause");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Pause");
     } catch( toolbox::fsm::exception::Exception& e) {
@@ -385,9 +385,9 @@ void gem::base::GEMWebApplication::webPause(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webResume(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webResume");
+  CMSGEMOS_DEBUG("GEMWebApplication::webResume");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Resume");
     } catch( toolbox::fsm::exception::Exception& e) {
@@ -400,9 +400,9 @@ void gem::base::GEMWebApplication::webResume(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webStop(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webStop");
+  CMSGEMOS_DEBUG("GEMWebApplication::webStop");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Stop");
     } catch( toolbox::fsm::exception::Exception& e) {
@@ -415,9 +415,9 @@ void gem::base::GEMWebApplication::webStop(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webHalt(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webHalt");
+  CMSGEMOS_DEBUG("GEMWebApplication::webHalt");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Halt");
     } catch( toolbox::fsm::exception::Exception& e) {
@@ -430,9 +430,9 @@ void gem::base::GEMWebApplication::webHalt(xgi::Input *in, xgi::Output *out)
 void gem::base::GEMWebApplication::webReset(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMWebApplication::webReset");
+  CMSGEMOS_DEBUG("GEMWebApplication::webReset");
   if (p_gemFSMApp) {
-    DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
+    CMSGEMOS_DEBUG("GEMWebApplication::p_gemFSMApp non-zero");
     try {
       p_gemFSMApp->fireEvent("Reset");
     } catch( toolbox::fsm::exception::Exception& e) {

--- a/gembase/src/common/utils/GEMInfoSpaceToolBox.cc
+++ b/gembase/src/common/utils/GEMInfoSpaceToolBox.cc
@@ -16,7 +16,7 @@ gem::base::utils::GEMInfoSpaceToolBox::GEMInfoSpaceToolBox(gem::base::GEMApplica
   // p_gemMonitor(gemMonitor),
   p_infoSpace(infoSpace)
 {
-  INFO("GEMInfoSpaceToolBox::Created GEMInfoSpaceToolBox from application "
+  CMSGEMOS_INFO("GEMInfoSpaceToolBox::Created GEMInfoSpaceToolBox from application "
        << gemApp->getApplicationDescriptor()->getClassName()
        << " and existing InfoSpace " << infoSpace->name());
 }
@@ -31,12 +31,12 @@ gem::base::utils::GEMInfoSpaceToolBox::GEMInfoSpaceToolBox(gem::base::GEMApplica
 {
   if (xdata::getInfoSpaceFactory()->hasItem(infoSpaceName)) {
     p_infoSpace = xdata::getInfoSpaceFactory()->get(infoSpaceName);
-    INFO("GEMInfoSpaceToolBox::Created GEMInfoSpaceToolBox from application "
+    CMSGEMOS_INFO("GEMInfoSpaceToolBox::Created GEMInfoSpaceToolBox from application "
          << gemApp->getApplicationDescriptor()->getClassName()
          << " and existing InfoSpace " << infoSpaceName);
   } else {
     p_infoSpace = xdata::getInfoSpaceFactory()->create(infoSpaceName);
-    INFO("GEMInfoSpaceToolBox::Created GEMInfoSpaceToolBox from application "
+    CMSGEMOS_INFO("GEMInfoSpaceToolBox::Created GEMInfoSpaceToolBox from application "
          << gemApp->getApplicationDescriptor()->getClassName()
          << " and new InfoSpace " << infoSpaceName);
   }
@@ -58,7 +58,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createString(std::string const& item
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -76,21 +76,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createString(std::string const& item
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created string " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created string " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace String item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace String item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace String item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -104,7 +104,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createBool(std::string const& itemNa
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -123,21 +123,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createBool(std::string const& itemNa
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created bool " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created bool " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace Boolean item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace Boolean item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace Boolean item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -151,7 +151,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createDouble(std::string const& item
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -170,21 +170,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createDouble(std::string const& item
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created double " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created double " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace Double item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace Double item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace Double item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -198,7 +198,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createInteger(std::string const& ite
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -217,21 +217,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createInteger(std::string const& ite
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created int " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created int " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace Integer item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace Integer item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace Integer item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -245,7 +245,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createInteger32(std::string const& i
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -264,21 +264,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createInteger32(std::string const& i
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created int32_t " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created int32_t " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace Integer32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace Integer32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace Integer32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -292,7 +292,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createInteger64(std::string const& i
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -311,21 +311,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createInteger64(std::string const& i
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created int64_t " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created int64_t " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace Integer64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace Integer64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace Integer64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -339,7 +339,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createUInt32(std::string const& item
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -358,21 +358,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createUInt32(std::string const& item
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created uint32_t " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created uint32_t " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace UnsignedInteger32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace UnsignedInteger32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace UnsignedInteger32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -386,7 +386,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createUInt64(std::string const& item
       std::string err = "An element with the name '" + itemName + "' exists already in this infospace.";
       XCEPT_DECLARE(gem::base::utils::exception::InfoSpaceProblem, top, err);
       p_gemApp->notifyQualified("fatal", top);
-      ERROR("GEMInfoSpaceToolBox::" << err);
+      CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << err);
       return false;
     }
 
@@ -405,21 +405,21 @@ bool gem::base::utils::GEMInfoSpaceToolBox::createUInt64(std::string const& item
     // p_infoSpace->fireItemAvailable(itemName, tmpptr.get());
     p_infoSpace->fireItemAvailable(itemName, tmpptr);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::Created uint64_t " << itemName << " in infoSpace " << p_infoSpace->name());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::Created uint64_t " << itemName << " in infoSpace " << p_infoSpace->name());
     return true;
   } catch (xdata::exception::Exception const& err) {
     std::string msg = "Error trying to create InfoSpace UnsignedInteger64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (std::exception const& err) {
     std::string msg = "Error trying to create InfoSpace UnsignedInteger64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg << " " << err.what());
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   } catch (...) {
     std::string msg = "Error trying to create InfoSpace UnsignedInteger64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -432,12 +432,12 @@ std::string gem::base::utils::GEMInfoSpaceToolBox::getString(std::string const& 
     xdata::Serializable* s = p_infoSpace->find(itemName);
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::String* res = dynamic_cast<xdata::String*>(s);
-    DEBUG("GEMInfoSpaceToolBox::found string " << res->toString());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found string " << res->toString());
     p_infoSpace->unlock();
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace String item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return "";
   }
@@ -451,7 +451,7 @@ bool gem::base::utils::GEMInfoSpaceToolBox::getBool(std::string const& itemName)
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::Boolean* res = dynamic_cast<xdata::Boolean*>(s);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::found bool " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found bool " << res->value_);
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace Boolean item '" + itemName + "'.";
@@ -468,7 +468,7 @@ double gem::base::utils::GEMInfoSpaceToolBox::getDouble(std::string const& itemN
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::Double* res = dynamic_cast<xdata::Double*>(s);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::found double " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found double " << res->value_);
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace Double item '" + itemName + "'.";
@@ -485,7 +485,7 @@ int gem::base::utils::GEMInfoSpaceToolBox::getInteger(std::string const& itemNam
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::Integer* res = dynamic_cast<xdata::Integer*>(s);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::found integer " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found integer " << res->value_);
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace Integer item '" + itemName + "'.";
@@ -502,7 +502,7 @@ int32_t gem::base::utils::GEMInfoSpaceToolBox::getInteger32(std::string const& i
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::Integer32* res = dynamic_cast<xdata::Integer32*>(s);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::found integer32 " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found integer32 " << res->value_);
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace Integer32 item '" + itemName + "'.";
@@ -519,7 +519,7 @@ int64_t gem::base::utils::GEMInfoSpaceToolBox::getInteger64(std::string const& i
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::Integer64* res = dynamic_cast<xdata::Integer64*>(s);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::found integer64 " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found integer64 " << res->value_);
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace Integer64 item '" + itemName + "'.";
@@ -536,7 +536,7 @@ uint32_t gem::base::utils::GEMInfoSpaceToolBox::getUInt32(std::string const& ite
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::UnsignedInteger32* res = dynamic_cast<xdata::UnsignedInteger32*>(s);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::found uint32_t " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found uint32_t " << res->value_);
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace UnsignedInteger32 item '" + itemName + "'.";
@@ -553,7 +553,7 @@ uint64_t gem::base::utils::GEMInfoSpaceToolBox::getUInt64(std::string const& ite
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::UnsignedInteger64* res = dynamic_cast<xdata::UnsignedInteger64*>(s);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::found uint64_t " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::found uint64_t " << res->value_);
     return res->value_;
   } catch (...) {
     std::string msg = "Trying to read a non-existent InfoSpace UnsignedInteger64 item '" + itemName + "'.";
@@ -569,16 +569,16 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setString(std::string const& itemNam
     xdata::Serializable* s = p_infoSpace->find(itemName);
     p_infoSpace->fireItemValueRetrieve(itemName);
     xdata::String* res = dynamic_cast<xdata::String*>(s);
-    DEBUG("GEMInfoSpaceToolBox::find string \"" << itemName << "\" s=" << std::hex << s << std::dec
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::find string \"" << itemName << "\" s=" << std::hex << s << std::dec
           << ", res=" << std::hex << res << std::dec);
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to string " << res->toString());
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to string " << res->toString());
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace String item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -594,11 +594,11 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setBool(std::string const& itemName,
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to bool " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to bool " << res->value_);
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace Boolean item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -614,11 +614,11 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setDouble(std::string const& itemNam
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to double " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to double " << res->value_);
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace Double item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -634,11 +634,11 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setInteger(std::string const& itemNa
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to integer " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to integer " << res->value_);
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace Integer item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -654,11 +654,11 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setInteger32(std::string const& item
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to integer32 " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to integer32 " << res->value_);
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace Integer32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -674,11 +674,11 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setInteger64(std::string const& item
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to integer64 " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to integer64 " << res->value_);
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace Integer64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -694,11 +694,11 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setUInt32(std::string const& itemNam
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to uint32_t " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to uint32_t " << res->value_);
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace UnsignedInteger32 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -714,11 +714,11 @@ bool gem::base::utils::GEMInfoSpaceToolBox::setUInt64(std::string const& itemNam
     *res = value;
     p_infoSpace->fireItemValueChanged(itemName);
     p_infoSpace->unlock();
-    DEBUG("GEMInfoSpaceToolBox::set value to uint64_t " << res->value_);
+    CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::set value to uint64_t " << res->value_);
     return true;
   } catch (...) {
     std::string msg = "Trying to set a non-existent InfoSpace UnsignedInteger64 item '" + itemName + "'.";
-    ERROR("GEMInfoSpaceToolBox::" << msg);
+    CMSGEMOS_ERROR("GEMInfoSpaceToolBox::" << msg);
     XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
     return false;
   }
@@ -887,48 +887,48 @@ uint64_t gem::base::utils::GEMInfoSpaceToolBox::getUInt64(xdata::InfoSpace* info
 
 std::string gem::base::utils::GEMInfoSpaceToolBox::getFormattedItem(std::string const& itemName, std::string const& format)
 {
-  DEBUG("GEMInfoSpaceToolBox::getFormattedItem(" << itemName << ", " << format << ")");
+  CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::getFormattedItem(" << itemName << ", " << format << ")");
   auto item = m_itemMap.find(itemName);
   if (item == m_itemMap.end()) {
     std::string err = itemName + "' does not exist in this infospace.";
-    WARN("GEMInfoSpaceToolBox::" << err);
+    CMSGEMOS_WARN("GEMInfoSpaceToolBox::" << err);
     return "Item not found";
   }
   std::stringstream result;
   GEMInfoSpaceItem* isItem = item->second;
-  DEBUG(itemName << " found in infospace " << std::hex << isItem << std::dec);
+  CMSGEMOS_DEBUG(itemName << " found in infospace " << std::hex << isItem << std::dec);
   ItemType type = isItem->m_itype;
 
   if ( type == INTEGER ) {
     int val = this->getInteger(itemName);
-    DEBUG(itemName << " has value " << val << std::dec);
+    CMSGEMOS_DEBUG(itemName << " has value " << val << std::dec);
     if ( format == "dec" ) {
       result << std::dec << val;
     } else {
-      WARN("Invalid format specified for INTEGER type item " << itemName << " formating as simple \"dec\"");
+      CMSGEMOS_WARN("Invalid format specified for INTEGER type item " << itemName << " formating as simple \"dec\"");
       result << std::dec << val;
     }
   } else if ( type == INTEGER32 ) {
     int32_t val = this->getInteger32(itemName);
-    DEBUG(itemName << " has value " << val << std::dec);
+    CMSGEMOS_DEBUG(itemName << " has value " << val << std::dec);
     if ( format == "dec" ) {
       result << std::dec << val;
     } else {
-      WARN("Invalid format specified for INTEGER32 type item " << itemName << " formating as simple \"dec\"");
+      CMSGEMOS_WARN("Invalid format specified for INTEGER32 type item " << itemName << " formating as simple \"dec\"");
       result << std::dec << val;
     }
   } else if ( type == INTEGER64 ) {
     int64_t val = this->getInteger64(itemName);
-    DEBUG(itemName << " has value " << val << std::dec);
+    CMSGEMOS_DEBUG(itemName << " has value " << val << std::dec);
     if ( format == "dec" ) {
       result << std::dec << val;
     } else {
-      WARN("Invalid format specified for INTEGER64 type item " << itemName << " formating as simple \"dec\"");
+      CMSGEMOS_WARN("Invalid format specified for INTEGER64 type item " << itemName << " formating as simple \"dec\"");
       result << std::dec << val;
     }
   } else if ( type == UINT32 ) {
     uint32_t val = this->getUInt32(itemName);
-    DEBUG(itemName << " has value " << std::hex << val << std::dec);
+    CMSGEMOS_DEBUG(itemName << " has value " << std::hex << val << std::dec);
     if ( format == "" || format == "hex" ) {
       result << "0x" << std::setw(8) << std::setfill('0') << std::hex << val;
     } else if ( format == "bit" ) {
@@ -983,7 +983,7 @@ std::string gem::base::utils::GEMInfoSpaceToolBox::getFormattedItem(std::string 
     }
   } else if (type == UINT64) {  // end of type == UINT32
     uint64_t val = this->getUInt64(itemName);
-    DEBUG(itemName << " has value " << std::hex << val << std::dec);
+    CMSGEMOS_DEBUG(itemName << " has value " << std::hex << val << std::dec);
     if ( format == "i2c/dec" ) {
       result << (val&(uint32_t)0xffffffff) << " (str.)" << std::endl
              << (val>>32) << " (ack.) ";
@@ -1005,11 +1005,11 @@ std::string gem::base::utils::GEMInfoSpaceToolBox::getFormattedItem(std::string 
 
   } else if (type == STRING) {  // end of type == UINT64
     std::string val = this->getString(itemName);
-    DEBUG(itemName << " has value " << val);
+    CMSGEMOS_DEBUG(itemName << " has value " << val);
     if ( format == "" ) {
       result << val;
     } else  {
-      WARN("GEMInfoSpaceToolBox::Unsupported format " << format);
+      CMSGEMOS_WARN("GEMInfoSpaceToolBox::Unsupported format " << format);
       result << val;
     }
   }  // end of type == STRING
@@ -1019,16 +1019,16 @@ std::string gem::base::utils::GEMInfoSpaceToolBox::getFormattedItem(std::string 
 
 std::string gem::base::utils::GEMInfoSpaceToolBox::getItemDocstring(std::string const& itemName)
 {
-  DEBUG("GEMInfoSpaceToolBox::getItemDocstring(" << itemName << ")");
+  CMSGEMOS_DEBUG("GEMInfoSpaceToolBox::getItemDocstring(" << itemName << ")");
   auto item = m_itemMap.find(itemName);
   if (item == m_itemMap.end()) {
     std::string err = itemName + "' does not exist in this infospace.";
-    WARN("GEMInfoSpaceToolBox::" << err);
+    CMSGEMOS_WARN("GEMInfoSpaceToolBox::" << err);
     return "Item not found";
   }
   std::stringstream result;
   GEMInfoSpaceItem* isItem = item->second;
-  DEBUG(itemName << " found in infospace " << std::hex << isItem << std::dec);
+  CMSGEMOS_DEBUG(itemName << " found in infospace " << std::hex << isItem << std::dec);
   return isItem->m_docstring;
 }
 
@@ -1052,13 +1052,13 @@ void gem::base::utils::GEMInfoSpaceToolBox::reset()
   // // simply empty the item lists?
   // for (auto it = m_uint32Items.begin(); it != m_uint32Items.end(); ++it) {
   //   if ((it->second).second) {
-  //     WARN("GEMInfoSpaceToolBox::resetGEMInfoSpaceToolBox::reset delete called for"
+  //     CMSGEMOS_WARN("GEMInfoSpaceToolBox::resetGEMInfoSpaceToolBox::reset delete called for"
   //          // << std::hex << std::setw(8) << std::setfill('0') << it << std::dec
   //          << " " << it->first << " " << (it->second).first << " "
   //          << sizeof((*(it->second).second)) << "(size) "
   //          << std::hex << std::setw(8) << std::setfill('0') << (it->second).second << std::dec);
   //     delete (it->second).second;
-  //     WARN("GEMInfoSpaceToolBox::resetGEMInfoSpaceToolBox::reset done with"
+  //     CMSGEMOS_WARN("GEMInfoSpaceToolBox::resetGEMInfoSpaceToolBox::reset done with"
   //          // << std::hex << std::setw(8) << std::setfill('0') << it << std::dec
   //          << " " << it->first << " " << (it->second).first << " "
   //          << sizeof(*((it->second).second)) << "(size) ");

--- a/gemdaqmonitor/src/common/DaqMonitor.cc
+++ b/gemdaqmonitor/src/common/DaqMonitor.cc
@@ -18,30 +18,30 @@ gem::daqmon::DaqMonitor::DaqMonitor(const std::string& board_domain_name,log4cpl
   //xhal::XHALInterface(board_domain_name, logger) //FIXME: if using shared logger, then XHALInterface overtakes everything and logging from XDAQ doesn't go through
   xhal::XHALInterface(board_domain_name) //Works as is, providing a bit messy logging, but with all info in place
 {
-  DEBUG("DaqMonitor::DaqMonitor:: entering constructor");
+  CMSGEMOS_DEBUG("DaqMonitor::DaqMonitor:: entering constructor");
   if (isConnected) { //TODO Add to the app monitoring space? Need to know in order to mask in web interface the boards which failed to connect
     this->loadModule("daq_monitor", "daq_monitor v1.0.1");
-    DEBUG("DaqMonitor::DaqMonitor:: daq_monitor module loaded");
+    CMSGEMOS_DEBUG("DaqMonitor::DaqMonitor:: daq_monitor module loaded");
   } else {
-    INFO("DaqMonitor::DaqMonitor:: RPC interface failed to connect");
+    CMSGEMOS_INFO("DaqMonitor::DaqMonitor:: RPC interface failed to connect");
   }
   toolbox::net::URN hwCfgURN("urn:gem:hw:"+board_domain_name);
-  DEBUG("DaqMonitor::DaqMonitor:: infospace " << hwCfgURN.toString() << " does not exist, creating");
+  CMSGEMOS_DEBUG("DaqMonitor::DaqMonitor:: infospace " << hwCfgURN.toString() << " does not exist, creating");
   is_daqmon =  is_toolbox_ptr(new gem::base::utils::GEMInfoSpaceToolBox(p_gemApp,
                                                                         hwCfgURN.toString(),
                                                                         true));
   addInfoSpace("DAQ_MONITORING", is_daqmon, toolbox::TimeInterval(2,  0));
 
   setupDaqMonitoring();
-  
+
   logCnt = 0;
-  
-  DEBUG("gem::daqmon::DaqMonitor : constructor done");
+
+  CMSGEMOS_DEBUG("gem::daqmon::DaqMonitor : constructor done");
 }
 
 gem::daqmon::DaqMonitor::~DaqMonitor()
 {
-  DEBUG("gem::daqmon::DaqMonitor : destructor called");
+  CMSGEMOS_DEBUG("gem::daqmon::DaqMonitor : destructor called");
 //TODO
 }
 
@@ -51,7 +51,7 @@ void gem::daqmon::DaqMonitor::reconnect()
     this->connect();
     this->loadModule("daq_monitor", "daq_monitor v1.0.1");
   } else {
-    ERROR("Interface already connected. Reconnection failed");
+    CMSGEMOS_ERROR("Interface already connected. Reconnection failed");
     throw xhal::utils::XHALRPCException("RPC exception: Interface already connected. Reconnection failed");
   }
 }
@@ -196,7 +196,7 @@ void gem::daqmon::DaqMonitor::setupDaqMonitoring()
 
 void gem::daqmon::DaqMonitor::updateMonitorables()
 {
-  DEBUG("DaqMonitor: Updating Monitorables");
+  CMSGEMOS_DEBUG("DaqMonitor: Updating Monitorables");
   try {
     updateDAQmain();
   } catch (...) {return;} //FIXME Define meaningful exceptions and intercept here or eventually at a different level... If even a updateDAQmain fails, do not attempt to do anything else for this AMC board
@@ -239,8 +239,8 @@ void gem::daqmon::DaqMonitor::updateMonitorables()
 
       std::ofstream logfile(logfilename, std::ios_base::out | std::ios_base::binary);
       bo::filtering_ostream m_out;
-      m_out.push(bo::gzip_compressor()); 
-      m_out.push(logfile); 
+      m_out.push(bo::gzip_compressor());
+      m_out.push(logfile);
       m_out << "Timestamp: " << buffer << std::endl;
 
       m_out << " { " << std::endl;
@@ -251,13 +251,13 @@ void gem::daqmon::DaqMonitor::updateMonitorables()
       m_out << " } " << std::endl;
     }
     ++logCnt;
-    
+
   } catch (...) {} //FIXME Define meaningful exceptions and intercept here or eventually at a different level...
 }
 
 void gem::daqmon::DaqMonitor::updateDAQmain()
 {
-  DEBUG("DaqMonitor: Update DAQ main table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update DAQ main table");
   req = wisc::RPCMsg("daq_monitor.getmonDAQmain");
   try {
     rsp = rpc.call_method(req);
@@ -265,7 +265,7 @@ void gem::daqmon::DaqMonitor::updateDAQmain()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("DAQ_MAIN update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("DAQ_MAIN update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("DAQ_MAIN update failed");
     }
     auto monlist = m_monitorableSetsMap.find("DAQ_MAIN");
@@ -278,7 +278,7 @@ void gem::daqmon::DaqMonitor::updateDAQmain()
 
 void gem::daqmon::DaqMonitor::updateDAQOHmain()
 {
-  DEBUG("DaqMonitor: Update DAQ OH main table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update DAQ OH main table");
   req = wisc::RPCMsg("daq_monitor.getmonDAQOHmain");
   req.set_word("NOH",NOH);
   try {
@@ -287,7 +287,7 @@ void gem::daqmon::DaqMonitor::updateDAQOHmain()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("DAQ_OH_MAIN update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("DAQ_OH_MAIN update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("DAQ_OH_MAIN update failed");
     }
     auto monlist = m_monitorableSetsMap.find("DAQ_OH_MAIN");
@@ -300,7 +300,7 @@ void gem::daqmon::DaqMonitor::updateDAQOHmain()
 
 void gem::daqmon::DaqMonitor::updateTTCmain()
 {
-  DEBUG("DaqMonitor: Update TTC main table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update TTC main table");
   req = wisc::RPCMsg("daq_monitor.getmonTTCmain");
   try {
     rsp = rpc.call_method(req);
@@ -308,7 +308,7 @@ void gem::daqmon::DaqMonitor::updateTTCmain()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("DAQ_TTC_MAIN update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("DAQ_TTC_MAIN update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("DAQ_TTC_MAIN update failed");
     }
     auto monlist = m_monitorableSetsMap.find("DAQ_TTC_MAIN");
@@ -321,7 +321,7 @@ void gem::daqmon::DaqMonitor::updateTTCmain()
 
 void gem::daqmon::DaqMonitor::updateTRIGGERmain()
 {
-  DEBUG("DaqMonitor: Update TRIGGER main table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update TRIGGER main table");
   req = wisc::RPCMsg("daq_monitor.getmonTRIGGERmain");
   req.set_word("NOH",NOH);
   try {
@@ -330,7 +330,7 @@ void gem::daqmon::DaqMonitor::updateTRIGGERmain()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("DAQ_TRIGGER_MAIN update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("DAQ_TRIGGER_MAIN update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("DAQ_TRIGGER_MAIN update failed");
     }
     auto monlist = m_monitorableSetsMap.find("DAQ_TRIGGER_MAIN");
@@ -343,7 +343,7 @@ void gem::daqmon::DaqMonitor::updateTRIGGERmain()
 
 void gem::daqmon::DaqMonitor::updateTRIGGEROHmain()
 {
-  DEBUG("DaqMonitor: Update TRIGGER OH main table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update TRIGGER OH main table");
   req = wisc::RPCMsg("daq_monitor.getmonTRIGGEROHmain");
   req.set_word("NOH",NOH);
   try {
@@ -352,7 +352,7 @@ void gem::daqmon::DaqMonitor::updateTRIGGEROHmain()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("DAQ_TRIGGER_OH_MAIN update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("DAQ_TRIGGER_OH_MAIN update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("DAQ_TRIGGER_OH_MAIN update failed");
     }
     auto monlist = m_monitorableSetsMap.find("DAQ_TRIGGER_OH_MAIN");
@@ -365,7 +365,7 @@ void gem::daqmon::DaqMonitor::updateTRIGGEROHmain()
 
 void gem::daqmon::DaqMonitor::updateOHmain()
 {
-  DEBUG("DaqMonitor: Update OH main table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update OH main table");
   req = wisc::RPCMsg("daq_monitor.getmonOHmain");
   req.set_word("NOH",NOH);
   try {
@@ -374,7 +374,7 @@ void gem::daqmon::DaqMonitor::updateOHmain()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("OH_MAIN update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("OH_MAIN update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("OH_MAIN update failed");
     }
     auto monlist = m_monitorableSetsMap.find("OH_MAIN");
@@ -388,7 +388,7 @@ void gem::daqmon::DaqMonitor::updateOHmain()
 
 void gem::daqmon::DaqMonitor::updateOHSCA()
 {
-  DEBUG("DaqMonitor: Update OH SCA table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update OH SCA table");
   req = wisc::RPCMsg("daq_monitor.getmonOHSCAmain");
   req.set_word("NOH",NOH);
   try {
@@ -397,7 +397,7 @@ void gem::daqmon::DaqMonitor::updateOHSCA()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("OH_SCA update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("OH_SCA update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("OH_SCA update failed"); FIXME instead of throwing an exception there should be an alert propagating
     }
     auto monlist = m_monitorableSetsMap.find("OH_SCA");
@@ -410,7 +410,7 @@ void gem::daqmon::DaqMonitor::updateOHSCA()
 
 void gem::daqmon::DaqMonitor::updateOHSysmon()
 {
-  DEBUG("DaqMonitor: Update OH Sysmon table");
+  CMSGEMOS_DEBUG("DaqMonitor: Update OH Sysmon table");
   req = wisc::RPCMsg("daq_monitor.getmonOHSysmon");
   req.set_word("NOH",NOH);
   req.set_word("doReset",0);
@@ -420,9 +420,9 @@ void gem::daqmon::DaqMonitor::updateOHSysmon()
   STANDARD_CATCH;
   try{
     if (rsp.get_key_exists("error")) {
-      ERROR("OH_Sysmon update error: " << rsp.get_string("error").c_str());
+      CMSGEMOS_ERROR("OH_Sysmon update error: " << rsp.get_string("error").c_str());
       //throw xhal::utils::XHALException("OH_Sysmon update failed"); FIXME instead of throwing an exception there should be an alert propagating
-    } 
+    }
     auto monlist = m_monitorableSetsMap.find("OH_Sysmon");
     for (auto monitem = monlist->second.begin(); monitem != monlist->second.end(); ++monitem) {
       (monitem->second.infoSpace)->setUInt32(monitem->first,rsp.get_word(monitem->first));
@@ -458,7 +458,7 @@ double gem::daqmon::DaqMonitor::sysmonVconv(uint32_t val)
 
 void gem::daqmon::DaqMonitor::updateDAQmainTableContent()
 {
-  DEBUG("DaqMonitor::updateDAQmainTableContent");
+  CMSGEMOS_DEBUG("DaqMonitor::updateDAQmainTableContent");
   uint32_t val;
   LabelData * ld;
   for (auto monname: {"DAQ_ENABLE","DAQ_LINK_READY"})
@@ -666,7 +666,7 @@ void gem::daqmon::DaqMonitor::updateOHmainTableContent()
         break;
       default:
         std::stringstream ss;
-        ss << std::uppercase << std::setfill('0') 
+        ss << std::uppercase << std::setfill('0')
            << std::setw(8) << std::hex << val << std::dec;
         ld->labelValue=ss.str();
         ld->labelClass="label label-info";
@@ -683,7 +683,7 @@ void gem::daqmon::DaqMonitor::updateOHmainTableContent()
         ld->labelValue=std::to_string(val);
         ld->labelClass="label label-info";
       }
-    }    
+    }
     std::vector<std::string> v_daq(v_oh_main.begin()+3,v_oh_main.end());
     v_daq.insert(v_daq.end(),v_daq_trigger_oh_main.begin(),v_daq_trigger_oh_main.end());
     for (auto monname: v_daq)
@@ -744,7 +744,7 @@ void gem::daqmon::DaqMonitor::updateOHmainTableContent()
           }
         }
       }
-    }    
+    }
     for (auto monname: v_oh_sysmon)
     {
       val = is_daqmon->getUInt32("OH"+std::to_string(i)+monname);
@@ -769,7 +769,7 @@ void gem::daqmon::DaqMonitor::updateOHmainTableContent()
 
 void gem::daqmon::DaqMonitor::buildTable(const std::string& table_name, xgi::Output* out)
 {
-  DEBUG("DaqMonitor: Build DAQ main table");
+  CMSGEMOS_DEBUG("DaqMonitor: Build DAQ main table");
   std::vector<std::string> v_daq;
   if (table_name == "DAQ_MAIN") {
     updateDAQmainTableContent();
@@ -865,12 +865,12 @@ void gem::daqmon::DaqMonitor::buildMonitorPage(xgi::Output* out)
 
 void gem::daqmon::DaqMonitor::jsonContentUpdate(xgi::Output* out)
 {
-  DEBUG("DaqMonitor::jsonContentUpdate");
+  CMSGEMOS_DEBUG("DaqMonitor::jsonContentUpdate");
   *out << " { " << std::endl;
   for (auto ld = m_LabelData.begin(); ld != m_LabelData.end();) {
     *out << "\"" << ld->second->labelId << "\" : { \"class_name\" : \"" << ld->second->labelClass << "\", \"value\" : \"" << ld->second->labelValue << "\" }";
     if (++ld == m_LabelData.end()) *out << std::endl; else *out << "," << std::endl;
   }
   *out << " } " << std::endl;
-  
+
 }

--- a/gemdaqmonitor/src/common/ShelfMonitor.cc
+++ b/gemdaqmonitor/src/common/ShelfMonitor.cc
@@ -29,15 +29,15 @@ XDAQ_INSTANTIATOR_IMPL(gem::daqmon::ShelfMonitor);
 
 gem::daqmon::ShelfMonitor::ShelfMonitor(xdaq::ApplicationStub* stub) :
   gem::base::GEMApplication(stub),
-  m_shelfID(-1) 
+  m_shelfID(-1)
 {
-  DEBUG("gem::daqmon::ShelfMonitor : Creating the ShelfMonitorWeb interface");
+  CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor : Creating the ShelfMonitorWeb interface");
   p_gemWebInterface = new gem::daqmon::ShelfMonitorWeb(this);
-  DEBUG("gem::daqmon::ShelfMonitor : Retrieving configuration");
+  CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor : Retrieving configuration");
   p_appInfoSpace->fireItemAvailable("shelfID",     &m_shelfID);
   p_appInfoSpace->addItemRetrieveListener("shelfID", this);
   p_appInfoSpace->addItemChangedListener("shelfID", this);
-  DEBUG("gem::daqmon::ShelfMonitor : configuration retrieved");
+  CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor : configuration retrieved");
   xgi::bind(this, &ShelfMonitor::stopAction, "stopAction");
   xgi::bind(this, &ShelfMonitor::resumeAction, "resumeAction");
   xgi::bind(this, &ShelfMonitor::pauseAction, "pauseAction");
@@ -46,7 +46,7 @@ gem::daqmon::ShelfMonitor::ShelfMonitor(xdaq::ApplicationStub* stub) :
 
 gem::daqmon::ShelfMonitor::~ShelfMonitor()
 {
-  DEBUG("gem::daqmon::ShelfMonitor : Destructor called");
+  CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor : Destructor called");
   // make sure to empty the v_supervisedApps  vector and free the pointers
 }
 
@@ -55,7 +55,7 @@ gem::daqmon::ShelfMonitor::~ShelfMonitor()
 void gem::daqmon::ShelfMonitor::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("gem::daqmon::ShelfMonitor::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
     importConfigurationParameters();
     importMonitoringParameters();
@@ -65,7 +65,7 @@ void gem::daqmon::ShelfMonitor::actionPerformed(xdata::Event& event)
 
   // item is changed, update it
   if (event.type() == "ItemChangedEvent" || event.type() == "urn:xdata-event:ItemChangedEvent") {
-    DEBUG("gem::daqmon::ShelfMonitor::actionPerformed() ItemChangedEvent");
+    CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor::actionPerformed() ItemChangedEvent");
   }
 
   // update monitoring variables
@@ -80,9 +80,9 @@ void gem::daqmon::ShelfMonitor::init()
   {
     char t_board_name[20];
     sprintf(t_board_name, "gem-shelf%02d-amc%02d", m_shelfID.value_, i);
-    DEBUG("gem::daqmon::ShelfMonitor::init :  Domain name for the board " << std::dec << i << " : " << t_board_name);
+    CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor::init :  Domain name for the board " << std::dec << i << " : " << t_board_name);
     v_daqmon.push_back(new gem::daqmon::DaqMonitor(t_board_name, this->getApplicationLogger(), this, i));
-    DEBUG("gem::daqmon::ShelfMonitor::init : DaqMonitor pointer created");
+    CMSGEMOS_DEBUG("gem::daqmon::ShelfMonitor::init : DaqMonitor pointer created");
   }
 }
 
@@ -97,8 +97,8 @@ bool gem::daqmon::ShelfMonitor::isGEMApplication(const std::string& classname) c
   return false;
 }
 
-void gem::daqmon::ShelfMonitor::startMonitoring() 
-{ 
+void gem::daqmon::ShelfMonitor::startMonitoring()
+{
     int cnt = 0;
     for (auto daqmon: v_daqmon)
     {
@@ -106,21 +106,21 @@ void gem::daqmon::ShelfMonitor::startMonitoring()
         daqmon->startMonitoring();
         ++cnt;
       } else {
-        INFO("gem::daqmon::ShelfMonitor::actionPerformed() setDefaultValues : Connection to the board " << daqmon->boardName() 
+        INFO("gem::daqmon::ShelfMonitor::actionPerformed() setDefaultValues : Connection to the board " << daqmon->boardName()
         << " cannot be established. Monitoring for this board is OFF");
       }
     }
     (cnt>0)?m_state="RUNNING":"FAILED";
 }
 
-void gem::daqmon::ShelfMonitor::stopMonitoring() 
-{ 
+void gem::daqmon::ShelfMonitor::stopMonitoring()
+{
     for (auto daqmon: v_daqmon)
     {
       if (daqmon->is_connected()) {
         daqmon->stopMonitoring();
       } else {
-        INFO("gem::daqmon::ShelfMonitor::actionPerformed() setDefaultValues : Connection to the board " << daqmon->boardName() 
+        INFO("gem::daqmon::ShelfMonitor::actionPerformed() setDefaultValues : Connection to the board " << daqmon->boardName()
         << " cannot be established. Monitoring for this board is OFF");
       }
     }

--- a/gemdaqmonitor/src/common/ShelfMonitorWeb.cc
+++ b/gemdaqmonitor/src/common/ShelfMonitorWeb.cc
@@ -35,7 +35,7 @@ void gem::daqmon::ShelfMonitorWeb::webDefault(xgi::Input * in, xgi::Output * out
 void gem::daqmon::ShelfMonitorWeb::applicationPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("ShelfMonitoringWeb::applicationPage : Do nothing for the moment, will be eventually filled later");
+  CMSGEMOS_DEBUG("ShelfMonitoringWeb::applicationPage : Do nothing for the moment, will be eventually filled later");
   //*out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
   //*out << "Hello World" << std::endl;
   //*out << "</div>" << std::endl;
@@ -44,10 +44,10 @@ void gem::daqmon::ShelfMonitorWeb::applicationPage(xgi::Input* in, xgi::Output* 
 void gem::daqmon::ShelfMonitorWeb::expertPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("ShelfMonitoringWeb::expertPage");
+  CMSGEMOS_DEBUG("ShelfMonitoringWeb::expertPage");
   *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
     *out << "<div align=\"center\">" << std::endl;
-    *out<< "<h1><span class=\"label label-info\" id=\"mon_state\">MONITORING STATE: " 
+    *out<< "<h1><span class=\"label label-info\" id=\"mon_state\">MONITORING STATE: "
         << dynamic_cast<gem::daqmon::ShelfMonitor*>(p_gemApp)->monitoringState() << "</span></h1>" << std::endl;
     *out << "<button class=\"btn btn-danger\" type=\"button\" onclick=\"expert_action(this.id)\" id=\"stop\" name=\"stop\">STOP MONITORING</button>" << std::endl;
     *out << "<button class=\"btn btn-warning\" type=\"button\" onclick=\"expert_action(this.id)\" id=\"pause\" name=\"pause\">PAUSE MONITORING</button>" << std::endl;
@@ -65,7 +65,7 @@ void gem::daqmon::ShelfMonitorWeb::expertPage(xgi::Input* in, xgi::Output* out)
 void gem::daqmon::ShelfMonitorWeb::monitorPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  INFO("ShelfMonitorWeb::monitorPage");
+  CMSGEMOS_INFO("ShelfMonitorWeb::monitorPage");
   *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
   for (unsigned int i = 0; i < NAMC; ++i){
     auto daqmon = dynamic_cast<gem::daqmon::ShelfMonitor*>(p_gemApp)->v_daqmon.at(i);
@@ -81,7 +81,7 @@ void gem::daqmon::ShelfMonitorWeb::monitorPage(xgi::Input* in, xgi::Output* out)
 void gem::daqmon::ShelfMonitorWeb::jsonUpdate(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("ShelfMonitorWeb::jsonUpdate");
+  CMSGEMOS_DEBUG("ShelfMonitorWeb::jsonUpdate");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   for (unsigned int i = 0; i < NAMC; ++i){
@@ -94,4 +94,3 @@ void gem::daqmon::ShelfMonitorWeb::jsonUpdate(xgi::Input* in, xgi::Output* out)
   }
   *out << " } " << std::endl;
 }
-

--- a/gemhardware/include/gem/hw/optohybrid/HwOptoHybrid.h
+++ b/gemhardware/include/gem/hw/optohybrid/HwOptoHybrid.h
@@ -234,7 +234,7 @@ namespace gem {
 
           uint32_t getFirmwareVersion() {
             uint32_t fwver = readReg(getDeviceBaseNode(),"STATUS.FW.VERSION");
-            TRACE("OH has firmware version 0x" << std::hex << fwver << std::dec << std::endl);
+            CMSGEMOS_TRACE("OH has firmware version 0x" << std::hex << fwver << std::dec << std::endl);
             return fwver;
           };
 
@@ -260,7 +260,7 @@ namespace gem {
            */
           uint32_t getFirmwareDate() {
             uint32_t fwver = readReg(getDeviceBaseNode(),"STATUS.FW.DATE");
-            TRACE("OH has firmware date 0x" << std::hex << fwver << std::dec << std::endl);
+            CMSGEMOS_TRACE("OH has firmware date 0x" << std::hex << fwver << std::dec << std::endl);
             return fwver;
           };
 
@@ -361,7 +361,7 @@ namespace gem {
            *  a 1 means the VFAT WILL be masked, and it's data packets will NOT go to the AMC
            */
           void setVFATMask(uint32_t const mask) {
-            DEBUG("HwOptoHybrid::setVFATMask setting tracking mask to "
+            CMSGEMOS_DEBUG("HwOptoHybrid::setVFATMask setting tracking mask to "
                   << std::hex << std::setw(8) << std::setfill('0') << mask << std::dec);
             return writeReg(getDeviceBaseNode(),toolbox::toString("CONTROL.VFAT.TRK_MASK"),mask&0x00ffffff); };
 
@@ -399,7 +399,7 @@ namespace gem {
            *  a 1 means the OptoHybrid WILL drop bad packets
            */
           void setDropBadCRCStatus(bool const drop) {
-            DEBUG("HwOptoHybrid::setVFATMask setting DROP_BAD_CRC to "
+            CMSGEMOS_DEBUG("HwOptoHybrid::setVFATMask setting DROP_BAD_CRC to "
                   << std::hex << drop << std::dec);
             return writeReg(getDeviceBaseNode(),toolbox::toString("CONTROL.VFAT.DROP_BAD_CRC"),drop); };
 

--- a/gemhardware/src/common/GEMHwDevice.cc
+++ b/gemhardware/src/common/GEMHwDevice.cc
@@ -14,7 +14,7 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
   m_gemLogger(log4cplus::Logger::getInstance(deviceName)),
   m_hwLock(toolbox::BSem::FULL, true)
 {
-  DEBUG("GEMHwDevice(std::string, std::string) ctor");
+  CMSGEMOS_DEBUG("GEMHwDevice(std::string, std::string) ctor");
   setLogLevelTo(uhal::Error());
   p_gemConnectionManager = std::shared_ptr<uhal::ConnectionManager>(new uhal::ConnectionManager("file://${GEM_ADDRESS_TABLE_PATH}/"+connectionFile));
   try {
@@ -22,20 +22,20 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
   } catch (uhal::exception::FileNotFound const& err) {
     std::string msg = toolbox::toString("Could not find uhal connection file '%s' ",
                                         connectionFile.c_str());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   } catch (uhal::exception::exception const& err) {
     std::string msgBase = "Could not obtain the uhal device from the connection manager";
     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   } catch (std::exception const& err) {
-    ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
+    CMSGEMOS_ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
     std::string msgBase = "Could not connect to the hardware";
     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   }
   // should have pointer to device by here
   setup(deviceName);
-  DEBUG("GEMHwDevice::ctor done");
+  CMSGEMOS_DEBUG("GEMHwDevice::ctor done");
 }
 gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
                                   std::string const& connectionURI,
@@ -44,7 +44,7 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
   m_gemLogger(log4cplus::Logger::getInstance(deviceName)),
   m_hwLock(toolbox::BSem::FULL, true)
 {
-  DEBUG("GEMHwDevice(std::string, std::string, std::string) ctor");
+  CMSGEMOS_DEBUG("GEMHwDevice(std::string, std::string, std::string) ctor");
   setLogLevelTo(uhal::Error());
   try {
     p_gemHW = std::shared_ptr<uhal::HwInterface>(new uhal::HwInterface(uhal::ConnectionManager::getDevice(deviceName,
@@ -54,20 +54,20 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
     std::string msg = toolbox::toString("Could not find uhal address table file '%s' "
                                         "(or one of its included address table modules).",
                                         addressTable.c_str());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   } catch (uhal::exception::exception const& err) {
     std::string msgBase = "Could not obtain the uhal device from the connection manager";
     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   } catch (std::exception const& err) {
-    ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
+    CMSGEMOS_ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
     std::string msgBase = "Could not connect to th e hardware";
     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   }
   // should have pointer to device by here
   setup(deviceName);
-  DEBUG("GEMHwDevice::ctor done");
+  CMSGEMOS_DEBUG("GEMHwDevice::ctor done");
 }
 
 gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
@@ -76,7 +76,7 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
   m_gemLogger(log4cplus::Logger::getInstance(deviceName)),
   m_hwLock(toolbox::BSem::FULL, true)
 {
-  DEBUG("GEMHwDevice(std::string, uhal::HwInterface) ctor");
+  CMSGEMOS_DEBUG("GEMHwDevice(std::string, uhal::HwInterface) ctor");
   setLogLevelTo(uhal::Error());
   try {
     p_gemHW = std::shared_ptr<uhal::HwInterface>(new uhal::HwInterface(uhalDevice));
@@ -85,16 +85,16 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
   } catch (uhal::exception::exception const& err) {
     std::string msgBase = "Could not obtain the uhal device from the passed device";
     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   } catch (std::exception const& err) {
-    ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
+    CMSGEMOS_ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
     std::string msgBase = "Could not connect to th e hardware";
     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   }
   // should have pointer to device by here
   setup(deviceName);
-  DEBUG("GEMHwDevice::ctor done");
+  CMSGEMOS_DEBUG("GEMHwDevice::ctor done");
 }
 
 // gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName):
@@ -109,11 +109,11 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
 //   m_ipBusPort(50001)
 //   // monGEMHw_(0)
 // {
-//   DEBUG("GEMHwDevice(std::string) ctor");
+//   CMSGEMOS_DEBUG("GEMHwDevice(std::string) ctor");
 //   setLogLevelTo(uhal::Error());
 
 //   toolbox::net::URN hwCfgURN("urn:gem:hw:"+deviceName);
-//   INFO("GEMHwDevice::Getting hwCfgInfoSpace with urn " << hwCfgURN.toString());
+//   CMSGEMOS_INFO("GEMHwDevice::Getting hwCfgInfoSpace with urn " << hwCfgURN.toString());
 //   p_hwCfgInfoSpace = xdata::getInfoSpaceFactory()->get(hwCfgURN.toString());
 
 //   setParametersFromInfoSpace();
@@ -128,13 +128,13 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
 
 //   std::stringstream tmpUri;
 //   if (controlhubAddress.size() > 0) {
-//     DEBUG("GEMHwDevice::Using control hub at address '" << controlhubAddress
+//     CMSGEMOS_DEBUG("GEMHwDevice::Using control hub at address '" << controlhubAddress
 //           << ", port number "              << controlhubPort << "'.");
 //     tmpUri << "chtcp-"<< ipBusProtocol << "://"
 //            << controlhubAddress << ":" << controlhubPort
 //            << "?target=" << deviceIPAddress << ":" << ipBusPort;
 //   } else {
-//     DEBUG("GEMHwDevice::No control hub address specified -> "
+//     CMSGEMOS_DEBUG("GEMHwDevice::No control hub address specified -> "
 //           "continuing with a direct connection.");
 //     tmpUri << "ipbusudp-" << ipBusProtocol << "://"
 //            << deviceIPAddress << ":" << ipBusPort;
@@ -142,7 +142,7 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
 //   std::string const uri = tmpUri.str();
 //   // std::string const addressTable = getAddressTableFileName();
 
-//   INFO("GEMHwDevice::uri, deviceName, address table : " << uri << " " << deviceName << " " << addressTable);
+//   CMSGEMOS_INFO("GEMHwDevice::uri, deviceName, address table : " << uri << " " << deviceName << " " << addressTable);
 //   try {
 //     p_gemHW = std::shared_ptr<uhal::HwInterface>(new uhal::HwInterface(uhal::ConnectionManager::getDevice(deviceName,
 //                                                                                                           uri,
@@ -151,20 +151,20 @@ gem::hw::GEMHwDevice::GEMHwDevice(std::string const& deviceName,
 //     std::string msg = toolbox::toString("Could not find uhal address table file '%s' "
 //                                         "(or one of its included address table modules).",
 //                                         addressTable.c_str());
-//     ERROR("GEMHwDevice::" << msg);
+//     CMSGEMOS_ERROR("GEMHwDevice::" << msg);
 //   } catch (uhal::exception::exception const& err) {
 //     std::string msgBase = "Could not obtain the uhal device from the connection manager";
 //     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-//     ERROR("GEMHwDevice::" << msg);
+//     CMSGEMOS_ERROR("GEMHwDevice::" << msg);
 //   } catch (std::exception const& err) {
-//     ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
+//     CMSGEMOS_ERROR("GEMHwDevice::Unknown std::exception caught from uhal");
 //     std::string msgBase = "Could not connect to th e hardware";
 //     std::string msg = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-//     ERROR("GEMHwDevice::" << msg);
+//     CMSGEMOS_ERROR("GEMHwDevice::" << msg);
 //   }
 //   //should have pointer to device by here
 //   setup(deviceName);
-//   DEBUG("GEMHwDevice::ctor done");
+//   CMSGEMOS_DEBUG("GEMHwDevice::ctor done");
 // }
 
 gem::hw::GEMHwDevice::~GEMHwDevice()
@@ -183,15 +183,15 @@ std::string gem::hw::GEMHwDevice::printErrorCounts() const {
             << "Read errors: "       <<m_ipBusErrs.ReadError     << std::endl
             << "Timeouts:    "       <<m_ipBusErrs.Timeout       << std::endl
             << "Controlhub errors: " <<m_ipBusErrs.ControlHubErr << std::endl;
-  TRACE(errstream);
+  CMSGEMOS_TRACE(errstream);
   return errstream.str();
 }
 
 // void gem::hw::GEMHwDevice::setParametersFromInfoSpace()
 // {
-//   DEBUG("GEMHwDevice::setParametersFromInfoSpace");
+//   CMSGEMOS_DEBUG("GEMHwDevice::setParametersFromInfoSpace");
 //   try {
-//     DEBUG("GEMHwDevice::trying to get parameters from the hwCfgInfoSpace");
+//     CMSGEMOS_DEBUG("GEMHwDevice::trying to get parameters from the hwCfgInfoSpace");
 //     setControlHubIPAddress( gem::base::utils::GEMInfoSpaceToolBox::getString(p_hwCfgInfoSpace, "ControlHubIPAddress"));
 //     setIPBusProtocolVersion(gem::base::utils::GEMInfoSpaceToolBox::getString(p_hwCfgInfoSpace, "IPBusProtocol"));
 //     setDeviceIPAddress(     gem::base::utils::GEMInfoSpaceToolBox::getString(p_hwCfgInfoSpace, "DeviceIPAddress"));
@@ -201,16 +201,16 @@ std::string gem::hw::GEMHwDevice::printErrorCounts() const {
 //     setIPBusPort(     gem::base::utils::GEMInfoSpaceToolBox::getUInt32(p_hwCfgInfoSpace, "IPBusPort"));
 //     return;
 //   } catch (gem::base::utils::exception::InfoSpaceProblem const& err) {
-//     ERROR("GEMHwDevice::Could not set the device parameters from the InfoSpace " <<
+//     CMSGEMOS_ERROR("GEMHwDevice::Could not set the device parameters from the InfoSpace " <<
 //           "(gem::utils::exception::InfoSpacePRoblem)::"
 //           << err.what());
 //   } catch (std::exception const& err) {
-//     ERROR("GEMHwDevice::Could not set the device parameters from the InfoSpace " <<
+//     CMSGEMOS_ERROR("GEMHwDevice::Could not set the device parameters from the InfoSpace " <<
 //           "(std::exception)"
 //           << err.what());
 //   }
 //   // if we catch an exception, need to execute this, as successful operation will return in the try block
-//   DEBUG("GEMHwDevice::Setting default values as InfoSpace setting failed");
+//   CMSGEMOS_DEBUG("GEMHwDevice::Setting default values as InfoSpace setting failed");
 //   setControlHubIPAddress("localhost");
 //   setAddressTableFileName("uhal_gem_amc_glib.xml");
 //   setIPBusProtocolVersion("2.0");
@@ -238,7 +238,7 @@ uhal::HwInterface& gem::hw::GEMHwDevice::getGEMHwInterface() const
 {
   if (p_gemHW == NULL) {
     std::string msg = "Trying to access hardware before connecting!";
-    ERROR("GEMHwDevice::" << msg);
+    CMSGEMOS_ERROR("GEMHwDevice::" << msg);
     XCEPT_RAISE(gem::hw::exception::UninitializedDevice, msg);
   } else {
     uhal::HwInterface& hw = static_cast<uhal::HwInterface&>(*p_gemHW);
@@ -254,7 +254,7 @@ uint32_t gem::hw::GEMHwDevice::readReg(std::string const& name)
 
   unsigned retryCount = 0;
   uint32_t res = 0x0;
-  DEBUG("GEMHwDevice::gem::hw::GEMHwDevice::readReg "  << name << std::endl
+  CMSGEMOS_DEBUG("GEMHwDevice::gem::hw::GEMHwDevice::readReg "  << name << std::endl
         << "Path  "      << hw.getNode(name).getPath() << std::endl
         << "Address 0x"  << std::hex << hw.getNode(name).getAddress() << std::dec << std::endl
         << "Mask 0x"     << std::hex << hw.getNode(name).getMask()    << std::dec << std::endl
@@ -268,7 +268,7 @@ uint32_t gem::hw::GEMHwDevice::readReg(std::string const& name)
       uhal::ValWord<uint32_t> val = hw.getNode(name).read();
       hw.dispatch();
       res = val.value();
-      TRACE("GEMHwDevice::Successfully read register " << name.c_str() << " with value 0x"
+      CMSGEMOS_TRACE("GEMHwDevice::Successfully read register " << name.c_str() << " with value 0x"
             << std::setfill('0') << std::setw(8) << std::hex << res << std::dec
             << " retry count is " << retryCount << ". Should move on to next operation");
       return res;
@@ -279,24 +279,24 @@ uint32_t gem::hw::GEMHwDevice::readReg(std::string const& name)
       if (knownErrorCode(errCode)) {
         ++retryCount;
         if (retryCount > (MAX_IPBUS_RETRIES-1))
-          DEBUG("GEMHwDevice::Failed to read register " << name <<
+          CMSGEMOS_DEBUG("GEMHwDevice::Failed to read register " << name <<
                 ". retryCount("<<retryCount<<")"
                 << std::endl);
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
       std::string msgBase = toolbox::toString("Could not read register '%s' (std)", name.c_str());
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to read register %s",name.c_str());
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
   return res;
 }
@@ -308,7 +308,7 @@ uint32_t gem::hw::GEMHwDevice::readReg(uint32_t const& address)
 
   unsigned retryCount = 0;
   uint32_t res = 0x0;
-  TRACE("GEMHwDevice::gem::hw::GEMHwDevice::readReg 0x" << std::setfill('0') << std::setw(8)
+  CMSGEMOS_TRACE("GEMHwDevice::gem::hw::GEMHwDevice::readReg 0x" << std::setfill('0') << std::setw(8)
         << std::hex << address << std::dec << std::endl);
   while (retryCount < MAX_IPBUS_RETRIES) {
     ++retryCount;
@@ -316,7 +316,7 @@ uint32_t gem::hw::GEMHwDevice::readReg(uint32_t const& address)
       uhal::ValWord<uint32_t> val = hw.getClient().read(address);
       hw.dispatch();
       res = val.value();
-      TRACE("GEMHwDevice::Successfully read register 0x" << std::setfill('0') << std::setw(8)
+      CMSGEMOS_TRACE("GEMHwDevice::Successfully read register 0x" << std::setfill('0') << std::setw(8)
             << std::hex << address << std::dec << " with value 0x"
             << std::setfill('0') << std::setw(8) << std::hex << res << std::dec
             << " retry count is " << retryCount << ". Should move on to next operation");
@@ -328,26 +328,26 @@ uint32_t gem::hw::GEMHwDevice::readReg(uint32_t const& address)
       if (knownErrorCode(errCode)) {
         ++retryCount;
         if (retryCount > (MAX_IPBUS_RETRIES-1))
-          DEBUG("GEMHwDevice::Failed to read register 0x" << std::setfill('0') << std::setw(8)
+          CMSGEMOS_DEBUG("GEMHwDevice::Failed to read register 0x" << std::setfill('0') << std::setw(8)
                 << std::hex << address << std::dec
                 << ". retryCount("<<retryCount<<")"
                 << std::endl);
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
       std::string msgBase = toolbox::toString("Could not read register '0x%08x' (std)", address);
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to read register 0x%08x",
                                       address);
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
   return res;
 }
@@ -359,7 +359,7 @@ uint32_t gem::hw::GEMHwDevice::readReg(uint32_t const& address, uint32_t const& 
 
   unsigned retryCount = 0;
   uint32_t res = 0x0;
-  TRACE("GEMHwDevice::gem::hw::GEMHwDevice::readReg 0x" << std::setfill('0') << std::setw(8)
+  CMSGEMOS_TRACE("GEMHwDevice::gem::hw::GEMHwDevice::readReg 0x" << std::setfill('0') << std::setw(8)
         << std::hex << address << std::dec << std::endl);
   while (retryCount < MAX_IPBUS_RETRIES) {
     ++retryCount;
@@ -367,7 +367,7 @@ uint32_t gem::hw::GEMHwDevice::readReg(uint32_t const& address, uint32_t const& 
       uhal::ValWord<uint32_t> val = hw.getClient().read(address,mask);
       hw.dispatch();
       res = val.value();
-      TRACE("GEMHwDevice::Successfully read register 0x" << std::setfill('0') << std::setw(8)
+      CMSGEMOS_TRACE("GEMHwDevice::Successfully read register 0x" << std::setfill('0') << std::setw(8)
             << std::hex << address << std::dec << " with mask "
             << std::hex << mask << std::dec << " with value "
             << std::setfill('0') << std::setw(8) << std::hex << res << std::dec
@@ -380,7 +380,7 @@ uint32_t gem::hw::GEMHwDevice::readReg(uint32_t const& address, uint32_t const& 
       if (knownErrorCode(errCode)) {
         ++retryCount;
         if (retryCount > (MAX_IPBUS_RETRIES-1))
-          DEBUG("GEMHwDevice::Failed to read register 0x" << std::setfill('0') << std::setw(8)
+          CMSGEMOS_DEBUG("GEMHwDevice::Failed to read register 0x" << std::setfill('0') << std::setw(8)
                 << std::hex << address << std::dec << " with mask "
                 << std::hex << address << std::dec
                 << ". retryCount("<<retryCount<<")"
@@ -388,19 +388,19 @@ uint32_t gem::hw::GEMHwDevice::readReg(uint32_t const& address, uint32_t const& 
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
       std::string msgBase = toolbox::toString("Could not read register '0x%08x' (std)", address);
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to read register 0x%08x",
                                       address);
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
   return res;
 }
@@ -437,7 +437,7 @@ void gem::hw::GEMHwDevice::readRegs(register_pair_list &regList, int const& freq
           ++dispatchcounter;
       }
 
-      DEBUG("GEMHwDevice::readRegs dispatched " << dispatchcounter
+      CMSGEMOS_DEBUG("GEMHwDevice::readRegs dispatched " << dispatchcounter
             << " calls for " << counter << " registers");
       // would like to have these local to the loop, how to do...?
       auto curVal = vals.begin();
@@ -455,7 +455,7 @@ void gem::hw::GEMHwDevice::readRegs(register_pair_list &regList, int const& freq
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
@@ -463,12 +463,12 @@ void gem::hw::GEMHwDevice::readRegs(register_pair_list &regList, int const& freq
       for (auto curReg = regList.begin(); curReg != regList.end(); ++curReg)
         msgBase += toolbox::toString(" '%s'", curReg->first.c_str());
       std::string msg = toolbox::toString("%s (std): %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to read registers");
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
 }
 
@@ -497,7 +497,7 @@ void gem::hw::GEMHwDevice::readRegs(addressed_register_pair_list &regList, int c
           ++dispatchcounter;
       }
 
-      DEBUG("GEMHwDevice::readRegs dispatched " << dispatchcounter
+      CMSGEMOS_DEBUG("GEMHwDevice::readRegs dispatched " << dispatchcounter
             << " calls for " << counter << " registers");
       // would like to have these local to the loop, how to do...?
       auto curVal = vals.begin();
@@ -515,7 +515,7 @@ void gem::hw::GEMHwDevice::readRegs(addressed_register_pair_list &regList, int c
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
@@ -523,12 +523,12 @@ void gem::hw::GEMHwDevice::readRegs(addressed_register_pair_list &regList, int c
       for (auto curReg = regList.begin(); curReg != regList.end(); ++curReg)
         msgBase += toolbox::toString(" '0x%08x mask 0x%08x'", curReg->first);
       std::string msg = toolbox::toString("%s (std): %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to read registers");
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
 }
 
@@ -558,7 +558,7 @@ void gem::hw::GEMHwDevice::readRegs(masked_register_pair_list &regList, int cons
           ++dispatchcounter;
       }
 
-      DEBUG("GEMHwDevice::readRegs dispatched " << dispatchcounter
+      CMSGEMOS_DEBUG("GEMHwDevice::readRegs dispatched " << dispatchcounter
             << " calls for " << counter << " registers");
       // would like to have these local to the loop, how to do...?
       auto curVal = vals.begin();
@@ -576,7 +576,7 @@ void gem::hw::GEMHwDevice::readRegs(masked_register_pair_list &regList, int cons
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
@@ -584,12 +584,12 @@ void gem::hw::GEMHwDevice::readRegs(masked_register_pair_list &regList, int cons
       for (auto curReg = regList.begin(); curReg != regList.end(); ++curReg)
         msgBase += toolbox::toString(" '0x%08x mask 0x%08x'", curReg->first.first, curReg->first.second);
       std::string msg = toolbox::toString("%s (std): %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to read registers");
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
 }
 
@@ -598,7 +598,7 @@ void gem::hw::GEMHwDevice::writeReg(std::string const& name, uint32_t const val)
   gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_hwLock);
   uhal::HwInterface& hw = getGEMHwInterface();
   unsigned retryCount = 0;
-  DEBUG("gem::hw::GEMHwDevice::writeReg " << name << std::endl
+  CMSGEMOS_DEBUG("gem::hw::GEMHwDevice::writeReg " << name << std::endl
         << "Path  "      << hw.getNode(name).getPath() << std::endl
         << "Address 0x"  << std::hex << hw.getNode(name).getAddress() << std::dec << std::endl
         << "Mask 0x"     << std::hex << hw.getNode(name).getMask()    << std::dec << std::endl
@@ -618,7 +618,7 @@ void gem::hw::GEMHwDevice::writeReg(std::string const& name, uint32_t const val)
         rval = hw.getNode(name).read();
       hw.dispatch();
       if (hw.getNode(name).getPermission() != uhal::defs::WRITE)
-        DEBUG("gem::hw::GEMHwDevice::writeReg initial: "
+        CMSGEMOS_DEBUG("gem::hw::GEMHwDevice::writeReg initial: "
               << std::hex << ival.value() << std::dec
               << ", write val: " << std::hex << val << std::dec
               << ", readback: "  << std::hex << rval.value() << std::dec
@@ -637,29 +637,29 @@ void gem::hw::GEMHwDevice::writeReg(std::string const& name, uint32_t const val)
       if (knownErrorCode(errCode)) {
         ++retryCount;
         if (retryCount > (MAX_IPBUS_RETRIES-1))
-          DEBUG("GEMHwDevice::Failed to write value 0x" << std::hex<< val << std::dec << " to register " << name <<
+          CMSGEMOS_DEBUG("GEMHwDevice::Failed to write value 0x" << std::hex<< val << std::dec << " to register " << name <<
                 ". retryCount("<<retryCount<<")"
                 << std::endl);
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (gem::hw::exception::WriteValueMismatch const& err) {
       std::string msgBase = toolbox::toString("Could not write to register '%s' (uHAL)", name.c_str());
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
       std::string errCode = toolbox::toString("%s",err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
     } catch (std::exception const& err) {
       std::string msgBase = toolbox::toString("Could not write to register '%s' (std)", name.c_str());
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to write to register %s",name.c_str());
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
 }
 
@@ -675,7 +675,7 @@ void gem::hw::GEMHwDevice::writeReg(uint32_t const& address, uint32_t const val)
       hw.getClient().write(address, val);
       uhal::ValWord<uint32_t> rval = hw.getClient().read(address);
       hw.dispatch();
-      DEBUG("gem::hw::GEMHwDevice::writeReg initial: "
+      CMSGEMOS_DEBUG("gem::hw::GEMHwDevice::writeReg initial: "
             << std::hex << ival.value() << std::dec
             << ", write val: " << std::hex << val << std::dec
             << ", readback: "  << std::hex << rval.value() << std::dec
@@ -693,31 +693,31 @@ void gem::hw::GEMHwDevice::writeReg(uint32_t const& address, uint32_t const val)
       if (knownErrorCode(errCode)) {
         ++retryCount;
         if (retryCount > (MAX_IPBUS_RETRIES-1))
-          DEBUG("GEMHwDevice::Failed to write value 0x" << std::hex<< val << std::dec << " to register 0x"
+          CMSGEMOS_DEBUG("GEMHwDevice::Failed to write value 0x" << std::hex<< val << std::dec << " to register 0x"
                 << std::setfill('0') << std::setw(8) << std::hex << address << std::dec
                 << ". retryCount("<<retryCount<<")"
                 << std::endl);
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (gem::hw::exception::WriteValueMismatch const& err) {
       std::string msgBase = toolbox::toString("Could not write to register '0x%08x' (uHAL)", address);
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
       std::string errCode = toolbox::toString("%s",err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
     } catch (std::exception const& err) {
       std::string msgBase = toolbox::toString("Could not write to register '0x%08x' (std)", address);
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to write to register 0x%08x",
                                       address);
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
 }
 
@@ -742,7 +742,7 @@ void gem::hw::GEMHwDevice::writeRegs(register_pair_list const& regList, int cons
         hw.dispatch();
           ++dispatchcounter;
       }
-      DEBUG("GEMHwDevice::writeRegs dispatched " << dispatchcounter
+      CMSGEMOS_DEBUG("GEMHwDevice::writeRegs dispatched " << dispatchcounter
             << " calls for " << counter << " registers");
       return;
     } catch (uhal::exception::exception const& err) {
@@ -755,7 +755,7 @@ void gem::hw::GEMHwDevice::writeRegs(register_pair_list const& regList, int cons
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
@@ -763,7 +763,7 @@ void gem::hw::GEMHwDevice::writeRegs(register_pair_list const& regList, int cons
       for (auto curReg = regList.begin(); curReg != regList.end(); ++curReg)
         msgBase += toolbox::toString(" '%s'", curReg->first.c_str());
       std::string msg = toolbox::toString("%s (std): %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
@@ -797,7 +797,7 @@ std::vector<uint32_t> gem::hw::GEMHwDevice::readBlock(std::string const& name)
   gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_hwLock);
   uhal::HwInterface& hw = getGEMHwInterface();
   size_t numWords       = hw.getNode(name).getSize();
-  TRACE("GEMHwDevice::reading block " << name << " which has size "<<numWords);
+  CMSGEMOS_TRACE("GEMHwDevice::reading block " << name << " which has size "<<numWords);
   return readBlock(name, numWords);
 }
 
@@ -826,25 +826,25 @@ std::vector<uint32_t> gem::hw::GEMHwDevice::readBlock(std::string const& name, s
       if (knownErrorCode(errCode)) {
         ++retryCount;
         if (retryCount > (MAX_IPBUS_RETRIES-1))
-          DEBUG("GEMHwDevice::Failed to read block " << name << " with " << numWords << " words" <<
+          CMSGEMOS_DEBUG("GEMHwDevice::Failed to read block " << name << " with " << numWords << " words" <<
                 ". retryCount("<<retryCount<<")" << std::endl
                 << "error was " << errCode
                 << std::endl);
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
       std::string msgBase = toolbox::toString("Could not read block '%s' (std)", name.c_str());
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to read block");
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
   return res;
 }
@@ -884,24 +884,24 @@ void gem::hw::GEMHwDevice::writeBlock(std::string const& name, std::vector<uint3
       if (knownErrorCode(errCode)) {
         ++retryCount;
         if (retryCount > (MAX_IPBUS_RETRIES-1))
-          DEBUG("GEMHwDevice::Failed to write block " << name <<
+          CMSGEMOS_DEBUG("GEMHwDevice::Failed to write block " << name <<
                 ". retryCount("<<retryCount<<")"
                 << std::endl);
         updateErrorCounters(errCode);
         continue;
       } else {
-        ERROR("GEMHwDevice::" << msg);
+        CMSGEMOS_ERROR("GEMHwDevice::" << msg);
         // XCEPT_RAISE(gem::hw::exception::HardwareProblem, toolbox::toString("%s.", msgBase.c_str()));
       }
     } catch (std::exception const& err) {
       std::string msgBase = toolbox::toString("Could not write to block '%s' (std)", name.c_str());
       std::string msg     = toolbox::toString("%s: %s.", msgBase.c_str(), err.what());
-      ERROR("GEMHwDevice::" << msg);
+      CMSGEMOS_ERROR("GEMHwDevice::" << msg);
       // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
     }
   }
   std::string msg = toolbox::toString("Maximum number of retries reached, unable to write block %s",name.c_str());
-  ERROR("GEMHwDevice::" << msg);
+  CMSGEMOS_ERROR("GEMHwDevice::" << msg);
   // XCEPT_RAISE(gem::hw::exception::HardwareProblem, msg);
 }
 

--- a/gemhardware/src/common/HwGenericAMC.cc
+++ b/gemhardware/src/common/HwGenericAMC.cc
@@ -9,7 +9,7 @@
 //   m_crate(-1),
 //   m_slot(-1)
 // {
-//   INFO("HwGenericAMC ctor");
+//   CMSGEMOS_INFO("HwGenericAMC ctor");
 
 //   for (unsigned li = 0; li < N_GTX; ++li) {
 //     b_links[li] = false;
@@ -17,7 +17,7 @@
 //     m_ipBusCounters.push_back(tmpGTXCounter);
 //   }
 
-//   INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
+//   CMSGEMOS_INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
 // }
 
 // gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice) :
@@ -27,7 +27,7 @@
 //   m_crate(-1),
 //   m_slot(-1)
 // {
-//   INFO("HwGenericAMC ctor");
+//   CMSGEMOS_INFO("HwGenericAMC ctor");
 
 //   for (unsigned li = 0; li < N_GTX; ++li) {
 //     b_links[li] = false;
@@ -35,7 +35,7 @@
 //     m_ipBusCounters.push_back(tmpGTXCounter);
 //   }
 
-//   INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
+//   CMSGEMOS_INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
 // }
 
 // gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
@@ -47,7 +47,7 @@
 //   m_crate(crate),
 //   m_slot(slot)
 // {
-//   INFO("HwGenericAMC ctor");
+//   CMSGEMOS_INFO("HwGenericAMC ctor");
 
 //   for (unsigned li = 0; li < N_GTX; ++li) {
 //     b_links[li] = false;
@@ -55,7 +55,7 @@
 //     m_ipBusCounters.push_back(tmpGTXCounter);
 //   }
 
-//   INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
+//   CMSGEMOS_INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
 // }
 
 gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
@@ -66,7 +66,7 @@ gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
   m_crate(-1),
   m_slot(-1)
 {
-  INFO("HwGenericAMC ctor");
+  CMSGEMOS_INFO("HwGenericAMC ctor");
 
   for (unsigned li = 0; li < N_GTX; ++li) {
     b_links[li] = false;
@@ -74,7 +74,7 @@ gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
@@ -87,7 +87,7 @@ gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
   m_slot(-1)
 
 {
-  INFO("trying to create HwGenericAMC(" << amcDevice << "," << connectionURI << "," <<addressTable);
+  CMSGEMOS_INFO("trying to create HwGenericAMC(" << amcDevice << "," << connectionURI << "," <<addressTable);
   setDeviceBaseNode(amcDevice);
   for (unsigned li = 0; li < N_GTX; ++li) {
     b_links[li] = false;
@@ -95,7 +95,7 @@ gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
@@ -113,7 +113,7 @@ gem::hw::HwGenericAMC::HwGenericAMC(std::string const& amcDevice,
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwGenericAMC ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::HwGenericAMC::~HwGenericAMC()
@@ -124,32 +124,32 @@ bool gem::hw::HwGenericAMC::isHwConnected()
 {
   // DO NOT LIKE THIS FUNCTION FIXME!!!
   if (b_is_connected) {
-    INFO("basic check: HwGenericAMC connection good");
+    CMSGEMOS_INFO("basic check: HwGenericAMC connection good");
     return true;
   } else if (gem::hw::GEMHwDevice::isHwConnected()) {
-    INFO("basic check: HwGenericAMC pointer valid");
+    CMSGEMOS_INFO("basic check: HwGenericAMC pointer valid");
     std::vector<linkStatus> tmp_activeLinks;
     m_maxLinks = this->getSupportedOptoHybrids();
     tmp_activeLinks.reserve(m_maxLinks);
     if ((this->getBoardID()).rfind("GLIB") != std::string::npos ) {
-      INFO("HwGenericAMC found boardID");
+      CMSGEMOS_INFO("HwGenericAMC found boardID");
       for (unsigned int gtx = 0; gtx < m_maxLinks; ++gtx) {
         // FIXME!!! somehow need to actually check that the specified link is present
         b_links[gtx] = true;
-        INFO("m_links 0x" << std::hex << std::setw(8) << std::setfill('0')
+        CMSGEMOS_INFO("m_links 0x" << std::hex << std::setw(8) << std::setfill('0')
              << m_links
              << " 0x1 << gtx = " << std::setw(8) << std::setfill('0') << (0x1<<gtx)
              << std::dec);
         m_links |= (0x1<<gtx);
-        INFO("gtx" << gtx << " present(" << this->getFirmwareVer() << ")");
-        INFO("m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
+        CMSGEMOS_INFO("gtx" << gtx << " present(" << this->getFirmwareVer() << ")");
+        CMSGEMOS_INFO("m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
               << m_links << std::dec);
         tmp_activeLinks.push_back(std::make_pair(gtx,this->LinkStatus(gtx)));
-        INFO("m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
+        CMSGEMOS_INFO("m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
               << m_links << std::dec);
       }
     } else {
-      WARN("Device not reachable (unable to find 'GLIB' in the board ID)"
+      CMSGEMOS_WARN("Device not reachable (unable to find 'GLIB' in the board ID)"
            << " board ID "              << this->getBoardID()
            << " user firmware version " << this->getFirmwareVer());
       return false;
@@ -158,7 +158,7 @@ bool gem::hw::HwGenericAMC::isHwConnected()
     v_activeLinks = tmp_activeLinks;
     if (!v_activeLinks.empty()) {
       b_is_connected = true;
-      DEBUG("checked gtxs: HwGenericAMC connection good");
+      CMSGEMOS_DEBUG("checked gtxs: HwGenericAMC connection good");
       return true;
     } else {
       b_is_connected = false;
@@ -251,24 +251,24 @@ std::string gem::hw::HwGenericAMC::getUserFirmwareDate()
 
 bool gem::hw::HwGenericAMC::linkCheck(uint8_t const& gtx, std::string const& opMsg)
 {
-  INFO("linkCheck:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
+  CMSGEMOS_INFO("linkCheck:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
        << m_links << std::dec);
   if (gtx > m_maxLinks) {
     std::string msg = toolbox::toString("%s requested for gtx (%d): outside expectation (0-%d)",
                                         opMsg.c_str(), gtx, m_maxLinks);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::exception::InvalidLink,msg);
     return false;
     //  } else if (!b_links[gtx]) {
   } else if (!((m_links>>gtx)&0x1)) {
-    INFO("linkCheck:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
+    CMSGEMOS_INFO("linkCheck:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
          << m_links << std::dec);
     std::string msg = toolbox::toString("%s requested inactive gtx (%d, 0x%08x, 0x%08x)",opMsg.c_str(), gtx,m_links,m_links>>gtx);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::exception::InvalidLink,msg);
     return false;
   }
-  INFO("linkCheck:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
+  CMSGEMOS_INFO("linkCheck:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
        << m_links << std::dec);
   return true;
 }
@@ -277,7 +277,7 @@ gem::hw::GEMHwDevice::OpticalLinkStatus gem::hw::HwGenericAMC::LinkStatus(uint8_
 {
   gem::hw::GEMHwDevice::OpticalLinkStatus linkStatus;
 
-  INFO("LinkStatus:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
+  CMSGEMOS_INFO("LinkStatus:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
        << m_links << std::dec);
   if (linkCheck(gtx, "Link status")) {
     linkStatus.GTX_TRK_Errors   = readReg(getDeviceBaseNode(),toolbox::toString("OH_LINKS.OH%d.TRACK_LINK_ERROR_CNT", gtx));
@@ -286,7 +286,7 @@ gem::hw::GEMHwDevice::OpticalLinkStatus gem::hw::HwGenericAMC::LinkStatus(uint8_
     linkStatus.GBT_TRK_Errors   = readReg(getDeviceBaseNode(),toolbox::toString("OH_LINKS.OH%d.TRACK_LINK_ERROR_CNT", gtx));
     linkStatus.GBT_Data_Packets = readReg(getDeviceBaseNode(),toolbox::toString("OH_LINKS.OH%d.VFAT_BLOCK_CNT",       gtx));
   }
-  INFO("LinkStatus:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
+  CMSGEMOS_INFO("LinkStatus:: m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
        << m_links << std::dec);
   return linkStatus;
 }
@@ -365,7 +365,7 @@ uint32_t gem::hw::HwGenericAMC::getFIFOOccupancy(uint8_t const& gtx)
     std::stringstream regName;
     regName << "TRK_DATA.OptoHybrid_" << (int)gtx;
     fifocc = readReg(getDeviceBaseNode(),regName.str()+".DEPTH");
-    DEBUG(toolbox::toString("getFIFOOccupancy(%d) %s.%s%s:: %d", gtx, getDeviceBaseNode().c_str(),
+    CMSGEMOS_DEBUG(toolbox::toString("getFIFOOccupancy(%d) %s.%s%s:: %d", gtx, getDeviceBaseNode().c_str(),
                             regName.str().c_str(), ".DEPTH", fifocc));
   }
   // the fifo occupancy is in number of 32 bit words
@@ -410,7 +410,7 @@ uint32_t gem::hw::HwGenericAMC::getTrackingData(uint8_t const& gtx, uint32_t* da
 {
   if (data==NULL) {
     std::string msg = toolbox::toString("Block read requested for null pointer");
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::exception::NULLReadoutPointer,msg);
   } else if (!linkCheck(gtx, "Tracking data")) {
     return 0;
@@ -444,12 +444,12 @@ void gem::hw::HwGenericAMC::flushFIFO(uint8_t const& gtx)
   if (linkCheck(gtx, "Flush FIFO")) {
     std::stringstream regName;
     regName << "TRK_DATA.OptoHybrid_" << (int)gtx;
-    INFO("Tracking FIFO" << (int)gtx << ":"
+    CMSGEMOS_INFO("Tracking FIFO" << (int)gtx << ":"
          << " ISFULL  0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISFULL")  << std::dec
          << " ISEMPTY 0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISEMPTY") << std::dec
          << " Depth   0x" << std::hex << getFIFOOccupancy(gtx) << std::dec);
     writeReg(getDeviceBaseNode(),regName.str()+".FLUSH",0x1);
-    INFO("Tracking FIFO" << (int)gtx << ":"
+    CMSGEMOS_INFO("Tracking FIFO" << (int)gtx << ":"
          << " ISFULL  0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISFULL")  << std::dec
          << " ISEMPTY 0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISEMPTY") << std::dec
          << " Depth   0x" << std::hex << getFIFOOccupancy(gtx) << std::dec);
@@ -658,7 +658,7 @@ void gem::hw::HwGenericAMC::setDAQLinkRunParameter(uint8_t const& parameter, uin
   if (parameter < 1 || parameter > 3) {
     std::string msg = toolbox::toString("Attempting to set DAQ link run parameter %d: outside expectation (1-%d)",
                                         (int)parameter,3);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     return;
   }
   std::stringstream regBase;
@@ -712,7 +712,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
   const int PLL_LOCK_READ_ATTEMPTS  = 10;
   const double PLL_LOCK_WAIT_TIME   = 0.00001; // wait 100us to allow the PLL to lock
 
-  INFO("HwGenericAMC::ttcMMCMPhaseShift: starting phase shifting procedure");
+  CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift: starting phase shifting procedure");
   // writeReg(getDeviceBaseNode(), "TTC.CTRL.MMCM_PHASE_SHIFT", 0x1);
 
   /*
@@ -750,7 +750,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
   // add readback of aforementioned registers
 
   if (readReg(getDeviceBaseNode(),"TTC.CTRL.DISABLE_PHASE_ALIGNMENT") == 0x0) {
-    WARN("HwGeneircAMC::ttcMMCMPhaseShift automatic phase alignment is turned off!!");
+    CMSGEMOS_WARN("HwGeneircAMC::ttcMMCMPhaseShift automatic phase alignment is turned off!!");
     // EXCEPT_RAISE
     return;
   }
@@ -793,10 +793,10 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
     writeReg(getDeviceBaseNode(), "TTC.CTRL.PA_GTH_MANUAL_SHIFT_EN", 0x1);
 
     if (!reversingForLock && (gthShiftCnt == 39)) {
-      DEBUG("HwGeneircAMC::ttcMMCMPhaseShift: normal GTH shift rollover 39->0");
+      CMSGEMOS_DEBUG("HwGeneircAMC::ttcMMCMPhaseShift: normal GTH shift rollover 39->0");
       gthShiftCnt = 0;
     } else if (reversingForLock && (gthShiftCnt == 0)){
-      DEBUG("HwGeneircAMC::ttcMMCMPhaseShift: rerversed GTH shift rollover 0->39");
+      CMSGEMOS_DEBUG("HwGeneircAMC::ttcMMCMPhaseShift: rerversed GTH shift rollover 0->39");
       gthShiftCnt = 39;
     } else {
       if (reversingForLock) {
@@ -808,10 +808,10 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
 
     uint32_t tmpGthShiftCnt  = readReg(getDeviceBaseNode(),"TTC.STATUS.CLK.PA_MANUAL_GTH_SHIFT_CNT");
     uint32_t tmpMmcmShiftCnt = readReg(getDeviceBaseNode(),"TTC.STATUS.CLK.PA_MANUAL_SHIFT_CNT");
-    INFO("HwGeneircAMC::ttcMMCMPhaseShift tmpGthShiftCnt: " << tmpGthShiftCnt
+    CMSGEMOS_INFO("HwGeneircAMC::ttcMMCMPhaseShift tmpGthShiftCnt: " << tmpGthShiftCnt
          << ", tmpMmcmShiftCnt: " << tmpMmcmShiftCnt);
     while (gthShiftCnt != tmpGthShiftCnt) {
-      WARN("HwGeneircAMC::ttcMMCMPhaseShift Repeating a GTH PI shift because the shift count doesn't"
+      CMSGEMOS_WARN("HwGeneircAMC::ttcMMCMPhaseShift Repeating a GTH PI shift because the shift count doesn't"
            << " match the expected value."
            << " Expected shift cnt = " << gthShiftCnt
            << ", ctp7 returned "       << tmpGthShiftCnt);
@@ -834,7 +834,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
 
       tmpMmcmShiftCnt = readReg(getDeviceBaseNode(),"TTC.STATUS.CLK.PA_MANUAL_SHIFT_CNT");
       if (mmcmShiftCnt != tmpMmcmShiftCnt)
-        WARN("HwGeneircAMC::ttcMMCMPhaseShift Reported MMCM shift count doesn't match the expected MMCM shift count."
+        CMSGEMOS_WARN("HwGeneircAMC::ttcMMCMPhaseShift Reported MMCM shift count doesn't match the expected MMCM shift count."
              << " Expected shift cnt = " << mmcmShiftCnt
              << " , ctp7 returned "      << tmpMmcmShiftCnt);
     }
@@ -852,7 +852,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
     uhal::ValWord<uint32_t> dblErrCnt  = getGEMHwInterface().getNode("GEM_AMC.TTC.STATUS.TTC_DOUBLE_ERROR_CNT").read();
     getGEMHwInterface().dispatch();
 
-    DEBUG("HwGeneircAMC::ttcMMCMPhaseShift GTH shift #" << i
+    CMSGEMOS_DEBUG("HwGeneircAMC::ttcMMCMPhaseShift GTH shift #" << i
           << ": mmcm shift cnt = "     << mmcmShiftCnt
           << ", mmcm phase counts = "  << phase
           << ", mmcm phase = "         << phaseNs
@@ -874,7 +874,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
         if (shiftOutOfLockFirst) {
           if (nBadLocks > 100) {
             firstUnlockFound = true;
-            INFO("HwGenericAMC::ttcMMCMPhaseShift 100 unlocks found after " << (i+1) << " shifts:"
+            CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift 100 unlocks found after " << (i+1) << " shifts:"
                  << " bad locks "           << nBadLocks
                  << ", good locks "         << nGoodLocks
                  << ", mmcm phase count = " << phase
@@ -882,7 +882,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
           }
         } else {
           if (reversingForLock && (nBadLocks > 0)) {
-            DEBUG("HwGenericAMC::ttcMMCMPhaseShift Bad BC0 lock found:"
+            CMSGEMOS_DEBUG("HwGenericAMC::ttcMMCMPhaseShift Bad BC0 lock found:"
                   << " phase count = " << phase
                   << ", phase ns = "   << phaseNs << "ns"
                   << ", returning to normal search");
@@ -894,7 +894,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
             nGoodLocks       = 0;
           } else if (nGoodLocks == 200) {
             reversingForLock = true;
-            INFO("HwGenericAMC::ttcMMCMPhaseShift 200 consecutive good BC0 locks found:"
+            CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift 200 consecutive good BC0 locks found:"
                  << " phase count = " << phase
                  << ", phase ns = "   << phaseNs << "ns"
                  << ", reversing scan direction");
@@ -903,7 +903,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
             getGEMHwInterface().dispatch();
           }
           if (reversingForLock && (nGoodLocks == 300)) {
-            INFO("HwGenericAMC::ttcMMCMPhaseShift Best lock found after reversing:"
+            CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift Best lock found after reversing:"
                  << " phase count = " << phase
                  << ", phase ns = "   << phaseNs << "ns");
             bestLockFound    = true;
@@ -922,7 +922,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
       } else { // shift to first good BC0 locked
         if (bc0Locked == 0) {
           if (nextLockFound) {
-            DEBUG("HwGenericAMC::ttcMMCMPhaseShift Unexpected unlock after " << (i+1) << " shifts:"
+            CMSGEMOS_DEBUG("HwGenericAMC::ttcMMCMPhaseShift Unexpected unlock after " << (i+1) << " shifts:"
                   << " bad locks "           << nBadLocks
                   << ", good locks "         << nGoodLocks
                   << ", mmcm phase count = " << phase
@@ -932,7 +932,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
           // nGoodLocks = 0;
         } else {
           if (!nextLockFound) {
-            INFO("HwGenericAMC::ttcMMCMPhaseShift Found next lock after "  << (i+1) << " shifts:"
+            CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift Found next lock after "  << (i+1) << " shifts:"
                  << " bad locks "           << nBadLocks
                  << ", good locks "         << nGoodLocks
                  << ", mmcm phase count = " << phase
@@ -943,7 +943,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
           nGoodLocks += 1;
         }
         if (nGoodLocks == 1920) {
-          INFO("HwGenericAMC::ttcMMCMPhaseShift Finished 1920 shifts after first good lock: "
+          CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift Finished 1920 shifts after first good lock: "
                << "bad locks "   << nBadLocks
                << " good locks " <<  nGoodLocks);
           bestLockFound = true;
@@ -971,14 +971,14 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
         if (shiftOutOfLockFirst) {
           if (nBadLocks > 500) {
             firstUnlockFound = true;
-            DEBUG("HwGenericAMC::ttcMMCMPhaseShift 500 unlocks found after " << i+1 << " shifts:"
+            CMSGEMOS_DEBUG("HwGenericAMC::ttcMMCMPhaseShift 500 unlocks found after " << i+1 << " shifts:"
                   << " bad locks "           << nBadLocks
                   << ", good locks "         << nGoodLocks
                   << ", mmcm phase count = " << phase
                   << ", mmcm phase ns = "    << phaseNs << "ns");
           } else {
             if (reversingForLock && (nBadLocks > 0)) {
-              DEBUG("HwGenericAMC::ttcMMCMPhaseShift Bad BC0 lock found:"
+              CMSGEMOS_DEBUG("HwGenericAMC::ttcMMCMPhaseShift Bad BC0 lock found:"
                     << " phase count = " << phase
                     << ", phase ns = "   << phaseNs << "ns"
                     << ", returning to normal search");
@@ -990,7 +990,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
               nGoodLocks       = 0;
             } else if (nGoodLocks == 50) {
               reversingForLock = true;
-              INFO("HwGenericAMC::ttcMMCMPhaseShift 50 consecutive good PLL locks found:"
+              CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift 50 consecutive good PLL locks found:"
                    << " phase count = " << phase
                    << ", phase ns = "   << phaseNs << "ns"
                    << ", reversing scan direction");
@@ -999,7 +999,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
               getGEMHwInterface().dispatch();
             }
             if (reversingForLock &&(nGoodLocks == 75)) {
-              INFO("HwGenericAMC::ttcMMCMPhaseShift Best lock found after reversing:"
+              CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift Best lock found after reversing:"
                    << " phase count = " << phase
                    << ", phase ns = "   << phaseNs << "ns.");
               bestLockFound = true;
@@ -1019,7 +1019,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
       } else { // shift to first good PLL locked
         if (pllLockCnt < PLL_LOCK_READ_ATTEMPTS) {
           if (nextLockFound) {
-            WARN("HwGenericAMC::ttcMMCMPhaseShift Unexpected unlock after " << i+1 << " shifts:"
+            CMSGEMOS_WARN("HwGenericAMC::ttcMMCMPhaseShift Unexpected unlock after " << i+1 << " shifts:"
                  << " bad locks "           << nBadLocks
                  << ", good locks "         << nGoodLocks
                  << ", mmcm phase count = " << phase
@@ -1028,7 +1028,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
             // nGoodLocks = 0;
           } else {
             if (!nextLockFound) {
-              INFO("HwGenericAMC::ttcMMCMPhaseShift Found next lock after " << i+1 << " shifts:"
+              CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift Found next lock after " << i+1 << " shifts:"
                    << " bad locks "           << nBadLocks
                    << ", good locks "         << nGoodLocks
                    << ", mmcm phase count = " << phase
@@ -1039,7 +1039,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
             nGoodLocks += 1;
           }
           if (nShiftsSinceLock == 1000) {
-            INFO("HwGenericAMC::ttcMMCMPhaseShift Finished 1000 shifts after first good lock:"
+            CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift Finished 1000 shifts after first good lock:"
                  << " bad locks "   << nBadLocks
                  << ", good locks " << nGoodLocks);
             bestLockFound = true;
@@ -1058,7 +1058,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
     } else {
       if (shiftOutOfLockFirst && (pllLockCnt < PLL_LOCK_READ_ATTEMPTS) && !firstUnlockFound) {
         firstUnlockFound = true;
-        WARN("HwGenericAMC::ttcMMCMPhaseShift Unlocked after " << i+1 << "shifts:"
+        CMSGEMOS_WARN("HwGenericAMC::ttcMMCMPhaseShift Unlocked after " << i+1 << "shifts:"
              << " mmcm phase count = "     << phase
              << ", mmcm phase ns = "       << phaseNs << "ns"
              << ", pllLockCnt = "          << pllLockCnt
@@ -1070,7 +1070,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
         if (!shiftOutOfLockFirst) {
           if (nGoodLocks == 50) {
             reversingForLock = true;
-            INFO("HwGenericAMC::ttcMMCMPhaseShift 200 consecutive good PLL locks found:"
+            CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift 200 consecutive good PLL locks found:"
                  << " phase count = " << phase
                  << ", phase ns = "   << phaseNs << "ns"
                  << ", reversing scan direction");
@@ -1078,7 +1078,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
             getGEMHwInterface().getNode("GEM_AMC.TTC.CTRL.PA_GTH_MANUAL_SHIFT_DIR").write(1);
           }
           if (reversingForLock && (nGoodLocks == 75)) {
-            INFO("HwGenericAMC::ttcMMCMPhaseShift Best lock found after reversing:"
+            CMSGEMOS_INFO("HwGenericAMC::ttcMMCMPhaseShift Best lock found after reversing:"
                  << " phase count = " << phase
                  << ", phase ns = "   << phaseNs << "ns.");
             bestLockFound    = true;
@@ -1095,7 +1095,7 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
           }
         } else if (firstUnlockFound || !shiftOutOfLockFirst) {
           if (!nextLockFound) {
-            DEBUG("HwGenericAMC::ttcMMCMPhaseShift Found next lock after " << i+1 << " shifts:"
+            CMSGEMOS_DEBUG("HwGenericAMC::ttcMMCMPhaseShift Found next lock after " << i+1 << " shifts:"
                   << " bad locks "           << nBadLocks
                   << ", good locks "         << nGoodLocks
                   << ", mmcm phase count = " << phase
@@ -1142,13 +1142,13 @@ void gem::hw::HwGenericAMC::ttcMMCMPhaseShift(bool shiftOutOfLockFirst, bool use
 
   if (bestLockFound) {
     ttcMMCMReset();
-    INFO("HwGeneircAMC::ttcMMCMPhaseShift Lock was found:"
+    CMSGEMOS_INFO("HwGeneircAMC::ttcMMCMPhaseShift Lock was found:"
          << " phase count " << phase
          << ", phase "      << phaseNs<< "ns");
   } else {
     std::stringstream msg;
     msg << "HwGeneircAMC::ttcMMCMPhaseShift Unable to find lock";
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::exception::MMCMLockFailed,msg);
   }
 }
@@ -1261,7 +1261,7 @@ uint32_t gem::hw::HwGenericAMC::getL1AID()
 
 uint32_t gem::hw::HwGenericAMC::getTTCSpyBuffer()
 {
-  WARN("HwGenericAMC::getTTCSpyBuffer: TTC.TTC_SPY_BUFFER is obsolete and will be removed in a future release");
+  CMSGEMOS_WARN("HwGenericAMC::getTTCSpyBuffer: TTC.TTC_SPY_BUFFER is obsolete and will be removed in a future release");
   return 0x0;
   // return readReg(getDeviceBaseNode(), "TTC.TTC_SPY_BUFFER");
 }

--- a/gemhardware/src/common/amc13/AMC13Manager.cc
+++ b/gemhardware/src/common/amc13/AMC13Manager.cc
@@ -154,14 +154,14 @@ gem::hw::amc13::AMC13Manager::AMC13Manager(xdaq::ApplicationStub* stub)
   uhal::setLogLevelTo(uhal::Error);
 
   // initialize the AMC13Manager application objects
-  DEBUG("AMC13Manager::connecting to the AMC13ManagerWeb interface");
+  CMSGEMOS_DEBUG("AMC13Manager::connecting to the AMC13ManagerWeb interface");
   p_gemWebInterface = new gem::hw::amc13::AMC13ManagerWeb(this);
   // p_gemMonitor      = new gem::hw::amc13::AMC13HwMonitor(this);
-  DEBUG("AMC13Manager::done");
+  CMSGEMOS_DEBUG("AMC13Manager::done");
 
-  // DEBUG("AMC13Manager::executing preInit for AMC13Manager");
+  // CMSGEMOS_DEBUG("AMC13Manager::executing preInit for AMC13Manager");
   // preInit();
-  // DEBUG("AMC13Manager::done");
+  // CMSGEMOS_DEBUG("AMC13Manager::done");
   p_appDescriptor->setAttribute("icon","/gemdaq/gemhardware/html/images/amc13/AMC13Manager.png");
 
   xoap::bind(this, &gem::hw::amc13::AMC13Manager::sendTriggerBurst,"sendtriggerburst", XDAQ_NS_URI );
@@ -174,14 +174,14 @@ gem::hw::amc13::AMC13Manager::AMC13Manager(xdaq::ApplicationStub* stub)
 }
 
 gem::hw::amc13::AMC13Manager::~AMC13Manager() {
-  DEBUG("AMC13Manager::dtor called");
+  CMSGEMOS_DEBUG("AMC13Manager::dtor called");
 }
 
 // This is the callback used for handling xdata:Event objects
 void gem::hw::amc13::AMC13Manager::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("AMC13Manager::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("AMC13Manager::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
     // p_gemMonitor->startMonitoring();
     // update configuration variables
@@ -206,10 +206,10 @@ void gem::hw::amc13::AMC13Manager::actionPerformed(xdata::Event& event)
     m_startL1ATricont        = m_localTriggerConfig.bag.startl1ATricont.value_;
     m_enableLEMO             = m_localTriggerConfig.bag.enableLEMO.value_;
 
-    DEBUG("AMC13Manager::actionPerformed m_enableLocalL1A " << std::endl
+    CMSGEMOS_DEBUG("AMC13Manager::actionPerformed m_enableLocalL1A " << std::endl
          << m_localTriggerConfig.bag.toString());
 
-    DEBUG("AMC13Manager::actionPerformed BGO channels "
+    CMSGEMOS_DEBUG("AMC13Manager::actionPerformed BGO channels "
           << m_amc13Params.bag.bgoConfig.size());
 
     for (auto bconf = m_amc13Params.bag.bgoConfig.begin(); bconf != m_amc13Params.bag.bgoConfig.end(); ++bconf)
@@ -235,7 +235,7 @@ void gem::hw::amc13::AMC13Manager::actionPerformed(xdata::Event& event)
 
   // item is changed, update it
   if (event.type() == "ItemChangedEvent" || event.type() == "urn:xdata-event:ItemChangedEvent") {
-    DEBUG("AMC13Manager::actionPerformed() ItemChangedEvent");
+    CMSGEMOS_DEBUG("AMC13Manager::actionPerformed() ItemChangedEvent");
   }
 
   gem::base::GEMApplication::actionPerformed(event);
@@ -271,35 +271,35 @@ void gem::hw::amc13::AMC13Manager::initializeAction()
   // std::string cardname    = toolbox::toString("gem.shelf%02d.amc13",m_crateID);
   std::string cardname    = m_cardName;
 
-  INFO("AMC13Manager::initializeAction m_amc13Params is:" << std::endl << m_amc13Params.bag.toString());
+  CMSGEMOS_INFO("AMC13Manager::initializeAction m_amc13Params is:" << std::endl << m_amc13Params.bag.toString());
 
   try {
     gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_amc13Lock);
-    DEBUG("Trying to create connection to " << m_cardName << " in " << connection);
+    CMSGEMOS_DEBUG("Trying to create connection to " << m_cardName << " in " << connection);
     p_amc13 = std::make_shared< ::amc13::AMC13>(connection, cardname+".T1", cardname+".T2");
   } catch (::amc13::Exception::exBase & e) {
     std::stringstream msg;
     msg << "AMC13Manager::AMC13::AMC13() failed, caught amc13::Exception: " << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem, msg.str());
   } catch (uhal::exception::exception & e) {
     std::stringstream msg;
     msg << "AMC13Manager::AMC13::AMC13() failed, caught uhal::exception: " << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem, msg.str());
   } catch (std::exception& e) {
     std::stringstream msg;
     msg << "AMC13Manager::AMC13::AMC13() failed, caught std::exception: " << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem, msg.str());
   } catch (...) {
     std::stringstream msg;
     msg << "AMC13Manager::AMC13::AMC13() failed (unknown exception)";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem, msg.str());
   }
 
-  DEBUG("AMC13Manager::initializeAction finished with AMC13::AMC13()");
+  CMSGEMOS_DEBUG("AMC13Manager::initializeAction finished with AMC13::AMC13()");
 
   try {
     gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_amc13Lock);
@@ -318,10 +318,10 @@ void gem::hw::amc13::AMC13Manager::initializeAction()
 
     p_amc13->enableAllTTC();
   } catch (uhal::exception::exception & e) {
-    ERROR("AMC13Manager::AMC13::AMC13() failed, caught uhal::exception " << e.what());
+    CMSGEMOS_ERROR("AMC13Manager::AMC13::AMC13() failed, caught uhal::exception " << e.what());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem,std::string("Problem during preinit : ")+e.what());
   } catch (std::exception& e) {
-    ERROR("AMC13Manager::AMC13::AMC13() failed, caught std::exception " << e.what());
+    CMSGEMOS_ERROR("AMC13Manager::AMC13::AMC13() failed, caught std::exception " << e.what());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem,std::string("Problem during preinit : ")+e.what());
   }
 
@@ -335,7 +335,7 @@ void gem::hw::amc13::AMC13Manager::initializeAction()
   gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_amc13Lock);
 
   // enable daq link (if SFP mask is non-zero
-  DEBUG("AMC13Manager::initializeAction Enabling DAQLink with settings: fake data:" << m_enableFakeData
+  CMSGEMOS_DEBUG("AMC13Manager::initializeAction Enabling DAQLink with settings: fake data:" << m_enableFakeData
         << ", sfpMask:" << m_sfpMask);
 
   p_amc13->fakeDataEnable(m_enableFakeData);
@@ -345,9 +345,9 @@ void gem::hw::amc13::AMC13Manager::initializeAction()
   p_amc13->sfpOutputEnable(m_sfpMask);
 
   // ignore AMC tts state per mask
-  INFO("AMC13Manager::initializeAction m_amcIgnoreTTSList " << m_amcIgnoreTTSList);
+  CMSGEMOS_INFO("AMC13Manager::initializeAction m_amcIgnoreTTSList " << m_amcIgnoreTTSList);
   m_ignoreAMCTTS = p_amc13->parseInputEnableList(m_amcIgnoreTTSList,true);
-  INFO("AMC13Manager::initializeAction m_amcIgnoreTTSList " << m_amcIgnoreTTSList
+  CMSGEMOS_INFO("AMC13Manager::initializeAction m_amcIgnoreTTSList " << m_amcIgnoreTTSList
        << " parsed as m_ignoreAMCTTS: " << std::hex << m_ignoreAMCTTS << std::dec);
   if (m_ignoreAMCTTS) {
     p_amc13->ttsDisableMask(m_ignoreAMCTTS);
@@ -389,7 +389,7 @@ void gem::hw::amc13::AMC13Manager::initializeAction()
   p_amc13->resetCounters();
 
   // unlock the access
-  INFO("AMC13Manager::initializeAction end");
+  CMSGEMOS_INFO("AMC13Manager::initializeAction end");
 }
 
 void gem::hw::amc13::AMC13Manager::configureAction()
@@ -406,10 +406,10 @@ void gem::hw::amc13::AMC13Manager::configureAction()
   p_amc13->configureLocalL1A(m_enableLocalL1A, m_L1Amode, m_L1Aburst, m_internalPeriodicPeriod, m_L1Arules);
 
   if (m_enableLocalTTC) {
-    DEBUG("AMC13Manager::configureAction configuring BGO channels "
+    CMSGEMOS_DEBUG("AMC13Manager::configureAction configuring BGO channels "
           << m_bgoConfig.size());
     for (auto bchan = m_bgoConfig.begin(); bchan != m_bgoConfig.end(); ++bchan) {
-      DEBUG("AMC13Manager::configureAction channel "
+      CMSGEMOS_DEBUG("AMC13Manager::configureAction channel "
             << bchan->bag.channel.value_);
       if (bchan->bag.channel.value_ > -1) {
         if (bchan->bag.isLong.value_)
@@ -425,12 +425,12 @@ void gem::hw::amc13::AMC13Manager::configureAction()
   }
   // set the settings from the config options
   // usleep(10); // just for testing the timing of different applications
-  INFO("AMC13Manager::configureAction end");
+  CMSGEMOS_INFO("AMC13Manager::configureAction end");
 }
 
 void gem::hw::amc13::AMC13Manager::startAction()
 {
-  DEBUG("AMC13Manager::Entering AMC13Manager::startAction()");
+  CMSGEMOS_DEBUG("AMC13Manager::Entering AMC13Manager::startAction()");
   // gem::base::GEMFSMApplication::enable();
   gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_amc13Lock);
 
@@ -450,7 +450,7 @@ void gem::hw::amc13::AMC13Manager::startAction()
   if (m_enableLocalTTC) {
     for (auto bchan = m_bgoConfig.begin(); bchan != m_bgoConfig.end(); ++bchan)
       if (bchan->bag.channel.value_ > -1) {
-        INFO("AMC13Manager::startAction enabling BGO channel " << bchan->bag.channel.value_);
+        CMSGEMOS_INFO("AMC13Manager::startAction enabling BGO channel " << bchan->bag.channel.value_);
 	if (bchan->bag.repeat.value_)
           p_amc13->enableBGORepeat(bchan->bag.channel.value_);
 	else
@@ -461,7 +461,7 @@ void gem::hw::amc13::AMC13Manager::startAction()
 
   if (m_enableLocalL1A) {
     if (m_enableLEMO) {
-      DEBUG("AMC13Manager::startAction enabling LEMO trigger " << m_enableLEMO);
+      CMSGEMOS_DEBUG("AMC13Manager::startAction enabling LEMO trigger " << m_enableLEMO);
       p_amc13->write(::amc13::AMC13::T1,"CONF.TTC.T3_TRIG",0x1);
     } else {
       p_amc13->startContinuousL1A();
@@ -475,7 +475,7 @@ void gem::hw::amc13::AMC13Manager::startAction()
   }
 
   if (m_scanType.value_ == 2 || m_scanType.value_ == 3) {
-    DEBUG("AMC13Manager::startAction Sending continuous triggers for ScanRoutines ");
+    CMSGEMOS_DEBUG("AMC13Manager::startAction Sending continuous triggers for ScanRoutines ");
     // p_amc13->enableLocalL1A(m_enableLocalL1A);
 
     // if (m_enableLocalL1A) {
@@ -491,7 +491,7 @@ void gem::hw::amc13::AMC13Manager::startAction()
     try {
       p_timer->stop();
     } catch (toolbox::task::exception::NotActive const& ex) {
-      WARN("AMC13Manager::start could not stop timer " << ex.what());
+      CMSGEMOS_WARN("AMC13Manager::start could not stop timer " << ex.what());
     }
     p_timer->start();
     toolbox::TimeInterval interval(0.1,0);  // period of 0.1 secs
@@ -499,7 +499,7 @@ void gem::hw::amc13::AMC13Manager::startAction()
     start = toolbox::TimeVal::gettimeofday();
     p_timer->scheduleAtFixedRate(start, this, interval, 0, "" );
   }  // end scan type
-  INFO("AMC13Manager::startAction end");
+  CMSGEMOS_INFO("AMC13Manager::startAction end");
 }
 
 void gem::hw::amc13::AMC13Manager::pauseAction()
@@ -508,10 +508,10 @@ void gem::hw::amc13::AMC13Manager::pauseAction()
   // if local triggers are enabled, do we have a separate trigger application?
   // we can just disable them here maybe?
   if (m_scanType.value_ == 2 || m_scanType.value_ == 3) {
-    INFO("AMC13Manager::pauseAction disabling triggers for scan, triggers seen this point = "
+    CMSGEMOS_INFO("AMC13Manager::pauseAction disabling triggers for scan, triggers seen this point = "
 	 << p_amc13->read(::amc13::AMC13::T1,"STATUS.GENERAL.L1A_COUNT_LO") - m_updatedL1ACount);
     m_updatedL1ACount = p_amc13->read(::amc13::AMC13::T1,"STATUS.GENERAL.L1A_COUNT_LO");
-    INFO("AMC13Manager::timeExpried, total triggers seen = " << m_updatedL1ACount);
+    CMSGEMOS_INFO("AMC13Manager::timeExpried, total triggers seen = " << m_updatedL1ACount);
   }
 
   if (m_enableLocalL1A) {
@@ -532,7 +532,7 @@ void gem::hw::amc13::AMC13Manager::pauseAction()
   if (m_enableLocalTTC)
     for (auto bchan = m_bgoConfig.begin(); bchan != m_bgoConfig.end(); ++bchan)
       if (bchan->bag.channel.value_ > -1) {
-        DEBUG("AMC13Manager::pauseAction disabling BGO channel " << bchan->bag.channel.value_);
+        CMSGEMOS_DEBUG("AMC13Manager::pauseAction disabling BGO channel " << bchan->bag.channel.value_);
         p_amc13->disableBGO(bchan->bag.channel.value_);
       }
 
@@ -540,7 +540,7 @@ void gem::hw::amc13::AMC13Manager::pauseAction()
   for (int bchan = 0; bchan < 4; ++bchan)
     p_amc13->disableBGO(bchan);
 
-  INFO("AMC13Manager::pauseAction end");
+  CMSGEMOS_INFO("AMC13Manager::pauseAction end");
 }
 
 void gem::hw::amc13::AMC13Manager::resumeAction()
@@ -551,7 +551,7 @@ void gem::hw::amc13::AMC13Manager::resumeAction()
     for (auto bchan = m_bgoConfig.begin(); bchan != m_bgoConfig.end(); ++bchan)
       if (bchan->bag.channel.value_ > -1) {
         sendLocalBGO = true;
-        DEBUG("AMC13Manager::resumeAction enabling BGO channel " << bchan->bag.channel.value_);
+        CMSGEMOS_DEBUG("AMC13Manager::resumeAction enabling BGO channel " << bchan->bag.channel.value_);
 	if (bchan->bag.repeat.value_)
           p_amc13->enableBGORepeat(bchan->bag.channel.value_);
 	else
@@ -579,7 +579,7 @@ void gem::hw::amc13::AMC13Manager::resumeAction()
   }
 
   // if (m_scanType.value_ == 2 || m_scanType.value_ == 3) {
-  //   DEBUG("AMC13Manager::resumeAction enabling triggers for scan");
+  //   CMSGEMOS_DEBUG("AMC13Manager::resumeAction enabling triggers for scan");
 
   //   if (m_enableLocalL1A) {
   //     p_amc13->configureLocalL1A(m_enableLocalL1A, m_L1Amode, m_L1Aburst, m_internalPeriodicPeriod, m_L1Arules);
@@ -594,17 +594,17 @@ void gem::hw::amc13::AMC13Manager::resumeAction()
   //   }
   // }
   // usleep(10);
-  INFO("AMC13Manager::resumeAction end");
+  CMSGEMOS_INFO("AMC13Manager::resumeAction end");
 }
 
 void gem::hw::amc13::AMC13Manager::stopAction()
 {
-  DEBUG("AMC13Manager::Entering AMC13Manager::stopAction()");
+  CMSGEMOS_DEBUG("AMC13Manager::Entering AMC13Manager::stopAction()");
   // gem::base::GEMFSMApplication::disable();
   gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_amc13Lock);
 
   if (m_scanType.value_ == 2 || m_scanType.value_ == 3) {
-    DEBUG("AMC13Manager::stopAction Sending continuous triggers for ScanRoutines ");
+    CMSGEMOS_DEBUG("AMC13Manager::stopAction Sending continuous triggers for ScanRoutines ");
     p_timer->stop();
   }
 
@@ -627,7 +627,7 @@ void gem::hw::amc13::AMC13Manager::stopAction()
   if (m_enableLocalTTC)
     for (auto bchan = m_bgoConfig.begin(); bchan != m_bgoConfig.end(); ++bchan)
       if (bchan->bag.channel.value_ > -1) {
-        DEBUG("AMC13Manager::stopAction disabling BGO channel " << bchan->bag.channel.value_);
+        CMSGEMOS_DEBUG("AMC13Manager::stopAction disabling BGO channel " << bchan->bag.channel.value_);
         p_amc13->disableBGO(bchan->bag.channel.value_);
       }
 
@@ -637,33 +637,33 @@ void gem::hw::amc13::AMC13Manager::stopAction()
 
  // usleep(10);
   p_amc13->endRun();
-  INFO("AMC13Manager::stopAction end");
+  CMSGEMOS_INFO("AMC13Manager::stopAction end");
 }
 
 void gem::hw::amc13::AMC13Manager::haltAction()
 {
   // what is necessary for a halt on the AMC13?
   usleep(10);  // just for testing the timing of different applications
-  INFO("AMC13Manager::haltAction end");
+  CMSGEMOS_INFO("AMC13Manager::haltAction end");
 }
 
 void gem::hw::amc13::AMC13Manager::resetAction()
 {
   // what is necessary for a reset on the AMC13?
-  DEBUG("Entering AMC13Manager::resetAction()");
+  CMSGEMOS_DEBUG("Entering AMC13Manager::resetAction()");
 
   if (p_timer) {
     try {
       p_timer->stop();
     } catch (toolbox::task::exception::NotActive const& ex) {
-      WARN("AMC13Manager::start could not stop timer " << ex.what());
+      CMSGEMOS_WARN("AMC13Manager::start could not stop timer " << ex.what());
     }
   }
 
   // maybe ensure triggers are disabled as well as BGO commands?
   usleep(10);
   // gem::base::GEMFSMApplication::resetAction();
-  INFO("AMC13Manager::resetAction end");
+  CMSGEMOS_INFO("AMC13Manager::resetAction end");
 }
 
 /*These should maybe only be implemented in GEMFSMApplication,
@@ -682,7 +682,7 @@ void gem::hw::amc13::AMC13Manager::resetAction(toolbox::Event::Reference e)
 xoap::MessageReference gem::hw::amc13::AMC13Manager::sendTriggerBurst(xoap::MessageReference msg)
 {
   // set to send a burst of trigger
-  INFO("Entering AMC13Manager::sendTriggerBurst()");
+  CMSGEMOS_INFO("Entering AMC13Manager::sendTriggerBurst()");
 
   if (msg.isNull()) {
     XCEPT_RAISE(xoap::exception::Exception,"Null message received!");
@@ -709,13 +709,13 @@ xoap::MessageReference gem::hw::amc13::AMC13Manager::sendTriggerBurst(xoap::Mess
     return reply;
   }
   try {
-    INFO("AMC13Manager::sendTriggerBurst command " << commandName << " succeeded ");
+    CMSGEMOS_INFO("AMC13Manager::sendTriggerBurst command " << commandName << " succeeded ");
     return
       gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "SentTriggers");
   } catch(xcept::Exception& err) {
     std::string msgBase = toolbox::toString("Failed to create SOAP reply for command '%s'",
                                             commandName.c_str());
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::base::utils::exception::SoftwareProblem,
                          top, toolbox::toString("%s.",msgBase.c_str()), err);
     this->notifyQualified("error", top);
@@ -728,7 +728,7 @@ xoap::MessageReference gem::hw::amc13::AMC13Manager::sendTriggerBurst(xoap::Mess
 
 xoap::MessageReference gem::hw::amc13::AMC13Manager::enableTriggers(xoap::MessageReference msg)
 {
-  DEBUG("AMC13Manager::enableTriggers");
+  CMSGEMOS_DEBUG("AMC13Manager::enableTriggers");
   // gem::base::GEMFSMApplication::disable();
 
   std::string commandName = "enableTriggers";
@@ -736,7 +736,7 @@ xoap::MessageReference gem::hw::amc13::AMC13Manager::enableTriggers(xoap::Messag
   if (!p_amc13) {
     std::string msgBase = toolbox::toString("Failed to create SOAP reply for command '%s', AMC13 not yet connected",
                                             commandName.c_str());
-    ERROR(toolbox::toString("%s", msgBase.c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s", msgBase.c_str()));
     return
       gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "Failed");
   }
@@ -752,13 +752,13 @@ xoap::MessageReference gem::hw::amc13::AMC13Manager::enableTriggers(xoap::Messag
   }
 
   try {
-    INFO("AMC13Manager::enableTriggers command " << commandName << " succeeded ");
+    CMSGEMOS_INFO("AMC13Manager::enableTriggers command " << commandName << " succeeded ");
     return
       gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "SentTriggers");
   } catch(xcept::Exception& err) {
     std::string msgBase = toolbox::toString("Failed to create SOAP reply for command '%s'",
                                             commandName.c_str());
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::base::utils::exception::SoftwareProblem,
                          top, toolbox::toString("%s.",msgBase.c_str()), err);
     this->notifyQualified("error", top);
@@ -770,14 +770,14 @@ xoap::MessageReference gem::hw::amc13::AMC13Manager::enableTriggers(xoap::Messag
 
 xoap::MessageReference gem::hw::amc13::AMC13Manager::disableTriggers(xoap::MessageReference msg)
 {
-  DEBUG("AMC13Manager::disableTriggers");
+  CMSGEMOS_DEBUG("AMC13Manager::disableTriggers");
   // gem::base::GEMFSMApplication::disable();
   std::string commandName = "disableTriggers";
 
   if (!p_amc13) {
     std::string msgBase = toolbox::toString("Failed to create SOAP reply for command '%s', AMC13 not yet connected",
                                             commandName.c_str());
-    ERROR(toolbox::toString("%s", msgBase.c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s", msgBase.c_str()));
     return
       gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "Failed");
   }
@@ -793,13 +793,13 @@ xoap::MessageReference gem::hw::amc13::AMC13Manager::disableTriggers(xoap::Messa
   }
 
   try {
-    INFO("AMC13Manager::disableTriggers " << commandName << " succeeded ");
+    CMSGEMOS_INFO("AMC13Manager::disableTriggers " << commandName << " succeeded ");
     return
       gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "SentTriggers");
   } catch(xcept::Exception& err) {
     std::string msgBase = toolbox::toString("Failed to create SOAP reply for command '%s'",
                                             commandName.c_str());
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::base::utils::exception::SoftwareProblem,
                          top, toolbox::toString("%s.",msgBase.c_str()), err);
     this->notifyQualified("error", top);
@@ -813,7 +813,7 @@ void gem::hw::amc13::AMC13Manager::timeExpired(toolbox::task::TimerEvent& event)
 {
   uint64_t currentTrigger = p_amc13->read(::amc13::AMC13::T1,"STATUS.GENERAL.L1A_COUNT_LO") - m_updatedL1ACount;
 
-  DEBUG("AMC13Manager::timeExpried, NTriggerRequested = " << m_nScanTriggers.value_
+  CMSGEMOS_DEBUG("AMC13Manager::timeExpried, NTriggerRequested = " << m_nScanTriggers.value_
         << " currentT = " << currentTrigger << " triggercounter final =  " << m_updatedL1ACount );
 
   if (currentTrigger >=  m_nScanTriggers.value_){
@@ -832,17 +832,17 @@ void gem::hw::amc13::AMC13Manager::timeExpired(toolbox::task::TimerEvent& event)
       p_amc13->enableLocalL1A(true);  // is this fine to switch to local L1A as a way to fake turning off upstream?
       */
     }
-    INFO("AMC13Manager::timeExpried, triggers seen this point = "
+    CMSGEMOS_INFO("AMC13Manager::timeExpried, triggers seen this point = "
 	 << p_amc13->read(::amc13::AMC13::T1,"STATUS.GENERAL.L1A_COUNT_LO") - m_updatedL1ACount);
     // m_updatedL1ACount = p_amc13->read(::amc13::AMC13::T1,"STATUS.GENERAL.L1A_COUNT_LO");
-    // INFO("AMC13Manager::timeExpried, total triggers seen = " << m_updatedL1ACount);
+    // CMSGEMOS_INFO("AMC13Manager::timeExpried, total triggers seen = " << m_updatedL1ACount);
     endScanPoint();
   }
 }
 
 void gem::hw::amc13::AMC13Manager::endScanPoint()
 {
-  INFO("AMC13Manager::endScanPoint");
+  CMSGEMOS_INFO("AMC13Manager::endScanPoint");
   gem::utils::soap::GEMSOAPToolBox::sendCommand("EndScanPoint",
                                                 p_appContext,p_appDescriptor,//getApplicationContext(),this->getApplicationDescriptor(),
                                                 const_cast<xdaq::ApplicationDescriptor*>(p_appZone->getApplicationDescriptor("gem::supervisor::GEMSupervisor", 0)));  // this should not be hard coded

--- a/gemhardware/src/common/amc13/AMC13ManagerWeb.cc
+++ b/gemhardware/src/common/amc13/AMC13ManagerWeb.cc
@@ -24,7 +24,7 @@ void gem::hw::amc13::AMC13ManagerWeb::webDefault(xgi::Input *in, xgi::Output *ou
   throw (xgi::exception::Exception)
 {
   if (p_gemFSMApp)
-    DEBUG("AMC13ManagerWeb::current state is" << dynamic_cast<gem::hw::amc13::AMC13Manager*>(p_gemFSMApp)->getCurrentState());
+    CMSGEMOS_DEBUG("AMC13ManagerWeb::current state is" << dynamic_cast<gem::hw::amc13::AMC13Manager*>(p_gemFSMApp)->getCurrentState());
 
   *out << cgicc::script().set("type", "text/javascript")
     .set("src", "/gemdaq/gemhardware/html/scripts/amc13/amc13.js")
@@ -41,12 +41,12 @@ void gem::hw::amc13::AMC13ManagerWeb::webDefault(xgi::Input *in, xgi::Output *ou
 void gem::hw::amc13::AMC13ManagerWeb::monitorPage(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("AMC13ManagerWeb::monitorPage");
+  CMSGEMOS_DEBUG("AMC13ManagerWeb::monitorPage");
 
   // process the form for the debug level, how do we set the default of 2 for the first load?
   *out << "    <div class=\"xdaq-tab-wrapper\">" << std::endl;
   *out << "      <div class=\"xdaq-tab\" title=\"AMC13 Status Page\" >"  << std::endl;
-  DEBUG("AMC13ManagerWeb::current level is "      << level);
+  CMSGEMOS_DEBUG("AMC13ManagerWeb::current level is "      << level);
 
   std::string method = toolbox::toString("/%s/setDisplayLevel", (p_gemApp->m_urn).c_str());
   *out << cgicc::form().set("method","POST")
@@ -109,13 +109,13 @@ void gem::hw::amc13::AMC13ManagerWeb::monitorPage(xgi::Input *in, xgi::Output *o
         s->Report(level,*out);
       } else {
         std::string msg = "Unable to obtain pointer to AMC13 device: " + currentState;
-        WARN("AMC13ManagerWeb:: " << msg);
+        CMSGEMOS_WARN("AMC13ManagerWeb:: " << msg);
         XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem, msg);
       }
     } catch (const gem::hw::amc13::exception::HardwareProblem& e) {
-      WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
+      CMSGEMOS_WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
     } catch (const std::exception& e) {
-      WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
+      CMSGEMOS_WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
     }
 
   *out << "        </span>" << std::endl;
@@ -127,19 +127,19 @@ void gem::hw::amc13::AMC13ManagerWeb::monitorPage(xgi::Input *in, xgi::Output *o
 void gem::hw::amc13::AMC13ManagerWeb::expertPage(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("AMC13ManagerWeb::expertPage");
+  CMSGEMOS_DEBUG("AMC13ManagerWeb::expertPage");
 }
 
 void gem::hw::amc13::AMC13ManagerWeb::applicationPage(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("AMC13ManagerWeb::applicationPage");
+  CMSGEMOS_DEBUG("AMC13ManagerWeb::applicationPage");
 }
 
 void gem::hw::amc13::AMC13ManagerWeb::jsonUpdate(xgi::Input *in, xgi::Output *out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("AMC13ManagerWeb::jsonUpdate");
+  CMSGEMOS_DEBUG("AMC13ManagerWeb::jsonUpdate");
   updateStatus(out);
 }
 
@@ -150,20 +150,20 @@ void gem::hw::amc13::AMC13ManagerWeb::setDisplayLevel(xgi::Input *in)
   try {
     cgicc::Cgicc cgi(in);
     int radio_i       = cgi["amc13statuslevel"]->getIntegerValue();
-    DEBUG("AMC13ManagerWeb::radio button value is " << radio_i);
+    CMSGEMOS_DEBUG("AMC13ManagerWeb::radio button value is " << radio_i);
     level = static_cast<size_t>(radio_i);
-    DEBUG("AMC13ManagerWeb::setting AMC13 display status info to " << level);
+    CMSGEMOS_DEBUG("AMC13ManagerWeb::setting AMC13 display status info to " << level);
   } catch (const xgi::exception::Exception& e) {
     level = 2;
-    WARN("AMC13ManagerWeb::Caught xgi::exception " << e.what());
+    CMSGEMOS_WARN("AMC13ManagerWeb::Caught xgi::exception " << e.what());
     // XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
     level = 2;
-    WARN("AMC13ManagerWeb::Caught std::exception " << e.what());
+    CMSGEMOS_WARN("AMC13ManagerWeb::Caught std::exception " << e.what());
     // XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (...) {
     level = 2;
-    WARN("AMC13ManagerWeb::Caught unknown exception");
+    CMSGEMOS_WARN("AMC13ManagerWeb::Caught unknown exception");
     // XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -182,14 +182,14 @@ void gem::hw::amc13::AMC13ManagerWeb::updateStatus(xgi::Output *out)
         s->Report(level,*out);
       } else {
         std::string msg = "Unable to obtain pointer to AMC13 device: " + currentState;
-        WARN("AMC13ManagerWeb:: " << msg);
+        CMSGEMOS_WARN("AMC13ManagerWeb:: " << msg);
         XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem, msg);
       }
     } catch (const gem::hw::amc13::exception::HardwareProblem& e) {
-      WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
+      CMSGEMOS_WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
       *out << "AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what();
     } catch (const std::exception& e) {
-      WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
+      CMSGEMOS_WARN("AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what());
       *out << "AMC13ManagerWeb::Unable to display the AMC13 status page: " << e.what();
     }
 }

--- a/gemhardware/src/common/amc13/AMC13Readout.cc
+++ b/gemhardware/src/common/amc13/AMC13Readout.cc
@@ -21,7 +21,7 @@ gem::hw::amc13::AMC13Readout::AMC13Readout(xdaq::ApplicationStub* stub)
   m_crateID(0),
   m_slot(0)
 {
-  DEBUG("AMC13Readout ctor begin");
+  CMSGEMOS_DEBUG("AMC13Readout ctor begin");
   p_appInfoSpace->fireItemAvailable("CardName",       &m_cardName);
   p_appInfoSpace->fireItemAvailable("crateID",        &m_crateID );
   p_appInfoSpace->fireItemAvailable("slot",           &m_slot    );
@@ -34,7 +34,7 @@ gem::hw::amc13::AMC13Readout::AMC13Readout(xdaq::ApplicationStub* stub)
   p_appInfoSpace->addItemChangedListener( "crateID",  this);
   p_appInfoSpace->addItemChangedListener( "slot",     this);
 
-  DEBUG("AMC13Readout::AMC13Readout() "                        << std::endl
+  CMSGEMOS_DEBUG("AMC13Readout::AMC13Readout() "                        << std::endl
         << " m_cardName:"       << m_cardName.toString()       << std::endl
         << " m_deviceName:"     << m_deviceName.toString()     << std::endl
         << " m_connectionFile:" << m_connectionFile.toString() << std::endl
@@ -44,7 +44,7 @@ gem::hw::amc13::AMC13Readout::AMC13Readout(xdaq::ApplicationStub* stub)
         );
   cnt = 0;
   nwrote_global = 0;
-  DEBUG("AMC13Readout ctor end");
+  CMSGEMOS_DEBUG("AMC13Readout ctor end");
 }
 
 gem::hw::amc13::AMC13Readout::~AMC13Readout()
@@ -54,11 +54,11 @@ gem::hw::amc13::AMC13Readout::~AMC13Readout()
 void gem::hw::amc13::AMC13Readout::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("AMC13Readout::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("AMC13Readout::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
   }
 
-  DEBUG("AMC13Readout::actionPerformed() " << event.type()     << std::endl
+  CMSGEMOS_DEBUG("AMC13Readout::actionPerformed() " << event.type()     << std::endl
         << " m_cardName:"       << m_cardName.toString()       << std::endl
         << " m_deviceName:"     << m_deviceName.toString()     << std::endl
         << " m_connectionFile:" << m_connectionFile.toString() << std::endl
@@ -73,7 +73,7 @@ void gem::hw::amc13::AMC13Readout::actionPerformed(xdata::Event& event)
 void gem::hw::amc13::AMC13Readout::initializeAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  INFO("AMC13Readout::initializeAction begin");
+  CMSGEMOS_INFO("AMC13Readout::initializeAction begin");
   //hcal has a pre-init, what is the reason to not do everything in initialize?
   std::string connection  = "${GEM_ADDRESS_TABLE_PATH}/"+m_connectionFile.toString();
   //std::string cardname    = toolbox::toString("gem.shelf%02d.amc13",m_crateID);
@@ -81,28 +81,28 @@ void gem::hw::amc13::AMC13Readout::initializeAction()
 
   try {
     //gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_amc13Lock);
-    DEBUG("Trying to create connection to " << cardName << " in " << connection);
+    CMSGEMOS_DEBUG("Trying to create connection to " << cardName << " in " << connection);
     //p_amc13 = new ::amc13::AMC13(connection, cardName+".T1", cardName+".T2");
     p_amc13 = std::make_shared< ::amc13::AMC13>(connection, cardName+".T1", cardName+".T2");
   } catch (uhal::exception::exception & e) {
     std::stringstream msg;
     msg << "AMC13Readout::initializeAction  failed, caught uhal::exception: "
         << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem,msg.str());
   } catch (std::exception& e) {
     std::stringstream msg;
     msg << "AMC13Readout::initializeAction  failed, caught std::exception: "
         << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem,msg.str());
   } catch (...) {
     std::stringstream msg;
     msg << "AMC13Readout::initializeAction  failed (unknown exception)";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::HardwareProblem,msg.str());
   }
-  DEBUG("AMC13Readout::initializeAction connected");
+  CMSGEMOS_DEBUG("AMC13Readout::initializeAction connected");
 
   gem::readout::GEMReadoutApplication::initializeAction();
 }
@@ -110,7 +110,7 @@ void gem::hw::amc13::AMC13Readout::initializeAction()
 void gem::hw::amc13::AMC13Readout::configureAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  DEBUG("AMC13Readout::configureAction begin");
+  CMSGEMOS_DEBUG("AMC13Readout::configureAction begin");
   // grab these from the config, updated through SOAP too
   //m_outFileName  = m_readoutSettings.bag.fileName.toString();
   gem::readout::GEMReadoutApplication::configureAction();
@@ -119,7 +119,7 @@ void gem::hw::amc13::AMC13Readout::configureAction()
 void gem::hw::amc13::AMC13Readout::startAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  DEBUG("AMC13Readout::startAction begin");
+  CMSGEMOS_DEBUG("AMC13Readout::startAction begin");
   cnt = 0;
   nwrote_global = 0;
   gem::readout::GEMReadoutApplication::startAction();
@@ -128,35 +128,35 @@ void gem::hw::amc13::AMC13Readout::startAction()
 void gem::hw::amc13::AMC13Readout::pauseAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  DEBUG("AMC13Readout::pauseAction begin");
+  CMSGEMOS_DEBUG("AMC13Readout::pauseAction begin");
   gem::readout::GEMReadoutApplication::pauseAction();
 }
 
 void gem::hw::amc13::AMC13Readout::resumeAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  DEBUG("AMC13Readout::resumeAction begin");
+  CMSGEMOS_DEBUG("AMC13Readout::resumeAction begin");
   gem::readout::GEMReadoutApplication::resumeAction();
 }
 
 void gem::hw::amc13::AMC13Readout::stopAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  DEBUG("AMC13Readout::stopAction begin");
+  CMSGEMOS_DEBUG("AMC13Readout::stopAction begin");
   gem::readout::GEMReadoutApplication::stopAction();
 }
 
 void gem::hw::amc13::AMC13Readout::haltAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  DEBUG("AMC13Readout::haltAction begin");
+  CMSGEMOS_DEBUG("AMC13Readout::haltAction begin");
   gem::readout::GEMReadoutApplication::haltAction();
 }
 
 void gem::hw::amc13::AMC13Readout::resetAction()
   throw (gem::hw::amc13::exception::Exception)
 {
-  DEBUG("AMC13Readout::resetAction begin");
+  CMSGEMOS_DEBUG("AMC13Readout::resetAction begin");
   gem::readout::GEMReadoutApplication::resetAction();
 }
 
@@ -170,17 +170,17 @@ int gem::hw::amc13::AMC13Readout::readout(unsigned int expected,
   } catch (amc13Exception const& e) {
     std::stringstream msg;
     msg << "AMC13Readout::readout error " << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
   } catch (std::exception const& e) {
     std::stringstream msg;
     msg << "AMC13Readout::readout error" << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
   } catch (...) {
     std::stringstream msg;
     msg << "AMC13Readout::readout error (unknown exception)";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
   }
 }
@@ -188,7 +188,7 @@ int gem::hw::amc13::AMC13Readout::readout(unsigned int expected,
 
 int gem::hw::amc13::AMC13Readout::dumpData()
 {
-  DEBUG("AMC13Readout::dumpData begin");
+  CMSGEMOS_DEBUG("AMC13Readout::dumpData begin");
   size_t siz;
   int rc;
   uint64_t* pEvt;
@@ -197,29 +197,29 @@ int gem::hw::amc13::AMC13Readout::dumpData()
   //fp = fopen(m_outFileName.c_str(), "a");
   int nwrote = 0;
 
-  DEBUG("File for output open");
+  CMSGEMOS_DEBUG("File for output open");
   while (true) {
-    DEBUG("Get number of events in the buffer");
+    CMSGEMOS_DEBUG("Get number of events in the buffer");
     int nevt = 0;
     try {
       nevt = p_amc13->read( ::amc13::AMC13Simple::T1, "STATUS.MONITOR_BUFFER.UNREAD_BLOCKS");
     } catch (amc13Exception const& e) {
       std::stringstream msg;
       msg << "AMC13Readout::dumpData error " << e.what();
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
     } catch (std::exception const& e) {
       std::stringstream msg;
       msg << "AMC13Readout::dumpData error" << e.what();
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
     } catch (...) {
       std::stringstream msg;
       msg << "AMC13Readout::dumpData error (unknown exception)";
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
     }
-    DEBUG("Trying to read " << std::dec << nevt << " events" << std::endl);
+    CMSGEMOS_DEBUG("Trying to read " << std::dec << nevt << " events" << std::endl);
     if (nevt) {
       std::stringstream chunkfilename;
       chunkfilename << m_outFileName.substr(0,m_outFileName.length()-4)
@@ -228,23 +228,23 @@ int gem::hw::amc13::AMC13Readout::dumpData()
 
       for (int i = 0; i < nevt; i++) {
         if ( (i % 100) == 0)
-          DEBUG("calling readEvent " << std::dec << i << "..." << std::endl);
+          CMSGEMOS_DEBUG("calling readEvent " << std::dec << i << "..." << std::endl);
         try {
           pEvt = p_amc13->readEvent(siz, rc);
         } catch (amc13Exception const& e) {
           std::stringstream msg;
           msg << "AMC13Readout::readout error " << e.what();
-          ERROR(msg.str());
+          CMSGEMOS_ERROR(msg.str());
           XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
         } catch (std::exception const& e) {
           std::stringstream msg;
           msg << "AMC13Readout::readout error" << e.what();
-          ERROR(msg.str());
+          CMSGEMOS_ERROR(msg.str());
           XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
         } catch (...) {
           std::stringstream msg;
           msg << "AMC13Readout::readout error (unknown exception)";
-          ERROR(msg.str());
+          CMSGEMOS_ERROR(msg.str());
           XCEPT_RAISE(gem::hw::amc13::exception::ReadoutProblem,msg.str());
         }
         if (rc == 0 && siz > 0 && pEvt != NULL) {
@@ -253,7 +253,7 @@ int gem::hw::amc13::AMC13Readout::dumpData()
           ++nwrote;
           ++nwrote_global;
         } else {
-          DEBUG("No more events" << std::endl);
+          CMSGEMOS_DEBUG("No more events" << std::endl);
           break;
         }
         if (pEvt)
@@ -267,11 +267,11 @@ int gem::hw::amc13::AMC13Readout::dumpData()
       }
     }
     if (nevt == 0) {
-      DEBUG("Monitor buffer empty" << std::endl);
+      CMSGEMOS_DEBUG("Monitor buffer empty" << std::endl);
       break;
     }
   }
-  DEBUG("Closing file" << std::endl);
+  CMSGEMOS_DEBUG("Closing file" << std::endl);
   // fclose(fp);
   return nwrote;
 }

--- a/gemhardware/src/common/ctp7/CTP7Manager.cc
+++ b/gemhardware/src/common/ctp7/CTP7Manager.cc
@@ -69,10 +69,10 @@ gem::hw::ctp7::CTP7Manager::CTP7Manager(xdaq::ApplicationStub* stub) :
   xgi::bind(this, &CTP7Manager::dumpCTP7FIFO, "dumpCTP7FIFO");
 
   // initialize the CTP7 application objects
-  DEBUG("CTP7Manager::Connecting to the CTP7ManagerWeb interface");
+  CMSGEMOS_DEBUG("CTP7Manager::Connecting to the CTP7ManagerWeb interface");
   p_gemWebInterface = new gem::hw::ctp7::CTP7ManagerWeb(this);
   // p_gemMonitor      = new gem::hw::ctp7::CTP7HwMonitor(this);
-  DEBUG("CTP7Manager::done");
+  CMSGEMOS_DEBUG("CTP7Manager::done");
 
   // set up the info hwCfgInfoSpace
   init();
@@ -89,31 +89,31 @@ std::vector<uint32_t> gem::hw::ctp7::CTP7Manager::dumpCTP7FIFO(int const& ctp7)
 {
   std::vector<uint32_t> dump;
   if (ctp7 < 0 || ctp7 > 11) {
-    WARN("CTP7Manager::dumpCTP7FIFO Specified invalid CTP7 card " << ctp7+1);
+    CMSGEMOS_WARN("CTP7Manager::dumpCTP7FIFO Specified invalid CTP7 card " << ctp7+1);
     return dump;
   } else if (!m_ctp7s.at(ctp7)) {
-    WARN("CTP7Manager::dumpCTP7FIFO Specified CTP7 card " << ctp7+1
+    CMSGEMOS_WARN("CTP7Manager::dumpCTP7FIFO Specified CTP7 card " << ctp7+1
          << " is not connected");
     return dump;
   //} else if (!(m_ctp7s.at(ctp7)->hasTrackingData(0))) {
-  //  WARN("CTP7Manager::dumpCTP7FIFO Specified CTP7 card " << ctp7
+  //  CMSGEMOS_WARN("CTP7Manager::dumpCTP7FIFO Specified CTP7 card " << ctp7
   //       << " has no tracking data in the FIFO");
   //  return dump;
   }
 
   try {
-    INFO("CTP7Manager::dumpCTP7FIFO Dumping FIFO for specified CTP7 card " << ctp7+1);
+    CMSGEMOS_INFO("CTP7Manager::dumpCTP7FIFO Dumping FIFO for specified CTP7 card " << ctp7+1);
     return m_ctp7s.at(ctp7)->getTrackingData(0, 24);
   } catch (gem::hw::ctp7::exception::Exception const& ex) {
-    ERROR("CTP7Manager::dumpCTP7FIFO Unable to read tracking data from CTP7 " << ctp7+1
+    CMSGEMOS_ERROR("CTP7Manager::dumpCTP7FIFO Unable to read tracking data from CTP7 " << ctp7+1
           << " FIFO, caught exception " << ex.what());
     return dump;
   } catch (std::exception const& ex) {
-    ERROR("CTP7Manager::dumpCTP7FIFO Unable to read tracking data from CTP7 " << ctp7+1
+    CMSGEMOS_ERROR("CTP7Manager::dumpCTP7FIFO Unable to read tracking data from CTP7 " << ctp7+1
           << " FIFO,  caught exception " << ex.what());
     return dump;
   } catch (...) {
-    ERROR("CTP7Manager::dumpCTP7FIFO Unable to read tracking data from CTP7 " << ctp7+1
+    CMSGEMOS_ERROR("CTP7Manager::dumpCTP7FIFO Unable to read tracking data from CTP7 " << ctp7+1
           << " FIFO");
     return dump;
   }
@@ -125,16 +125,16 @@ uint16_t gem::hw::ctp7::CTP7Manager::parseAMCEnableList(std::string const& enabl
   std::vector<std::string> slots;
 
   boost::split(slots, enableList, boost::is_any_of(", "), boost::token_compress_on);
-  DEBUG("CTP7Manager::AMC input enable list is " << enableList);
+  CMSGEMOS_DEBUG("CTP7Manager::AMC input enable list is " << enableList);
   // would be great to multithread this portion
   for (auto slot = slots.begin(); slot != slots.end(); ++slot) {
-    DEBUG("CTP7Manager::slot is " << *slot);
+    CMSGEMOS_DEBUG("CTP7Manager::slot is " << *slot);
     if (slot->find('-') != std::string::npos) {  // found a possible range
-      DEBUG("CTP7Manager::found a hyphen in " << *slot);
+      CMSGEMOS_DEBUG("CTP7Manager::found a hyphen in " << *slot);
       std::vector<std::string> range;
       boost::split(range, *slot, boost::is_any_of("-"), boost::token_compress_on);
       if (range.size() > 2) {
-        WARN("CTP7Manager::parseAMCEnableList::Found poorly formatted range " << *slot);
+        CMSGEMOS_WARN("CTP7Manager::parseAMCEnableList::Found poorly formatted range " << *slot);
         continue;
       }
       if (isValidSlotNumber(range.at(0)) && isValidSlotNumber(range.at(1))) {
@@ -145,11 +145,11 @@ uint16_t gem::hw::ctp7::CTP7Manager::parseAMCEnableList(std::string const& enabl
         ss1 >> max;
 
         if (min == max) {
-          WARN("CTP7Manager::parseAMCEnableList::Found poorly formatted range " << *slot);
+          CMSGEMOS_WARN("CTP7Manager::parseAMCEnableList::Found poorly formatted range " << *slot);
           continue;
         }
         if (min > max) {  // elements in the wrong order
-          WARN("CTP7Manager::parseAMCEnableList::Found poorly formatted range " << *slot);
+          CMSGEMOS_WARN("CTP7Manager::parseAMCEnableList::Found poorly formatted range " << *slot);
           continue;
         }
 
@@ -158,14 +158,14 @@ uint16_t gem::hw::ctp7::CTP7Manager::parseAMCEnableList(std::string const& enabl
         }  //  end loop over range of list
       }  // end check on valid values
     } else {  //not a range
-      DEBUG("CTP7Manager::found no hyphen in " << *slot);
+      CMSGEMOS_DEBUG("CTP7Manager::found no hyphen in " << *slot);
       if (slot->length() > 2) {
-        WARN("CTP7Manager::parseAMCEnableList::Found longer value than expected (1-12) " << *slot);
+        CMSGEMOS_WARN("CTP7Manager::parseAMCEnableList::Found longer value than expected (1-12) " << *slot);
         continue;
       }
 
       if (!isValidSlotNumber(*slot)) {
-        WARN("CTP7Manager::parseAMCEnableList::Found invalid value " << *slot);
+        CMSGEMOS_WARN("CTP7Manager::parseAMCEnableList::Found invalid value " << *slot);
         continue;
       }
       std::stringstream ss(*slot);
@@ -174,7 +174,7 @@ uint16_t gem::hw::ctp7::CTP7Manager::parseAMCEnableList(std::string const& enabl
       slotMask |= (0x1 << (slotNum-1));
     }  // done processing single values
   }  // done looping over extracted values
-  DEBUG("CTP7Manager::parseAMCEnableList::Parsed enabled list 0x" << std::hex << slotMask << std::dec);
+  CMSGEMOS_DEBUG("CTP7Manager::parseAMCEnableList::Parsed enabled list 0x" << std::hex << slotMask << std::dec);
   return slotMask;
 }
 
@@ -184,14 +184,14 @@ bool gem::hw::ctp7::CTP7Manager::isValidSlotNumber(std::string const& s)
     int i_val;
     i_val = std::stoi(s);
     if (!(i_val > 0 && i_val < 13)) {
-      ERROR("CTP7Manager::isValidSlotNumber::Found value outside expected (1-12) " << i_val);
+      CMSGEMOS_ERROR("CTP7Manager::isValidSlotNumber::Found value outside expected (1-12) " << i_val);
       return false;
     }
   } catch (std::invalid_argument const& err) {
-    ERROR("CTP7Manager::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
+    CMSGEMOS_ERROR("CTP7Manager::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
     return false;
   } catch (std::out_of_range const& err) {
-    ERROR("CTP7Manager::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
+    CMSGEMOS_ERROR("CTP7Manager::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
     return false;
   }
   // if you get here, should be possible to parse as an integer in the range [1,12]
@@ -202,16 +202,16 @@ bool gem::hw::ctp7::CTP7Manager::isValidSlotNumber(std::string const& s)
 void gem::hw::ctp7::CTP7Manager::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("CTP7Manager::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("CTP7Manager::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
     m_amcEnableMask = parseAMCEnableList(m_amcSlots.toString());
-    INFO("CTP7Manager::Parsed AMCEnableList m_amcSlots = " << m_amcSlots.toString()
+    CMSGEMOS_INFO("CTP7Manager::Parsed AMCEnableList m_amcSlots = " << m_amcSlots.toString()
          << " to slotMask 0x" << std::hex << m_amcEnableMask << std::dec);
 
     // how to handle passing in various values nested in a vector in a bag
     for (auto slot = m_ctp7Info.begin(); slot != m_ctp7Info.end(); ++slot) {
       if (slot->bag.present.value_)
-        DEBUG("CTP7Manager::Found attribute:" << slot->bag.toString());
+        CMSGEMOS_DEBUG("CTP7Manager::Found attribute:" << slot->bag.toString());
     }
     // p_gemMonitor->startMonitoring();
   }
@@ -228,13 +228,13 @@ void gem::hw::ctp7::CTP7Manager::init()
 void gem::hw::ctp7::CTP7Manager::initializeAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  DEBUG("CTP7Manager::initializeAction begin");
+  CMSGEMOS_DEBUG("CTP7Manager::initializeAction begin");
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
-    DEBUG("CTP7Manager::looping over slots(" << (slot+1) << ") and finding expected cards");
+    CMSGEMOS_DEBUG("CTP7Manager::looping over slots(" << (slot+1) << ") and finding expected cards");
     CTP7Info& info = m_ctp7Info[slot].bag;
     if ((m_amcEnableMask >> (slot)) & 0x1) {
-      DEBUG("CTP7Manager::info:" << info.toString());
-      DEBUG("CTP7Manager::expect a card in slot " << (slot+1));
+      CMSGEMOS_DEBUG("CTP7Manager::info:" << info.toString());
+      CMSGEMOS_DEBUG("CTP7Manager::expect a card in slot " << (slot+1));
       info.slotID  = slot+1;
       info.present = true;
       // actually check presence? this just says that we expect it to be there
@@ -253,8 +253,8 @@ void gem::hw::ctp7::CTP7Manager::initializeAction()
     if (!info.present)
       continue;
 
-    DEBUG("CTP7Manager::info:" << info.toString());
-    DEBUG("CTP7Manager::creating pointer to card in slot " << (slot+1));
+    CMSGEMOS_DEBUG("CTP7Manager::info:" << info.toString());
+    CMSGEMOS_DEBUG("CTP7Manager::creating pointer to card in slot " << (slot+1));
 
     // create the cfgInfoSpace object (qualified vs non?)
     std::string deviceName = toolbox::toString("gem.shelf%02d.ctp7%02d",
@@ -263,19 +263,19 @@ void gem::hw::ctp7::CTP7Manager::initializeAction()
     toolbox::net::URN hwCfgURN("urn:gem:hw:"+deviceName);
 
     if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-      DEBUG("CTP7Manager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
+      CMSGEMOS_DEBUG("CTP7Manager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
       is_ctp7s.at(slot) = is_toolbox_ptr(new gem::base::utils::GEMInfoSpaceToolBox(this,
                                                                                    xdata::getInfoSpaceFactory()->get(hwCfgURN.toString()),
                                                                                    true));
     } else {
-      DEBUG("CTP7Manager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
+      CMSGEMOS_DEBUG("CTP7Manager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
       // is_ctp7s.at(slot) = xdata::getInfoSpaceFactory()->create(hwCfgURN.toString());
       is_ctp7s.at(slot) = is_toolbox_ptr(new gem::base::utils::GEMInfoSpaceToolBox(this,
                                                                                    hwCfgURN.toString(),
                                                                                    true));
     }
 
-    DEBUG("CTP7Manager::exporting config parameters into infospace");
+    CMSGEMOS_DEBUG("CTP7Manager::exporting config parameters into infospace");
     is_ctp7s.at(slot)->createString("ControlHubAddress", info.controlHubAddress.value_, &(info.controlHubAddress),
                                  GEMUpdateType::NOUPDATE);
     is_ctp7s.at(slot)->createString("IPBusProtocol",     info.ipBusProtocol.value_    , &(info.ipBusProtocol),
@@ -289,15 +289,15 @@ void gem::hw::ctp7::CTP7Manager::initializeAction()
     is_ctp7s.at(slot)->createUInt32("IPBusPort",         info.ipBusPort.value_        , &(info.ipBusPort),
                                  GEMUpdateType::NOUPDATE);
 
-    DEBUG("CTP7Manager::InfoSpace found item: ControlHubAddress " << is_ctp7s.at(slot)->getString("ControlHubAddress"));
-    DEBUG("CTP7Manager::InfoSpace found item: IPBusProtocol "     << is_ctp7s.at(slot)->getString("IPBusProtocol")    );
-    DEBUG("CTP7Manager::InfoSpace found item: DeviceIPAddress "   << is_ctp7s.at(slot)->getString("DeviceIPAddress")  );
-    DEBUG("CTP7Manager::InfoSpace found item: AddressTable "      << is_ctp7s.at(slot)->getString("AddressTable")     );
-    DEBUG("CTP7Manager::InfoSpace found item: ControlHubPort "    << is_ctp7s.at(slot)->getUInt32("ControlHubPort")   );
-    DEBUG("CTP7Manager::InfoSpace found item: IPBusPort "         << is_ctp7s.at(slot)->getUInt32("IPBusPort")        );
+    CMSGEMOS_DEBUG("CTP7Manager::InfoSpace found item: ControlHubAddress " << is_ctp7s.at(slot)->getString("ControlHubAddress"));
+    CMSGEMOS_DEBUG("CTP7Manager::InfoSpace found item: IPBusProtocol "     << is_ctp7s.at(slot)->getString("IPBusProtocol")    );
+    CMSGEMOS_DEBUG("CTP7Manager::InfoSpace found item: DeviceIPAddress "   << is_ctp7s.at(slot)->getString("DeviceIPAddress")  );
+    CMSGEMOS_DEBUG("CTP7Manager::InfoSpace found item: AddressTable "      << is_ctp7s.at(slot)->getString("AddressTable")     );
+    CMSGEMOS_DEBUG("CTP7Manager::InfoSpace found item: ControlHubPort "    << is_ctp7s.at(slot)->getUInt32("ControlHubPort")   );
+    CMSGEMOS_DEBUG("CTP7Manager::InfoSpace found item: IPBusPort "         << is_ctp7s.at(slot)->getUInt32("IPBusPort")        );
 
     try {
-      DEBUG("CTP7Manager::obtaining pointer to HwCTP7");
+      CMSGEMOS_DEBUG("CTP7Manager::obtaining pointer to HwCTP7");
       // m_ctp7s.at(slot) = ctp7_shared_ptr(new gem::hw::ctp7::HwCTP7(info.crateID.value_,info.slotID.value_));
       m_ctp7s.at(slot) = ctp7_shared_ptr(new gem::hw::ctp7::HwCTP7(deviceName, m_connectionFile.toString()));
       if (m_ctp7s.at(slot)->isHwConnected()) {
@@ -309,20 +309,20 @@ void gem::hw::ctp7::CTP7Manager::initializeAction()
         m_ctp7Monitors.at(slot)->setupHwMonitoring();
         m_ctp7Monitors.at(slot)->startMonitoring();
       } else {
-        ERROR("CTP7Manager:: unable to communicate with CTP7 in slot " << slot);
+        CMSGEMOS_ERROR("CTP7Manager:: unable to communicate with CTP7 in slot " << slot);
         XCEPT_RAISE(gem::hw::ctp7::exception::Exception, "initializeAction failed");
       }
     } catch (gem::hw::ctp7::exception::Exception const& ex) {
-      ERROR("CTP7Manager::caught exception " << ex.what());
+      CMSGEMOS_ERROR("CTP7Manager::caught exception " << ex.what());
       XCEPT_RAISE(gem::hw::ctp7::exception::Exception, "initializeAction failed");
     } catch (toolbox::net::exception::MalformedURN const& ex) {
-      ERROR("CTP7Manager::caught exception " << ex.what());
+      CMSGEMOS_ERROR("CTP7Manager::caught exception " << ex.what());
       XCEPT_RAISE(gem::hw::ctp7::exception::Exception, "initializeAction failed");
     } catch (std::exception const& ex) {
-      ERROR("CTP7Manager::caught exception " << ex.what());
+      CMSGEMOS_ERROR("CTP7Manager::caught exception " << ex.what());
       XCEPT_RAISE(gem::hw::ctp7::exception::Exception, "initializeAction failed");
     }
-    DEBUG("CTP7Manager::connected");
+    CMSGEMOS_DEBUG("CTP7Manager::connected");
     // set the web view to be empty or grey
     // if (!info.present.value_) continue;
     // p_gemWebInterface->ctp7InSlot(slot);
@@ -335,22 +335,22 @@ void gem::hw::ctp7::CTP7Manager::initializeAction()
       continue;
 
     if (m_ctp7s.at(slot)->isHwConnected()) {
-      DEBUG("CTP7Manager::connected a card in slot " << (slot+1));
+      CMSGEMOS_DEBUG("CTP7Manager::connected a card in slot " << (slot+1));
     } else {
-      ERROR("CTP7Manager::CTP7 in slot " << (slot+1) << " is not connected");
+      CMSGEMOS_ERROR("CTP7Manager::CTP7 in slot " << (slot+1) << " is not connected");
       fireEvent("Fail");
       // maybe raise exception so as to not continue with other cards? let's just return for the moment
       return;
     }
   }
   usleep(10000); // just for testing the timing of different applications
-  DEBUG("CTP7Manager::initializeAction end");
+  CMSGEMOS_DEBUG("CTP7Manager::initializeAction end");
 }
 
 void gem::hw::ctp7::CTP7Manager::configureAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  DEBUG("CTP7Manager::configureAction");
+  CMSGEMOS_DEBUG("CTP7Manager::configureAction");
 
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     usleep(5000); // just for testing the timing of different applications
@@ -370,7 +370,7 @@ void gem::hw::ctp7::CTP7Manager::configureAction()
       m_ctp7s.at(slot)->setDAQLinkRunParameters(0xfaac);
 
       // should FIFOs be emptied in configure or at start?
-      DEBUG("CTP7Manager::emptying trigger/tracking data FIFOs");
+      CMSGEMOS_DEBUG("CTP7Manager::emptying trigger/tracking data FIFOs");
       for (unsigned gtx = 0; gtx < HwCTP7::N_GTX; ++gtx) {
         // m_ctp7s.at(slot)->flushTriggerFIFO(gtx);
         m_ctp7s.at(slot)->flushFIFO(gtx);
@@ -381,37 +381,37 @@ void gem::hw::ctp7::CTP7Manager::configureAction()
       // setup run mode?
       // setup DAQ mode?
     } else {
-      ERROR("CTP7Manager::CTP7 in slot " << (slot+1) << " is not connected");
+      CMSGEMOS_ERROR("CTP7Manager::CTP7 in slot " << (slot+1) << " is not connected");
       fireEvent("Fail");
       // maybe raise exception so as to not continue with other cards?
     }
   }
 
-  DEBUG("CTP7Manager::configureAction end");
+  CMSGEMOS_DEBUG("CTP7Manager::configureAction end");
 }
 
 void gem::hw::ctp7::CTP7Manager::startAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
 
-  INFO("gem::hw::ctp7::CTP7Manager::startAction begin");
+  CMSGEMOS_INFO("gem::hw::ctp7::CTP7Manager::startAction begin");
   // what is required for starting the CTP7?
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     usleep(500);
-    DEBUG("CTP7Manager::looping over slots(" << (slot+1) << ") and finding infospace items");
+    CMSGEMOS_DEBUG("CTP7Manager::looping over slots(" << (slot+1) << ") and finding infospace items");
     CTP7Info& info = m_ctp7Info[slot].bag;
 
     if (!info.present)
       continue;
 
     if (m_ctp7s.at(slot)->isHwConnected()) {
-      DEBUG("connected a card in slot " << (slot+1));
+      CMSGEMOS_DEBUG("connected a card in slot " << (slot+1));
       // enable the DAQ
       m_ctp7s.at(slot)->enableDAQLink();
       m_ctp7s.at(slot)->setL1AInhibit(0x0);
       usleep(100); // just for testing the timing of different applications
     } else {
-      ERROR("CTP7 in slot " << (slot+1) << " is not connected");
+      CMSGEMOS_ERROR("CTP7 in slot " << (slot+1) << " is not connected");
       fireEvent("Fail");
       // maybe raise exception so as to not continue with other cards? let's just return for the moment
       return;
@@ -424,7 +424,7 @@ void gem::hw::ctp7::CTP7Manager::startAction()
     */
   }
   usleep(10000);
-  INFO("gem::hw::ctp7::CTP7Manager::startAction end");
+  CMSGEMOS_INFO("gem::hw::ctp7::CTP7Manager::startAction end");
 }
 
 void gem::hw::ctp7::CTP7Manager::pauseAction()
@@ -444,7 +444,7 @@ void gem::hw::ctp7::CTP7Manager::resumeAction()
 void gem::hw::ctp7::CTP7Manager::stopAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("gem::hw::ctp7::CTP7Manager::stopAction begin");
+  CMSGEMOS_INFO("gem::hw::ctp7::CTP7Manager::stopAction begin");
   // what is required for stopping the CTP7?
   usleep(10000);  // just for testing the timing of different applications
 }
@@ -462,10 +462,10 @@ void gem::hw::ctp7::CTP7Manager::resetAction()
   // what is required for resetting the CTP7?
   // unregister listeners and items in info spaces
 
-  DEBUG("CTP7Manager::resetAction begin");
+  CMSGEMOS_DEBUG("CTP7Manager::resetAction begin");
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     usleep(500);  // just for testing the timing of different applications
-    DEBUG("CTP7Manager::looping over slots(" << (slot+1) << ") and finding infospace items");
+    CMSGEMOS_DEBUG("CTP7Manager::looping over slots(" << (slot+1) << ") and finding infospace items");
     CTP7Info& info = m_ctp7Info[slot].bag;
 
     if (!info.present)
@@ -475,13 +475,13 @@ void gem::hw::ctp7::CTP7Manager::resetAction()
     if (m_ctp7Monitors.at(slot))
       m_ctp7Monitors.at(slot)->reset();
 
-    DEBUG("CTP7Manager::looking for hwCfgInfoSpace items for CTP7 in slot " << (slot+1));
+    CMSGEMOS_DEBUG("CTP7Manager::looking for hwCfgInfoSpace items for CTP7 in slot " << (slot+1));
     toolbox::net::URN hwCfgURN("urn:gem:hw:"+toolbox::toString("gem.shelf%02d.ctp7%02d",
                                                                info.crateID.value_,
                                                                info.slotID.value_));
 
     if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-      DEBUG("CTP7Manager::revoking config parameters infospace");
+      CMSGEMOS_DEBUG("CTP7Manager::revoking config parameters infospace");
 
       // reset the hw infospace toolbox
       is_ctp7s.at(slot)->reset();
@@ -505,7 +505,7 @@ void gem::hw::ctp7::CTP7Manager::resetAction()
       if (is_ctp7s.at(slot)->getInfoSpace()->hasItem("IPBusPort"))
         is_ctp7s.at(slot)->getInfoSpace()->fireItemRevoked("IPBusPort");
     } else {
-      DEBUG("CTP7Manager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
+      CMSGEMOS_DEBUG("CTP7Manager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
       continue;
     }
   }

--- a/gemhardware/src/common/ctp7/CTP7ManagerWeb.cc
+++ b/gemhardware/src/common/ctp7/CTP7ManagerWeb.cc
@@ -23,7 +23,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::webDefault(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
   if (p_gemFSMApp)
-    DEBUG("current state is" << dynamic_cast<gem::hw::ctp7::CTP7Manager*>(p_gemFSMApp)->getCurrentState());
+    CMSGEMOS_DEBUG("current state is" << dynamic_cast<gem::hw::ctp7::CTP7Manager*>(p_gemFSMApp)->getCurrentState());
   *out << cgicc::script().set("type", "text/javascript")
     .set("src", "/gemdaq/gemhardware/html/scripts/ctp7/ctp7.js")
        << cgicc::script() << std::endl;
@@ -35,7 +35,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::webDefault(xgi::Input* in, xgi::Output* out)
 void gem::hw::ctp7::CTP7ManagerWeb::monitorPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("CTP7ManagerWeb::monitorPage");
+  CMSGEMOS_DEBUG("CTP7ManagerWeb::monitorPage");
   *out << "    <div class=\"xdaq-tab-wrapper\">" << std::endl;
   *out << "      <div class=\"xdaq-tab\" title=\"DAQ Link Monitoring\" >"  << std::endl;
   // all monitored CTP7s in one page, or separate tabs?
@@ -52,7 +52,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::monitorPage(xgi::Input* in, xgi::Output* out
 void gem::hw::ctp7::CTP7ManagerWeb::expertPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("CTP7ManagerWeb::expertPage");
+  CMSGEMOS_DEBUG("CTP7ManagerWeb::expertPage");
   // fill this page with the expert views for the CTP7Manager
   *out << "    <div class=\"xdaq-tab-wrapper\">" << std::endl;
   *out << "      <div class=\"xdaq-tab\" title=\"Register dump page\"/>"  << std::endl;
@@ -121,7 +121,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::buildCardSummaryTable(xgi::Input* in, xgi::O
 void gem::hw::ctp7::CTP7ManagerWeb::cardPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("CTP7ManagerWeb::cardPage");
+  CMSGEMOS_DEBUG("CTP7ManagerWeb::cardPage");
   // fill this page with the card views for the CTP7Manager
   *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {
@@ -139,7 +139,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::cardPage(xgi::Input* in, xgi::Output* out)
 void gem::hw::ctp7::CTP7ManagerWeb::registerDumpPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("CTP7ManagerWeb::registerDumpPage");
+  CMSGEMOS_DEBUG("CTP7ManagerWeb::registerDumpPage");
   // dump registers for a given CTP7 and display
 }
 
@@ -147,7 +147,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::registerDumpPage(xgi::Input* in, xgi::Output
 void gem::hw::ctp7::CTP7ManagerWeb::fifoDumpPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("CTP7ManagerWeb::fifoDumpPage");
+  CMSGEMOS_DEBUG("CTP7ManagerWeb::fifoDumpPage");
   // dump tracking fifo for given number of blocks
   //*out << cgicc::form() << std::endl;//.set("method","POST").set("action",);
   // input vs. button?
@@ -193,7 +193,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::fifoDumpPage(xgi::Input* in, xgi::Output* ou
 void gem::hw::ctp7::CTP7ManagerWeb::jsonUpdate(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("CTP7ManagerWeb::jsonUpdate");
+  CMSGEMOS_DEBUG("CTP7ManagerWeb::jsonUpdate");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {
@@ -214,7 +214,7 @@ void gem::hw::ctp7::CTP7ManagerWeb::jsonUpdate(xgi::Input* in, xgi::Output* out)
 void gem::hw::ctp7::CTP7ManagerWeb::dumpCTP7FIFO(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("CTP7ManagerWeb::dumpCTP7FIFO");
+  CMSGEMOS_DEBUG("CTP7ManagerWeb::dumpCTP7FIFO");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {

--- a/gemhardware/src/common/ctp7/CTP7Monitor.cc
+++ b/gemhardware/src/common/ctp7/CTP7Monitor.cc
@@ -208,11 +208,11 @@ void gem::hw::ctp7::CTP7Monitor::updateMonitorables()
   // define how to update the desired values
   // get SYSTEM monitorables
   // can this be split into two loops, one just to do a list read, the second to fill the InfoSpace with the returned values
-  DEBUG("CTP7Monitor: Updating monitorables");
+  CMSGEMOS_DEBUG("CTP7Monitor: Updating monitorables");
   for (auto monlist = m_monitorableSetsMap.begin(); monlist != m_monitorableSetsMap.end(); ++monlist) {
-    DEBUG("CTP7Monitor: Updating monitorables in set " << monlist->first);
+    CMSGEMOS_DEBUG("CTP7Monitor: Updating monitorables in set " << monlist->first);
     for (auto monitem = monlist->second.begin(); monitem != monlist->second.end(); ++monitem) {
-      DEBUG("CTP7Monitor: Updating monitorable " << monitem->first);
+      CMSGEMOS_DEBUG("CTP7Monitor: Updating monitorable " << monitem->first);
       std::stringstream regName;
       regName << monitem->second.regname;
       uint32_t address = p_ctp7->getGEMHwInterface().getNode(regName.str()).getAddress();
@@ -252,7 +252,7 @@ void gem::hw::ctp7::CTP7Monitor::updateMonitorables()
       } else if (monitem->second.updatetype == GEMUpdateType::NOUPDATE) {
         continue;
       } else {
-        ERROR("CTP7Monitor: Unknown update type encountered");
+        CMSGEMOS_ERROR("CTP7Monitor: Unknown update type encountered");
         continue;
       }
     } // end loop over items in list
@@ -261,9 +261,9 @@ void gem::hw::ctp7::CTP7Monitor::updateMonitorables()
 
 void gem::hw::ctp7::CTP7Monitor::buildMonitorPage(xgi::Output* out)
 {
-  DEBUG("CTP7Monitor::buildMonitorPage");
+  CMSGEMOS_DEBUG("CTP7Monitor::buildMonitorPage");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
@@ -293,7 +293,7 @@ void gem::hw::ctp7::CTP7Monitor::buildMonitorPage(xgi::Output* out)
            << monitem->first
            << "</td>"   << std::endl;
 
-      DEBUG("CTP7Monitor::" << monitem->first << " formatted to "
+      CMSGEMOS_DEBUG("CTP7Monitor::" << monitem->first << " formatted to "
             << (monitem->second.infoSpace)->getFormattedItem(monitem->first,monitem->second.format));
       //this will be repeated for every CTP7Monitor in the CTP7Manager..., need a better unique ID
       *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -320,24 +320,24 @@ void gem::hw::ctp7::CTP7Monitor::buildMonitorPage(xgi::Output* out)
 void gem::hw::ctp7::CTP7Monitor::reset()
 {
   //have to get rid of the timer
-  DEBUG("GEMMonitor::reset");
+  CMSGEMOS_DEBUG("GEMMonitor::reset");
   for (auto infoSpace = m_infoSpaceMap.begin(); infoSpace != m_infoSpaceMap.end(); ++infoSpace) {
-    DEBUG("CTP7Monitor::reset removing " << infoSpace->first << " from p_timer");
+    CMSGEMOS_DEBUG("CTP7Monitor::reset removing " << infoSpace->first << " from p_timer");
     try {
       p_timer->remove(infoSpace->first);
     } catch (toolbox::task::exception::Exception& te) {
-      ERROR("CTP7Monitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
+      CMSGEMOS_ERROR("CTP7Monitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
     }
   }
   stopMonitoring();
-  DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
+  CMSGEMOS_DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
   try {
     toolbox::task::getTimerFactory()->removeTimer(m_timerName);
   } catch (toolbox::task::exception::Exception& te) {
-    ERROR("CTP7Monitor::Caught exception while removing timer " << m_timerName << " " << te.what());
+    CMSGEMOS_ERROR("CTP7Monitor::Caught exception while removing timer " << m_timerName << " " << te.what());
   }
 
-  DEBUG("CTP7Monitor::reset - clearing all maps");
+  CMSGEMOS_DEBUG("CTP7Monitor::reset - clearing all maps");
   m_infoSpaceMap.clear();
   m_infoSpaceMonitorableSetMap.clear();
   m_monitorableSetInfoSpaceMap.clear();

--- a/gemhardware/src/common/ctp7/CTP7Readout.cc
+++ b/gemhardware/src/common/ctp7/CTP7Readout.cc
@@ -44,13 +44,13 @@ gem::hw::ctp7::CTP7Readout::CTP7Readout(xdaq::ApplicationStub* stub) :
 
 gem::hw::ctp7::CTP7Readout::~CTP7Readout()
 {
-  DEBUG("CTP7Readout::destructor called");
+  CMSGEMOS_DEBUG("CTP7Readout::destructor called");
 }
 
 void gem::hw::ctp7::CTP7Readout::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("CTP7Readout::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("CTP7Readout::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
   }
   // update monitoring variables
@@ -60,27 +60,27 @@ void gem::hw::ctp7::CTP7Readout::actionPerformed(xdata::Event& event)
 void gem::hw::ctp7::CTP7Readout::initializeAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::initializeAction begin");
+  CMSGEMOS_INFO("CTP7Readout::initializeAction begin");
   try {
     p_ctp7 = ctp7_shared_ptr(new gem::hw::ctp7::HwCTP7(m_deviceName.toString(), m_connectionFile.toString()));
   } catch (gem::hw::ctp7::exception::Exception const& ex) {
-    ERROR("CTP7Readout::initializeAction caught exception " << ex.what());
+    CMSGEMOS_ERROR("CTP7Readout::initializeAction caught exception " << ex.what());
     XCEPT_RAISE(gem::hw::ctp7::exception::Exception, "initializeAction failed");
   } catch (toolbox::net::exception::MalformedURN const& ex) {
-    ERROR("CTP7Readout::initializeAction caught exception " << ex.what());
+    CMSGEMOS_ERROR("CTP7Readout::initializeAction caught exception " << ex.what());
     XCEPT_RAISE(gem::hw::ctp7::exception::Exception, "initializeAction failed");
   } catch (std::exception const& ex) {
-    ERROR("CTP7Readout::initializeAction caught exception " << ex.what());
+    CMSGEMOS_ERROR("CTP7Readout::initializeAction caught exception " << ex.what());
     XCEPT_RAISE(gem::hw::ctp7::exception::Exception, "initializeAction failed");
   }
-  DEBUG("CTP7Readout::initializeAction connected");
+  CMSGEMOS_DEBUG("CTP7Readout::initializeAction connected");
 }
 
 
 void gem::hw::ctp7::CTP7Readout::configureAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::configureAction begin");
+  CMSGEMOS_INFO("CTP7Readout::configureAction begin");
   // grab these from the config, updated through SOAP too
   m_outFileName  = m_readoutSettings.bag.fileName.toString();
   m_errFileName  = m_outFileName + "_ERR";
@@ -95,48 +95,48 @@ void gem::hw::ctp7::CTP7Readout::configureAction()
 void gem::hw::ctp7::CTP7Readout::startAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::startAction begin");
+  CMSGEMOS_INFO("CTP7Readout::startAction begin");
 }
 
 void gem::hw::ctp7::CTP7Readout::pauseAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::pauseAction begin");
+  CMSGEMOS_INFO("CTP7Readout::pauseAction begin");
 }
 
 void gem::hw::ctp7::CTP7Readout::resumeAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::resumeAction begin");
+  CMSGEMOS_INFO("CTP7Readout::resumeAction begin");
 }
 
 void gem::hw::ctp7::CTP7Readout::stopAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::stopAction begin");
+  CMSGEMOS_INFO("CTP7Readout::stopAction begin");
 }
 
 void gem::hw::ctp7::CTP7Readout::haltAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::haltAction begin");
+  CMSGEMOS_INFO("CTP7Readout::haltAction begin");
 }
 
 void gem::hw::ctp7::CTP7Readout::resetAction()
   throw (gem::hw::ctp7::exception::Exception)
 {
-  INFO("CTP7Readout::resetAction begin");
+  CMSGEMOS_INFO("CTP7Readout::resetAction begin");
 }
 
 uint32_t* gem::hw::ctp7::CTP7Readout::dumpData(uint8_t const& readout_mask)
 {
 
-  INFO("info dump data parker");
-  DEBUG("Reading out dumpData(" << (int)readout_mask << ")");
+  CMSGEMOS_INFO("info dump data parker");
+  CMSGEMOS_DEBUG("Reading out dumpData(" << (int)readout_mask << ")");
   uint32_t *point = &m_counter[0];
   m_contvfats = 0;
   uint32_t* pDu = getCTP7Data(readout_mask, m_counter);
-  DEBUG("point 0x" << std::hex << point << " pDu 0x" << pDu << std::dec);
+  CMSGEMOS_DEBUG("point 0x" << std::hex << point << " pDu 0x" << pDu << std::dec);
   if (pDu)
     for (unsigned count = 0; count < 5; ++count) m_counter[count] = *(pDu+count);
   return point;
@@ -146,17 +146,17 @@ uint32_t* gem::hw::ctp7::CTP7Readout::getCTP7Data(uint8_t const& gtx, uint32_t c
 {
   uint32_t *point = &counter[0];
 
-  DEBUG("CTP7Readout::getCTP7Data Starting while loop readout "
+  CMSGEMOS_DEBUG("CTP7Readout::getCTP7Data Starting while loop readout "
         << std::endl << "FIFO VFAT block depth 0x" << std::hex
         << p_ctp7->getFIFOVFATBlockOccupancy(gtx)
         << std::endl << "FIFO depth 0x" << std::hex
         << p_ctp7->getFIFOOccupancy(gtx)
         );
   while ( p_ctp7->getFIFOVFATBlockOccupancy(gtx) ) {
-    DEBUG("CTP7Readout::getCTP7Data initiating call to getTrackingData(gtx,"
+    CMSGEMOS_DEBUG("CTP7Readout::getCTP7Data initiating call to getTrackingData(gtx,"
           << p_ctp7->getFIFOVFATBlockOccupancy(gtx) << ")");
     std::vector<uint32_t> data = p_ctp7->getTrackingData(gtx, p_ctp7->getFIFOVFATBlockOccupancy(gtx));
-    DEBUG("CTP7Readout::getCTP7Data"
+    CMSGEMOS_DEBUG("CTP7Readout::getCTP7Data"
           << std::endl << "FIFO VFAT block depth 0x" << std::hex
           << p_ctp7->getFIFOVFATBlockOccupancy(gtx)
           << std::endl << "FIFO depth 0x" << std::hex
@@ -167,23 +167,23 @@ uint32_t* gem::hw::ctp7::CTP7Readout::getCTP7Data(uint8_t const& gtx, uint32_t c
     for (auto iword = data.begin(); iword != data.end(); ++iword) {
       contqueue++;
       //gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_queueLock);
-      DEBUG(" ::getCTP7Data pushing into queue 0x"
+      CMSGEMOS_DEBUG(" ::getCTP7Data pushing into queue 0x"
             << std::setfill('0') << std::setw(8) << std::hex << *iword << std::dec );
       m_dataque.push(*iword);
       if (contqueue%kUPDATE7 == 0 &&  contqueue != 0) {
         m_contvfats++;
-        DEBUG(" ::getCTP7Data counter " << contqueue << " contvfats " << m_contvfats
+        CMSGEMOS_DEBUG(" ::getCTP7Data counter " << contqueue << " contvfats " << m_contvfats
               << " m_dataque.size " << m_dataque.size());
       }
     }
-    DEBUG(" ::getCTP7Data end of while loop do we go again?" << std::endl
+    CMSGEMOS_DEBUG(" ::getCTP7Data end of while loop do we go again?" << std::endl
           << " FIFO VFAT block occupancy  0x" << std::hex << p_ctp7->getFIFOVFATBlockOccupancy(gtx)
           << std::endl
           << " FIFO occupancy             0x" << std::hex << p_ctp7->getFIFOOccupancy(gtx) << std::endl
           << " hasTrackingData            0x" << std::hex << p_ctp7->hasTrackingData(gtx)  << std::endl
           );
   }// while(p_ctp7->getFIFOVFATBlockOccupancy(gtx))
-  DEBUG("CTP7Readout::getCTP7Data"
+  CMSGEMOS_DEBUG("CTP7Readout::getCTP7Data"
         << std::endl
         << " FIFO VFAT block occupancy  0x" << std::hex << p_ctp7->getFIFOVFATBlockOccupancy(gtx)
         << std::endl
@@ -196,10 +196,10 @@ uint32_t* gem::hw::ctp7::CTP7Readout::getCTP7Data(uint8_t const& gtx, uint32_t c
 uint32_t* gem::hw::ctp7::CTP7Readout::selectData(uint32_t counter[5])
 {
   for(int j = 0; j < 5; j++) {
-    INFO("CTP7Readout::selectData counter " << j <<  " "<< counter[j] );
+    CMSGEMOS_INFO("CTP7Readout::selectData counter " << j <<  " "<< counter[j] );
   }
   uint32_t *point = &counter[0];
-  DEBUG("CTP7Readout::selectData point  " << std::hex << point );
+  CMSGEMOS_DEBUG("CTP7Readout::selectData point  " << std::hex << point );
   uint32_t* pDQ = GEMEventMaker(counter);
   for (unsigned count = 0; count < 5; ++count) counter[count] = *(pDQ+count);
   return point;
@@ -219,9 +219,9 @@ uint32_t* gem::hw::ctp7::CTP7Readout::GEMEventMaker(uint32_t counter[5])
   uint64_t msVFAT, lsVFAT;
   uint32_t ES;
 
-  DEBUG("CTP7Readout::GEMEventMaker  " << std::hex << point );
+  CMSGEMOS_DEBUG("CTP7Readout::GEMEventMaker  " << std::hex << point );
   if (m_dataque.empty()) return point;
-  DEBUG(" ::GEMEventMaker m_dataque.size " << m_dataque.size() );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker m_dataque.size " << m_dataque.size() );
 
   this->readVFATblock(m_dataque);
 
@@ -236,7 +236,7 @@ uint32_t* gem::hw::ctp7::CTP7Readout::GEMEventMaker(uint32_t counter[5])
 
   // GEM Event selector
   ES = ( evn << 12 ) | bcn;
-  DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << " evn 0x"<< evn
+  CMSGEMOS_DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << " evn 0x"<< evn
         << " bcn 0x" << std::hex << bcn << std::dec << " vftas.size "
         << m_vfats.size() << " m_erros.size " << m_erros.size()
         << " chip ID 0x" << std::hex << (int)chipid << std::dec <<
@@ -260,7 +260,7 @@ uint32_t* gem::hw::ctp7::CTP7Readout::GEMEventMaker(uint32_t counter[5])
     m_isFirst = true;
 
     if ( m_vfats.size() != 0 || m_erros.size() != 0 ) {
-      DEBUG(" ::GEMEventMaker m_isFirst GEMevSelector ");
+      CMSGEMOS_DEBUG(" ::GEMEventMaker m_isFirst GEMevSelector ");
       GEMevSelector(m_ESexp);
     }
 
@@ -270,15 +270,15 @@ uint32_t* gem::hw::ctp7::CTP7Readout::GEMEventMaker(uint32_t counter[5])
     m_erros.reserve(MaxERRS);
     m_ESexp = ES;
   }
-  DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << std::dec << " bool " << m_isFirst );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << std::dec << " bool " << m_isFirst );
   //if (islot < 0 || islot > 23) {
   //  if ( int(m_erros.size()) <MaxERRS ) m_erros.push_back(vfat);
-  //  DEBUG(" ::GEMEventMaker warning !!! islot is undefined " << islot << " m_erros.size " << int(m_erros.size()) );
+  //  CMSGEMOS_DEBUG(" ::GEMEventMaker warning !!! islot is undefined " << islot << " m_erros.size " << int(m_erros.size()) );
   //} else {
   // VFATs Pay Load
   if ( int(m_vfats.size()) <= MaxVFATS )
     m_vfats.push_back(vfat);
-  DEBUG(" ::GEMEventMaker m_event " << m_event << " m_vfats.size " << m_vfats.size() << std::hex << " ES 0x" << ES << std::dec );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker m_event " << m_event << " m_vfats.size " << m_vfats.size() << std::hex << " ES 0x" << ES << std::dec );
   //}//end of event selection
 
   m_queueDepth = m_dataque.size();
@@ -301,7 +301,7 @@ void gem::hw::ctp7::CTP7Readout::GEMevSelector(const  uint32_t& ES)
   AMCGEBData  geb;
   AMCVFATData vfat;
 
-  DEBUG(" ::GEMEventMaker m_vfats.size " << int(m_vfats.size()) << " m_rvent " << m_rvent << " event " << m_event);
+  CMSGEMOS_DEBUG(" ::GEMEventMaker m_vfats.size " << int(m_vfats.size()) << " m_rvent " << m_rvent << " event " << m_event);
 
   uint32_t locEvent = 0;
   uint32_t locError = 0;
@@ -315,7 +315,7 @@ void gem::hw::ctp7::CTP7Readout::GEMevSelector(const  uint32_t& ES)
     uint8_t ECff = ( (0x0ff0 & (*iVFAT).EC ) >> 4);
     uint32_t localEvent = ( ECff << 12 ) | ( 0x0fff & (*iVFAT).BC );
 
-    DEBUG(" ::GEMEventMaker vfats ES 0x" << std::hex << ( 0x00ffffff & ES) << " and from vfat 0x" <<
+    CMSGEMOS_DEBUG(" ::GEMEventMaker vfats ES 0x" << std::hex << ( 0x00ffffff & ES) << " and from vfat 0x" <<
           ( 0x00ffffff & localEvent ) << " EC 0x" << (int)ECff << " BC 0x" << ( 0x0fff & (*iVFAT).BC ) << std::dec );
 
     if ( ES == localEvent ) {
@@ -331,7 +331,7 @@ void gem::hw::ctp7::CTP7Readout::GEMevSelector(const  uint32_t& ES)
           GEMfillHeaders(m_event, nChip, gem, geb);
           GEMfillTrailers(gem, geb);
           // GEM Event Writing
-          DEBUG(" ::GEMEventMaker writing...  geb.vfats.size " << int(geb.vfats.size()) );
+          CMSGEMOS_DEBUG(" ::GEMEventMaker writing...  geb.vfats.size " << int(geb.vfats.size()) );
           TypeDataFlag = "PayLoad";
           if(int(geb.vfats.size()) != 0) writeGEMevent(m_outFileName, false, TypeDataFlag,
                                                        gem, geb, vfat);
@@ -347,18 +347,18 @@ void gem::hw::ctp7::CTP7Readout::GEMevSelector(const  uint32_t& ES)
   TypeDataFlag = "Errors";
 
   // contents all local events (one buffer, all links):
-  DEBUG(" ::GEMEventMaker END ES 0x" << std::hex << ES << std::dec << " errES " <<  m_erros.size() << " m_rvent " << m_rvent );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker END ES 0x" << std::hex << ES << std::dec << " errES " <<  m_erros.size() << " m_rvent " << m_rvent );
 
   uint32_t nErro = 0;
   for (auto iErr=m_erros.begin(); iErr != m_erros.end(); ++iErr) {
 
     uint8_t ECff = ( (0x0ff0 & (*iErr).EC ) >> 4);
     uint32_t localErr = ( ECff << 12 ) | ( 0x0fff & (*iErr).BC );
-    DEBUG(" ::GEMEventMaker ERROR vfats ES 0x" << ES << " EC " << localErr );
+    CMSGEMOS_DEBUG(" ::GEMEventMaker ERROR vfats ES 0x" << ES << " EC " << localErr );
 
     if( ES == localErr ) {
       nErro++;
-      DEBUG(" ::GEMEventMaker " << " nErro " << nErro << " ES 0x" << std::hex << ES << std::dec );
+      CMSGEMOS_DEBUG(" ::GEMEventMaker " << " nErro " << nErro << " ES 0x" << std::hex << ES << std::dec );
       // VFATs Errors
       geb.vfats.push_back(*iErr);
       if ( m_erros.size() == nErro ) {
@@ -379,7 +379,7 @@ void gem::hw::ctp7::CTP7Readout::GEMevSelector(const  uint32_t& ES)
   geb.vfats.clear();
 
   if (m_event%kUPDATE == 0 &&  m_event != 0) {
-    DEBUG(" ::GEMEventMaker m_vfats.size " << std::setfill(' ') << std::setw(7) << int(m_vfats.size()) <<
+    CMSGEMOS_DEBUG(" ::GEMEventMaker m_vfats.size " << std::setfill(' ') << std::setw(7) << int(m_vfats.size()) <<
           " m_erros.size " << std::setfill(' ') << std::setw(3) << int(m_erros.size()) <<
           " locEvent   " << std::setfill(' ') << std::setw(6) << locEvent <<
           " locError   " << std::setfill(' ') << std::setw(3) << locError << " event " << m_event
@@ -405,7 +405,7 @@ bool gem::hw::ctp7::CTP7Readout::VFATfillData(/*int const& islot, */AMCGEBData& 
   ChamID =  (0x000000fff0000000 & geb.header) >> 28;
   sumVFAT=  (0x000000000fffffff & geb.header);
 
-  DEBUG(" ::VFATfillData ChamID 0x" << ChamID << std::dec
+  CMSGEMOS_DEBUG(" ::VFATfillData ChamID 0x" << ChamID << std::dec
         //<< " islot " << islot
         << " sumVFAT " << sumVFAT);
 
@@ -424,7 +424,7 @@ void gem::hw::ctp7::CTP7Readout::writeGEMevent(std::string  outFile, bool const&
                                                AMCGEMData&  gem, AMCGEBData&  geb, AMCVFATData& vfat)
 {
   if(OKprint) {
-    DEBUG(" ::writeGEMevent m_vfat " << m_vfat << " event " << m_event << " sumVFAT " << (0x000000000fffffff & geb.header) <<
+    CMSGEMOS_DEBUG(" ::writeGEMevent m_vfat " << m_vfat << " event " << m_event << " sumVFAT " << (0x000000000fffffff & geb.header) <<
           " geb.vfats.size " << int(geb.vfats.size()) );
   }
   // GEM Chamber's Data
@@ -492,7 +492,7 @@ void gem::hw::ctp7::CTP7Readout::GEMfillHeaders(uint32_t const& event, uint32_t 
   BXID     =  (0x00000000ffffffff & gem.header1) >> 20;
   DataLgth =  (0x00000000000fffff & gem.header1);
 
-  DEBUG(" ::GEMfillHeaders event " << event << " LV1ID " << LV1ID << " BXID " << BXID);
+  CMSGEMOS_DEBUG(" ::GEMfillHeaders event " << event << " LV1ID " << LV1ID << " BXID " << BXID);
 
   // GEM Event Headers [2]
   uint64_t User        = BOOST_BINARY( 1 );    // :32
@@ -518,7 +518,7 @@ void gem::hw::ctp7::CTP7Readout::GEMfillHeaders(uint32_t const& event, uint32_t 
   uint64_t MP7BordStat = BOOST_BINARY( 1 );    // :8
 
   gem.header3 = (BufStat << 40)|(DAVList << 16)|(DAVCount << 11)|(FormatVer << 8)|(MP7BordStat);
-  DEBUG("GEM HEADER 3 " << std::hex << gem.header3 << "\n");
+  CMSGEMOS_DEBUG("GEM HEADER 3 " << std::hex << gem.header3 << "\n");
 
   DAVList     = (0xffffff0000000000 & gem.header3) >> 40;
   BufStat     = (0x000000ffffff0000 & gem.header3) >> 16;
@@ -527,13 +527,13 @@ void gem::hw::ctp7::CTP7Readout::GEMfillHeaders(uint32_t const& event, uint32_t 
   FormatVer   = (0x0000000000000f00 & gem.header3) >> 8;
   MP7BordStat = (0x00000000000000ff & gem.header3);
 
-  DEBUG("DAVCount " << std::hex << DAVCount_check << "\n");
+  CMSGEMOS_DEBUG("DAVCount " << std::hex << DAVCount_check << "\n");
 
   // last geb header:
   uint64_t runhed;
   //geb.runhed = (m_runType << 24)|(m_latency << 16)|(m_VT1 << 8)|(m_VT2);
   geb.runhed = (m_runType << 24)|(m_runParams);
-  INFO("GEMfillHeadres" << geb.runhed);
+  CMSGEMOS_INFO("GEMfillHeadres" << geb.runhed);
 }// end GEMfillHeaders
 
 void gem::hw::ctp7::CTP7Readout::GEMfillTrailers(AMCGEMData&  gem,AMCGEBData&  geb)
@@ -568,7 +568,7 @@ void gem::hw::ctp7::CTP7Readout::GEMfillTrailers(AMCGEMData&  gem,AMCGEBData&  g
   OHwCount   = (0x0000ffff00000000 & geb.trailer) >> 32;
   ChamStatus = (0x00000000ffff0000 & geb.trailer) >> 16;
 
-  DEBUG(" OHcrc 0x" << std::hex << OHcrc << " OHwCount " << OHwCount << " ChamStatus " << ChamStatus << std::dec);
+  CMSGEMOS_DEBUG(" OHcrc 0x" << std::hex << OHcrc << " OHwCount " << OHwCount << " ChamStatus " << ChamStatus << std::dec);
 }
 
 void gem::hw::ctp7::CTP7Readout::readVFATblock(std::queue<uint32_t>& dataque)
@@ -576,7 +576,7 @@ void gem::hw::ctp7::CTP7Readout::readVFATblock(std::queue<uint32_t>& dataque)
   uint32_t datafront = 0;
   for (int iQue = 0; iQue < 7; iQue++){
     datafront = dataque.front();
-    DEBUG(" ::GEMEventMaker iQue " << iQue << " 0x"
+    CMSGEMOS_DEBUG(" ::GEMEventMaker iQue " << iQue << " 0x"
           << std::setfill('0') << std::setw(8) << std::hex << datafront << std::dec );
     //this never seems to get reset? maybe iQue%7 to read the words after the first block?
     if ((iQue%7) == 5 ) {
@@ -614,7 +614,7 @@ void gem::hw::ctp7::CTP7Readout::readVFATblock(std::queue<uint32_t>& dataque)
              since iQue stays the same and we removed 7 blocks
              -MD
           */
-          INFO(" ::GEMEventMaker found misaligned word 0x"
+          CMSGEMOS_INFO(" ::GEMEventMaker found misaligned word 0x"
                << std::setfill('0') << std::hex << datafront << std::dec
                << " queue m_dataque.size " << dataque.size() );
           dataque.pop();
@@ -630,9 +630,9 @@ void gem::hw::ctp7::CTP7Readout::readVFATblock(std::queue<uint32_t>& dataque)
     } else if ( (iQue%7) == 6 ) {
       BX      = datafront;
     }
-    DEBUG(" ::GEMEventMaker (pre pop) m_dataque.size " << dataque.size() );
+    CMSGEMOS_DEBUG(" ::GEMEventMaker (pre pop) m_dataque.size " << dataque.size() );
     dataque.pop();
-    DEBUG(" ::GEMEventMaker (post pop)  m_dataque.size " << dataque.size() );
+    CMSGEMOS_DEBUG(" ::GEMEventMaker (post pop)  m_dataque.size " << dataque.size() );
   }// end queue
 }
 
@@ -643,13 +643,13 @@ void gem::hw::ctp7::CTP7Readout::ScanRoutines(uint8_t latency, uint8_t VT1, uint
   m_latency = latency;
   m_VT1 = VT1;
   m_VT2 = VT2;
-  DEBUG("CTP7Readout::ScanRoutines Latency = " << (int)m_latency  << " VT1 = " << (int)m_VT1 << " VT2 = " << (int)m_VT2);
+  CMSGEMOS_DEBUG("CTP7Readout::ScanRoutines Latency = " << (int)m_latency  << " VT1 = " << (int)m_VT1 << " VT2 = " << (int)m_VT2);
 }
 
 xoap::MessageReference gem::hw::ctp7::CTP7Readout::updateScanParameters(xoap::MessageReference msg)
   throw (xoap::exception::Exception)
 {
-  INFO("CTP7Readout::updateScanParameters()");
+  CMSGEMOS_INFO("CTP7Readout::updateScanParameters()");
   if (msg.isNull()) {
     XCEPT_RAISE(xoap::exception::Exception,"Null message received!");
   }
@@ -661,10 +661,10 @@ xoap::MessageReference gem::hw::ctp7::CTP7Readout::updateScanParameters(xoap::Me
       = gem::utils::soap::GEMSOAPToolBox::extractCommandWithParameter(msg);
     commandName = command.first;
     parameterValue = command.second;
-    INFO("CTP7Readout received command " << commandName);
+    CMSGEMOS_INFO("CTP7Readout received command " << commandName);
   } catch(xoap::exception::Exception& err) {
     std::string msgBase = toolbox::toString("Unable to extract command from CommandWithParameter SOAP message");
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::readout::exception::SOAPCommandParameterProblem, top,
                          toolbox::toString("%s.", msgBase.c_str()), err);
     //p_gemApp->notifyQualified("error", top);
@@ -681,7 +681,7 @@ xoap::MessageReference gem::hw::ctp7::CTP7Readout::updateScanParameters(xoap::Me
   }
   //this has to be injected into the GEM header
   m_runParams = std::stoi(parameterValue);
-  DEBUG(toolbox::toString("CTP7Readout::updateScanParameters() received command '%s' with value. %s",
+  CMSGEMOS_DEBUG(toolbox::toString("CTP7Readout::updateScanParameters() received command '%s' with value. %s",
                           commandName.c_str(), parameterValue.c_str()));
   return gem::utils::soap::GEMSOAPToolBox::makeFSMSOAPReply(commandName, "ParametersUpdated");
 }
@@ -690,7 +690,7 @@ xoap::MessageReference gem::hw::ctp7::CTP7Readout::updateScanParameters(xoap::Me
 xoap::MessageReference gem::hw::ctp7::CTP7Readout::queueDepth(xoap::MessageReference msg)
   throw (xoap::exception::Exception)
 {
-  INFO("CTP7Readout::queueDepth()");
+  CMSGEMOS_INFO("CTP7Readout::queueDepth()");
   if (msg.isNull()) {
     XCEPT_RAISE(xoap::exception::Exception,"Null message received!");
   }
@@ -702,10 +702,10 @@ xoap::MessageReference gem::hw::ctp7::CTP7Readout::queueDepth(xoap::MessageRefer
       = gem::utils::soap::GEMSOAPToolBox::extractCommandWithParameter(msg);
     commandName = command.first;
     parameterValue = command.second;
-    INFO("CTP7Readout received command " << commandName);
+    CMSGEMOS_INFO("CTP7Readout received command " << commandName);
   } catch(xoap::exception::Exception& err) {
     std::string msgBase = toolbox::toString("Unable to extract command from CommandWithParameter SOAP message");
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::readout::exception::SOAPCommandParameterProblem, top,
                          toolbox::toString("%s.", msgBase.c_str()), err);
     //p_gemApp->notifyQualified("error", top);
@@ -721,7 +721,7 @@ xoap::MessageReference gem::hw::ctp7::CTP7Readout::queueDepth(xoap::MessageRefer
     return reply;
   }
   //this has to be injected into the GEM header
-  DEBUG(toolbox::toString("CTP7Readout::queueDepth() received command '%s' with value. %s",
+  CMSGEMOS_DEBUG(toolbox::toString("CTP7Readout::queueDepth() received command '%s' with value. %s",
                           commandName.c_str(), parameterValue.c_str()));
   return gem::utils::soap::GEMSOAPToolBox::makeFSMSOAPReply(commandName, "ParametersUpdated");
 }

--- a/gemhardware/src/common/ctp7/HwCTP7.cc
+++ b/gemhardware/src/common/ctp7/HwCTP7.cc
@@ -9,7 +9,7 @@ gem::hw::ctp7::HwCTP7::HwCTP7() :
   m_crate(-1),
   m_slot(-1)
 {
-  INFO("HwCTP7 ctor");
+  CMSGEMOS_INFO("HwCTP7 ctor");
   // use a connection file and connection manager?
   setDeviceID("CTP7Hw");
   setAddressTableFileName("ctp7_address_table.xml");
@@ -22,7 +22,7 @@ gem::hw::ctp7::HwCTP7::HwCTP7() :
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::ctp7::HwCTP7::HwCTP7(std::string const& ctp7Device,
@@ -39,7 +39,7 @@ gem::hw::ctp7::HwCTP7::HwCTP7(std::string const& ctp7Device,
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::ctp7::HwCTP7::HwCTP7(std::string const& ctp7Device,
@@ -51,7 +51,7 @@ gem::hw::ctp7::HwCTP7::HwCTP7(std::string const& ctp7Device,
   m_slot(-1)
 
 {
-  INFO("trying to create HwCTP7(" << ctp7Device << "," << connectionURI << "," <<addressTable);
+  CMSGEMOS_INFO("trying to create HwCTP7(" << ctp7Device << "," << connectionURI << "," <<addressTable);
   setDeviceBaseNode("CTP7");
   for (unsigned li = 0; li < N_GTX; ++li) {
     b_links[li] = false;
@@ -59,7 +59,7 @@ gem::hw::ctp7::HwCTP7::HwCTP7(std::string const& ctp7Device,
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::ctp7::HwCTP7::HwCTP7(std::string const& ctp7Device,
@@ -77,7 +77,7 @@ gem::hw::ctp7::HwCTP7::HwCTP7(std::string const& ctp7Device,
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::ctp7::HwCTP7::HwCTP7(const int& crate, const int& slot) :
@@ -87,17 +87,17 @@ gem::hw::ctp7::HwCTP7::HwCTP7(const int& crate, const int& slot) :
   m_crate(crate),
   m_slot(slot)
 {
-  INFO("HwCTP7 ctor");
+  CMSGEMOS_INFO("HwCTP7 ctor");
   // use a connection file and connection manager?
   setDeviceID(toolbox::toString("gem.shelf%02d.ctp7%02d",crate,slot));
 
   // uhal::ConnectionManager manager ( "file://${GEM_ADDRESS_TABLE_PATH}/connections_ch.xml" );
-  INFO("getting the ConnectionManager pointer");
+  CMSGEMOS_INFO("getting the ConnectionManager pointer");
   p_gemConnectionManager.reset(new uhal::ConnectionManager("file://${GEM_ADDRESS_TABLE_PATH}/connections_ch.xml"));
   // p_gemConnectionManager.reset(new uhal::ConnectionManager("file://../data/connections_ch.xml"));
-  INFO("getting HwInterface " << getDeviceID() << " pointer from ConnectionManager");
+  CMSGEMOS_INFO("getting HwInterface " << getDeviceID() << " pointer from ConnectionManager");
   p_gemHW.reset(new uhal::HwInterface(p_gemConnectionManager->getDevice(this->getDeviceID())));
-  INFO("setting the device base node");
+  CMSGEMOS_INFO("setting the device base node");
   setDeviceBaseNode("CTP7");
   // gem::hw::ctp7::HwCTP7::initDevice();
   //
@@ -114,7 +114,7 @@ gem::hw::ctp7::HwCTP7::HwCTP7(const int& crate, const int& slot) :
     m_ipBusCounters.push_back(tmpGTXCounter);
   }
 
-  INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
+  CMSGEMOS_INFO("HwCTP7 ctor done, deviceBaseNode is " << getDeviceBaseNode());
 }
 
 gem::hw::ctp7::HwCTP7::~HwCTP7()
@@ -124,7 +124,7 @@ gem::hw::ctp7::HwCTP7::~HwCTP7()
 bool gem::hw::ctp7::HwCTP7::isHwConnected()
 {
   if ( b_is_connected ) {
-    INFO("basic check: HwCTP7 connection good");
+    CMSGEMOS_INFO("basic check: HwCTP7 connection good");
     return true;
   } else if (gem::hw::GEMHwDevice::isHwConnected()) {
     std::vector<linkStatus> tmp_activeLinks;
@@ -134,11 +134,11 @@ bool gem::hw::ctp7::HwCTP7::isHwConnected()
       if ((this->getBoardID()).rfind("CTP7") != std::string::npos ) {
         // somehow need to actually check that the specified link is present
         b_links[gtx] = true;
-        DEBUG("gtx" << gtx << " present(" << this->getFirmwareVer() << ")");
+        CMSGEMOS_DEBUG("gtx" << gtx << " present(" << this->getFirmwareVer() << ")");
         tmp_activeLinks.push_back(std::make_pair(gtx,this->LinkStatus(gtx)));
       } else {
         b_links[gtx] = false;
-        INFO("gtx" << gtx << " not reachable (unable to find 2 or 5 or 201 in the firmware string, "
+        CMSGEMOS_INFO("gtx" << gtx << " not reachable (unable to find 2 or 5 or 201 in the firmware string, "
              << "or 'CTP7' in the board ID)"
              << " board ID "              << this->getBoardID()
              << " user firmware version " << this->getFirmwareVer());
@@ -148,12 +148,12 @@ bool gem::hw::ctp7::HwCTP7::isHwConnected()
     if (!v_activeLinks.empty()) {
       b_is_connected = true;
       // m_controlLink = (v_activeLinks.begin())->first;
-      // INFO("connected - control gtx" << (int)m_controlLink);
-      INFO("checked gtxs: HwCTP7 connection good");
+      // CMSGEMOS_INFO("connected - control gtx" << (int)m_controlLink);
+      CMSGEMOS_INFO("checked gtxs: HwCTP7 connection good");
       return true;
     } else {
       b_is_connected = false;
-      // INFO("not connected - control gtx" << (int)m_controlLink);
+      // CMSGEMOS_INFO("not connected - control gtx" << (int)m_controlLink);
       return false;
     }
   } else {
@@ -282,14 +282,14 @@ void gem::hw::ctp7::HwCTP7::XPointControl(bool xpoint2, uint8_t const& input, ui
 {
   if (xpoint2 && (input > 2 || output > 0)) {
     std::string msg = toolbox::toString("Invalid clock routing for XPoint2 %d -> %d",input,output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::ctp7::exception::InvalidXPoint2Routing,msg);
     return;
   }
 
   if ((input > 3 || output > 3)) {
     std::string msg = toolbox::toString( "Invalid clock routing for XPoint%d %d -> %d",xpoint2,input,output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::ctp7::exception::InvalidXPointRouting,msg);
     return;
   }
@@ -326,7 +326,7 @@ uint8_t gem::hw::ctp7::HwCTP7::XPointControl(bool xpoint2, uint8_t const& output
   /*
     if (xpoint2 && output > 0) {
     std::string msg = toolbox::toString("Invalid clock output for XPoint2 %d",output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::ctp7::exception::InvalidXPoint2Routing,msg);
     return output;
     }
@@ -334,7 +334,7 @@ uint8_t gem::hw::ctp7::HwCTP7::XPointControl(bool xpoint2, uint8_t const& output
 
   if (output > 3) {
     std::string msg = toolbox::toString( "Invalid clock output for XPoint%d %d",xpoint2,output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::ctp7::exception::InvalidXPointRouting,msg);
     return output;
   }
@@ -367,7 +367,7 @@ uint8_t gem::hw::ctp7::HwCTP7::SFPStatus(uint8_t const& sfpcage)
   // gem::utils::LockGuard<gem::utils::Lock> guardedLock(hwLock_);
   if (sfpcage < 1 || sfpcage > 4) {
     std::string msg = toolbox::toString("Status requested for SFP (%d): outside expectation (1,4)", sfpcage);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::ctp7::exception::InvalidLink,msg);
     return 0;
   }
@@ -436,12 +436,12 @@ bool gem::hw::ctp7::HwCTP7::linkCheck(uint8_t const& gtx, std::string const& opM
   if (gtx > N_GTX) {
     std::string msg = toolbox::toString("%s requested for gtx (%d): outside expectation (0-%d)",
                                         opMsg.c_str(), gtx, N_GTX);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::ctp7::exception::InvalidLink,msg);
     return false;
   } else if (!b_links[gtx]) {
     std::string msg = toolbox::toString("%s requested inactive gtx (%d)",opMsg.c_str(), gtx);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::ctp7::exception::InvalidLink,msg);
     return false;
   }
@@ -533,7 +533,7 @@ uint32_t gem::hw::ctp7::HwCTP7::getFIFOOccupancy(uint8_t const& gtx)
     std::stringstream regName;
     regName << "TRK_DATA.OptoHybrid_" << (int)gtx;
     fifocc = readReg(getDeviceBaseNode(),regName.str()+".DEPTH");
-    DEBUG(toolbox::toString("getFIFOOccupancy(%d) %s.%s%s:: %d", gtx, getDeviceBaseNode().c_str(),
+    CMSGEMOS_DEBUG(toolbox::toString("getFIFOOccupancy(%d) %s.%s%s:: %d", gtx, getDeviceBaseNode().c_str(),
                             regName.str().c_str(), ".DEPTH", fifocc));
   }
   // the fifo occupancy is in number of 32 bit words
@@ -578,7 +578,7 @@ uint32_t gem::hw::ctp7::HwCTP7::getTrackingData(uint8_t const& gtx, uint32_t* da
 {
   if (data==NULL) {
     std::string msg = toolbox::toString("Block read requested for null pointer");
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::ctp7::exception::NULLReadoutPointer,msg);
   } else if (!linkCheck(gtx, "Tracking data")) {
     return 0;
@@ -612,12 +612,12 @@ void gem::hw::ctp7::HwCTP7::flushFIFO(uint8_t const& gtx)
   if (linkCheck(gtx, "Flush FIFO")) {
     std::stringstream regName;
     regName << "TRK_DATA.OptoHybrid_" << (int)gtx;
-    INFO("Tracking FIFO" << (int)gtx << ":"
+    CMSGEMOS_INFO("Tracking FIFO" << (int)gtx << ":"
          << " ISFULL  0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISFULL")  << std::dec
          << " ISEMPTY 0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISEMPTY") << std::dec
          << " Depth   0x" << std::hex << getFIFOOccupancy(gtx) << std::dec);
     writeReg(getDeviceBaseNode(),regName.str()+".FLUSH",0x1);
-    INFO("Tracking FIFO" << (int)gtx << ":"
+    CMSGEMOS_INFO("Tracking FIFO" << (int)gtx << ":"
          << " ISFULL  0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISFULL")  << std::dec
          << " ISEMPTY 0x" << std::hex << readReg(getDeviceBaseNode(),regName.str()+".ISEMPTY") << std::dec
          << " Depth   0x" << std::hex << getFIFOOccupancy(gtx) << std::dec);
@@ -797,7 +797,7 @@ void gem::hw::ctp7::HwCTP7::setDAQLinkRunParameter(uint8_t const& parameter, uin
   if (parameter < 1 || parameter > 3) {
     std::string msg = toolbox::toString("Attempting to set DAQ link run parameter %d: outside expectation (1-%d)",
                                         (int)parameter,3);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     return;
   }
   std::stringstream regBase;

--- a/gemhardware/src/common/glib/GLIBManager.cc
+++ b/gemhardware/src/common/glib/GLIBManager.cc
@@ -82,10 +82,10 @@ gem::hw::glib::GLIBManager::GLIBManager(xdaq::ApplicationStub* stub) :
   xgi::bind(this, &GLIBManager::dumpGLIBFIFO, "dumpGLIBFIFO");
 
   // initialize the GLIB application objects
-  DEBUG("GLIBManager::Connecting to the GLIBManagerWeb interface");
+  CMSGEMOS_DEBUG("GLIBManager::Connecting to the GLIBManagerWeb interface");
   p_gemWebInterface = new gem::hw::glib::GLIBManagerWeb(this);
   // p_gemMonitor      = new gem::hw::glib::GLIBHwMonitor(this);
-  DEBUG("GLIBManager::done");
+  CMSGEMOS_DEBUG("GLIBManager::done");
 
   // set up the info hwCfgInfoSpace
   init();
@@ -102,38 +102,38 @@ std::vector<uint32_t> gem::hw::glib::GLIBManager::dumpGLIBFIFO(int const& glib)
 {
   std::vector<uint32_t> dump;
   if (glib < 0 || glib > 11) {
-    WARN("GLIBManager::dumpGLIBFIFO Specified invalid GLIB card " << glib+1);
+    CMSGEMOS_WARN("GLIBManager::dumpGLIBFIFO Specified invalid GLIB card " << glib+1);
     return dump;
   } else if (!m_glibs.at(glib)) {
-    WARN("GLIBManager::dumpGLIBFIFO Specified GLIB card " << glib+1
+    CMSGEMOS_WARN("GLIBManager::dumpGLIBFIFO Specified GLIB card " << glib+1
          << " is not connected");
     return dump;
     //} else if (!(m_glibs.at(glib)->hasTrackingData(0))) {
-    //  WARN("GLIBManager::dumpGLIBFIFO Specified GLIB card " << glib
+    //  CMSGEMOS_WARN("GLIBManager::dumpGLIBFIFO Specified GLIB card " << glib
     //       << " has no tracking data in the FIFO");
     //  return dump;
   }
 
   try {
-    INFO("GLIBManager::dumpGLIBFIFO Dumping FIFO for specified GLIB card " << glib+1);
+    CMSGEMOS_INFO("GLIBManager::dumpGLIBFIFO Dumping FIFO for specified GLIB card " << glib+1);
     return m_glibs.at(glib)->getTrackingData(0, 24);
   } catch (gem::hw::glib::exception::Exception const& e) {
     std::stringstream msg;
     msg << "GLIBManager::dumpGLIBFIFO Unable to read tracking data from AMC" << glib+1
         << " FIFO, caught exception " << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     return dump;
   } catch (std::exception const& e) {
     std::stringstream msg;
     msg << "GLIBManager::dumpGLIBFIFO Unable to read tracking data from AMC" << glib+1
         << " FIFO, caught exception " << e.what();
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     return dump;
   } catch (...) {
     std::stringstream msg;
     msg << "GLIBManager::dumpGLIBFIFO Unable to read tracking data from AMC" << glib+1
         << " FIFO, caught unknown exception ";
-    ERROR(msg.str());
+    CMSGEMOS_ERROR(msg.str());
     return dump;
   }
 }
@@ -142,10 +142,10 @@ std::vector<uint32_t> gem::hw::glib::GLIBManager::dumpGLIBFIFO(int const& glib)
 void gem::hw::glib::GLIBManager::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("GLIBManager::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("GLIBManager::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
     m_amcEnableMask = gem::hw::utils::parseAMCEnableList(m_amcSlots.toString());
-    INFO("GLIBManager::Parsed AMCEnableList m_amcSlots = " << m_amcSlots.toString()
+    CMSGEMOS_INFO("GLIBManager::Parsed AMCEnableList m_amcSlots = " << m_amcSlots.toString()
          << " to slotMask 0x" << std::hex << m_amcEnableMask << std::dec);
 
     // how to handle passing in various values nested in a vector in a bag
@@ -155,7 +155,7 @@ void gem::hw::glib::GLIBManager::actionPerformed(xdata::Event& event)
       // if (slot->bag.present.value_)
       if (slot->bag.crateID.value_ > -1) {
         slot->bag.present = true;
-        DEBUG("GLIBManager::Found attribute:" << slot->bag.toString());
+        CMSGEMOS_DEBUG("GLIBManager::Found attribute:" << slot->bag.toString());
       }
     }
     // p_gemMonitor->startMonitoring();
@@ -173,20 +173,20 @@ void gem::hw::glib::GLIBManager::init()
 void gem::hw::glib::GLIBManager::initializeAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  DEBUG("GLIBManager::initializeAction begin");
+  CMSGEMOS_DEBUG("GLIBManager::initializeAction begin");
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
-    DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding expected cards");
+    CMSGEMOS_DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding expected cards");
     GLIBInfo& info = m_glibInfo[slot].bag;
     if ((m_amcEnableMask >> (slot)) & 0x1) {
-      DEBUG("GLIBManager::info:" << info.toString());
-      DEBUG("GLIBManager::expect a card in slot " << (slot+1));
-      DEBUG("GLIBManager::bag"
+      CMSGEMOS_DEBUG("GLIBManager::info:" << info.toString());
+      CMSGEMOS_DEBUG("GLIBManager::expect a card in slot " << (slot+1));
+      CMSGEMOS_DEBUG("GLIBManager::bag"
             << "crate " << info.crateID.value_
             << " slot " << info.slotID.value_);
       // this maybe shouldn't be done?
       info.slotID  = slot+1;
-      DEBUG("GLIBManager::bag"
+      CMSGEMOS_DEBUG("GLIBManager::bag"
             << "crate " << info.crateID.value_
             << " slot " << info.slotID.value_);
       // this maybe shouldn't be done?
@@ -208,7 +208,7 @@ void gem::hw::glib::GLIBManager::initializeAction()
     if (!info.present)
       continue;
 
-    DEBUG("GLIBManager::creating pointer to card in slot " << (slot+1));
+    CMSGEMOS_DEBUG("GLIBManager::creating pointer to card in slot " << (slot+1));
 
     // create the cfgInfoSpace object (qualified vs non?)
     std::string deviceName = info.cardName.toString();
@@ -219,23 +219,23 @@ void gem::hw::glib::GLIBManager::initializeAction()
     toolbox::net::URN hwCfgURN("urn:gem:hw:"+deviceName);
 
     if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-      DEBUG("GLIBManager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
+      CMSGEMOS_DEBUG("GLIBManager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
       is_glibs.at(slot) = is_toolbox_ptr(new gem::base::utils::GEMInfoSpaceToolBox(this,
                                                                                    xdata::getInfoSpaceFactory()->get(hwCfgURN.toString()),
                                                                                    true));
     } else {
-      DEBUG("GLIBManager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
+      CMSGEMOS_DEBUG("GLIBManager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
       is_glibs.at(slot) = is_toolbox_ptr(new gem::base::utils::GEMInfoSpaceToolBox(this,
                                                                                    hwCfgURN.toString(),
                                                                                    true));
     }
 
     try {
-      DEBUG("GLIBManager::obtaining pointer to HwGLIB");
+      CMSGEMOS_DEBUG("GLIBManager::obtaining pointer to HwGLIB");
       m_glibs.at(slot) = glib_shared_ptr(new gem::hw::glib::HwGLIB(deviceName, m_connectionFile.toString()));
       glib_shared_ptr amc = m_glibs.at(slot);
       if (amc->isHwConnected()) {
-        DEBUG("GLIBManager::Creating InfoSpace items for GLIB device " << deviceName);
+        CMSGEMOS_DEBUG("GLIBManager::Creating InfoSpace items for GLIB device " << deviceName);
 
         // FIXME should not need this here?
         amc->disableDAQLink();
@@ -252,31 +252,31 @@ void gem::hw::glib::GLIBManager::initializeAction()
       } else {
         std::stringstream msg;
         msg << "GLIBManager::initializeAction unable to communicate with GLIB in slot " << slot;
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         XCEPT_RAISE(gem::hw::glib::exception::Exception, "initializeAction failed");
       }
     } catch (uhalException const& e) {
       std::stringstream msg;
       msg << "GLIBManager::initializeAction caught uHAL exception " << e.what();
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     } catch (gem::hw::glib::exception::Exception const& e) {
       std::stringstream msg;
       msg << "GLIBManager::initializeAction caught exception " << e.what();
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     } catch (toolbox::net::exception::MalformedURN const& e) {
       std::stringstream msg;
       msg << "GLIBManager::initializeAction caught exception " << e.what();
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     } catch (std::exception const& e) {
       std::stringstream msg;
       msg << "GLIBManager::initializeAction caught exception " << e.what();
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     }
-    DEBUG("GLIBManager::connected");
+    CMSGEMOS_DEBUG("GLIBManager::connected");
     // set the web view to be empty or grey
     // if (!info.present.value_) continue;
     // p_gemWebInterface->glibInSlot(slot);
@@ -293,23 +293,23 @@ void gem::hw::glib::GLIBManager::initializeAction()
 
     glib_shared_ptr amc = m_glibs.at(slot);
     if (amc->isHwConnected()) {
-      DEBUG("GLIBManager::connected a card in slot " << (slot+1));
+      CMSGEMOS_DEBUG("GLIBManager::connected a card in slot " << (slot+1));
     } else {
       std::stringstream msg;
       msg << "GLIBManager::initializeAction GLIB in slot " << (slot+1) << " is not connected";
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       // fireEvent("Fail");
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     }
   }
   // usleep(10); // just for testing the timing of different applications
-  INFO("GLIBManager::initializeAction end");
+  CMSGEMOS_INFO("GLIBManager::initializeAction end");
 }
 
 void gem::hw::glib::GLIBManager::configureAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  DEBUG("GLIBManager::configureAction");
+  CMSGEMOS_DEBUG("GLIBManager::configureAction");
 
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
@@ -340,12 +340,12 @@ void gem::hw::glib::GLIBManager::configureAction()
         if (m_relockPhase.value_)
           pashiftcmd << " --relock";
         pashiftcmd << "'\"";
-        INFO("GLIBManager::configureAction executing " << pashiftcmd.str());
+        CMSGEMOS_INFO("GLIBManager::configureAction executing " << pashiftcmd.str());
         int retval = std::system(pashiftcmd.str().c_str());
         if (retval) {
           std::stringstream msg;
           msg << "GLIBManager::configureAction unable to shift phases: " << retval;
-          ERROR(msg.str());
+          CMSGEMOS_ERROR(msg.str());
           // fireEvent("Fail");
           // XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
           XCEPT_RAISE(gem::hw::glib::exception::ConfigurationProblem, msg.str());
@@ -362,7 +362,7 @@ void gem::hw::glib::GLIBManager::configureAction()
       amc->setDAQLinkRunParameters(0xfaac);
 
       if (m_scanType.value_ == 2) {
-	INFO("GLIBManager::configureAction: FIRST  " << m_scanMin.value_);
+        CMSGEMOS_INFO("GLIBManager::configureAction: FIRST  " << m_scanMin.value_);
 
 	amc->setDAQLinkRunType(0x2);
 	amc->setDAQLinkRunParameter(0x1,m_scanMin.value_);
@@ -371,7 +371,7 @@ void gem::hw::glib::GLIBManager::configureAction()
       } else if (m_scanType.value_ == 3) {
 	uint32_t initialVT1 = m_scanMin.value_;
 	uint32_t initialVT2 = 0;  // std::max(0,(uint32_t)m_scanMax.value_);
-	INFO("GLIBManager::configureAction FIRST VT1 " << initialVT1 << " VT2 " << initialVT2);
+        CMSGEMOS_INFO("GLIBManager::configureAction FIRST VT1 " << initialVT1 << " VT2 " << initialVT2);
 
 	amc->setDAQLinkRunType(0x3);
 	// amc->setDAQLinkRunParameter(0x1,latency);  // set this at start so DQM has it?
@@ -391,7 +391,7 @@ void gem::hw::glib::GLIBManager::configureAction()
       // temp workaround, call confAllChambers python script?
       // if P5 config?
       // if (m_setupLocation.toString().rfind("P5") != std::string::npos) {
-      INFO("GLIBManager::configureAction running confAllChambers for P5 setup");
+      CMSGEMOS_INFO("GLIBManager::configureAction running confAllChambers for P5 setup");
       std::stringstream confcmd;
       // FIXME hard coded for now, but super hacky garbage
       confcmd << "confAllChambers.py -s" << (slot+1)
@@ -399,12 +399,12 @@ void gem::hw::glib::GLIBManager::configureAction()
               << " --ztrim="   << 4.0
               << " --vt1bump=" << 10
               << " --config --run";
-      INFO("GLIBManager::configureAction executing " << confcmd.str());
+      CMSGEMOS_INFO("GLIBManager::configureAction executing " << confcmd.str());
       int retval = std::system(confcmd.str().c_str());
       if (retval) {
         std::stringstream msg;
         msg << "GLIBManager::configureAction unable to configure chambers: " << retval;
-        WARN(msg.str());
+        CMSGEMOS_WARN(msg.str());
         // fireEvent("Fail");
         // XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
         // XCEPT_RAISE(gem::hw::glib::exception::ConfigurationProblem, msg.str());
@@ -414,12 +414,12 @@ void gem::hw::glib::GLIBManager::configureAction()
       // FIXME hard coded for now, but super hacky garbage
       statuscmd << "amc_info_uhal.py -s" << (slot+1)
                 << " --shelf="           << info.crateID.toString();
-      INFO("GLIBManager::configureAction running " << statuscmd.str() << " after configuring");
+      CMSGEMOS_INFO("GLIBManager::configureAction running " << statuscmd.str() << " after configuring");
       retval = std::system(statuscmd.str().c_str());
       if (retval) {
         std::stringstream msg;
         msg << "GLIBManager::configureAction unable to check AMC status: " << retval;
-        WARN(msg.str());
+        CMSGEMOS_WARN(msg.str());
         // fireEvent("Fail");
         // XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
         // XCEPT_RAISE(gem::hw::glib::exception::ConfigurationProblem, msg.str());
@@ -430,34 +430,34 @@ void gem::hw::glib::GLIBManager::configureAction()
     } else {
       std::stringstream msg;
       msg << "GLIBManager::configureAction GLIB in slot " << (slot+1) << " is not connected";
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       // fireEvent("Fail");
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     }
   }
 
-  INFO("GLIBManager::configureAction end");
+  CMSGEMOS_INFO("GLIBManager::configureAction end");
 }
 
 void gem::hw::glib::GLIBManager::startAction()
   throw (gem::hw::glib::exception::Exception)
 {
   if (m_scanType.value_ == 2) {
-    INFO("GLIBManager::startAction() " << std::endl << m_scanInfo.bag.toString());
+    CMSGEMOS_INFO("GLIBManager::startAction() " << std::endl << m_scanInfo.bag.toString());
     m_lastLatency = m_scanMin.value_;
     m_lastVT1 = 0;
   } else if (m_scanType.value_ == 3) {
-    INFO("GLIBManager::startAction() " << std::endl << m_scanInfo.bag.toString());
+    CMSGEMOS_INFO("GLIBManager::startAction() " << std::endl << m_scanInfo.bag.toString());
     m_lastLatency = 0;
     m_lastVT1 = m_scanMin.value_;
   }
 
-  INFO("GLIBManager::startAction begin");
+  CMSGEMOS_INFO("GLIBManager::startAction begin");
   // what is required for starting the GLIB?
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);
-    DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
+    CMSGEMOS_DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
     GLIBInfo& info = m_glibInfo[slot].bag;
 
     if (!info.present)
@@ -468,7 +468,7 @@ void gem::hw::glib::GLIBManager::startAction()
       if (m_glibMonitors.at(slot))
         m_glibMonitors.at(slot)->pauseMonitoring();
 
-      DEBUG("connected a card in slot " << (slot+1));
+      CMSGEMOS_DEBUG("connected a card in slot " << (slot+1));
       // enable the DAQ
       amc->ttcReset();
       amc->enableDAQLink(0x4);  // FIXME
@@ -481,12 +481,12 @@ void gem::hw::glib::GLIBManager::startAction()
       // FIXME hard coded for now, but super hacky garbage
       statuscmd << "amc_info_uhal.py -s" << (slot+1)
                 << " --shelf="           << info.crateID.toString();
-      INFO("GLIBManager::startAction running " << statuscmd.str() << " after starting");
+      CMSGEMOS_INFO("GLIBManager::startAction running " << statuscmd.str() << " after starting");
       int retval = std::system(statuscmd.str().c_str());
       if (retval) {
         std::stringstream msg;
         msg << "GLIBManager::startAction unable to check AMC status: " << retval;
-        WARN(msg.str());
+        CMSGEMOS_WARN(msg.str());
         // fireEvent("Fail");
         // XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
         // XCEPT_RAISE(gem::hw::glib::exception::ConfigurationProblem, msg.str());
@@ -497,7 +497,7 @@ void gem::hw::glib::GLIBManager::startAction()
     } else {
       std::stringstream msg;
       msg << "GLIBManager::startAction GLIB in slot " << (slot+1) << " is not connected";
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       // fireEvent("Fail");
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     }
@@ -509,7 +509,7 @@ void gem::hw::glib::GLIBManager::startAction()
     */
   }
   // usleep(10);
-  INFO("GLIBManager::startAction end");
+  CMSGEMOS_INFO("GLIBManager::startAction end");
 }
 
 void gem::hw::glib::GLIBManager::pauseAction()
@@ -519,7 +519,7 @@ void gem::hw::glib::GLIBManager::pauseAction()
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);
-    DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
+    CMSGEMOS_DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
     GLIBInfo& info = m_glibInfo[slot].bag;
 
     if (!info.present)
@@ -530,33 +530,33 @@ void gem::hw::glib::GLIBManager::pauseAction()
       if (m_glibMonitors.at(slot))
         m_glibMonitors.at(slot)->pauseMonitoring();
 
-      DEBUG("connected a card in slot " << (slot+1));
+      CMSGEMOS_DEBUG("connected a card in slot " << (slot+1));
 
       if (m_scanType.value_ == 2) {
 	uint8_t updatedLatency = m_lastLatency + m_stepSize.value_;
-	INFO("GLIBManager::pauseAction LatencyScan AMC" << (slot+1) << " Latency " << (int)updatedLatency);
+        CMSGEMOS_INFO("GLIBManager::pauseAction LatencyScan AMC" << (slot+1) << " Latency " << (int)updatedLatency);
 
         // wait for events to finish building
         while (!amc->l1aFIFOIsEmpty()) {
-          DEBUG("GLIBManager::pauseAction waiting for AMC" << (slot+1) << " to finish building events");
+          CMSGEMOS_DEBUG("GLIBManager::pauseAction waiting for AMC" << (slot+1) << " to finish building events");
           usleep(10);
         }
-        DEBUG("GLIBManager::pauseAction AMC" << (slot+1) << " finished building events, updating run parameter "
+        CMSGEMOS_DEBUG("GLIBManager::pauseAction AMC" << (slot+1) << " finished building events, updating run parameter "
               << (int)updatedLatency);
-	amc->setDAQLinkRunParameter(0x1,updatedLatency);
+        amc->setDAQLinkRunParameter(0x1,updatedLatency);
       } else if (m_scanType.value_ == 3) {
-	uint8_t updatedVT1 = m_lastVT1 + m_stepSize.value_;
-	uint8_t updatedVT2 = 0; //std::max(0,(int)m_scanMax.value_);
-	INFO("GLIBManager::pauseAction ThresholdScan AMC" << (slot+1) << ""
+        uint8_t updatedVT1 = m_lastVT1 + m_stepSize.value_;
+        uint8_t updatedVT2 = 0; //std::max(0,(int)m_scanMax.value_);
+        CMSGEMOS_INFO("GLIBManager::pauseAction ThresholdScan AMC" << (slot+1) << ""
              << " VT1 " << (int)updatedVT1
              << " VT2 " << (int)updatedVT2);
 
         // wait for events to finish building
         while (!amc->l1aFIFOIsEmpty()) {
-          DEBUG("GLIBManager::pauseAction waiting for AMC" << (slot+1) << " to finish building events");
+          CMSGEMOS_DEBUG("GLIBManager::pauseAction waiting for AMC" << (slot+1) << " to finish building events");
           usleep(10);
         }
-        DEBUG("GLIBManager::pauseAction finished AMC" << (slot+1) << " building events, updating VT1 " << (int)updatedVT1
+        CMSGEMOS_DEBUG("GLIBManager::pauseAction finished AMC" << (slot+1) << " building events, updating VT1 " << (int)updatedVT1
               << " and VT2 " << (int)updatedVT2);
 	amc->setDAQLinkRunParameter(0x2,updatedVT1);
 	amc->setDAQLinkRunParameter(0x3,updatedVT2);
@@ -568,7 +568,7 @@ void gem::hw::glib::GLIBManager::pauseAction()
     } else {
       std::stringstream msg;
       msg << "GLIBManager::pauseAction GLIB in slot " << (slot+1) << " is not connected";
-      ERROR(msg.str());
+      CMSGEMOS_ERROR(msg.str());
       // fireEvent("Fail");
       XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
     }
@@ -576,15 +576,15 @@ void gem::hw::glib::GLIBManager::pauseAction()
 
   // Update the scan parameters
   if (m_scanType.value_ == 2) {
-    INFO("GLIBManager::pauseAction LatencyScan old Latency " << (int)m_lastLatency);
+    CMSGEMOS_INFO("GLIBManager::pauseAction LatencyScan old Latency " << (int)m_lastLatency);
     m_lastLatency += m_stepSize.value_;
-    INFO("GLIBManager::pauseAction LatencyScan new Latency " << (int)m_lastLatency);
+    CMSGEMOS_INFO("GLIBManager::pauseAction LatencyScan new Latency " << (int)m_lastLatency);
   } else if (m_scanType.value_ == 3) {
-    INFO("GLIBManager::pauseAction ThresholdScan old VT1 " << (int)m_lastVT1);
+    CMSGEMOS_INFO("GLIBManager::pauseAction ThresholdScan old VT1 " << (int)m_lastVT1);
     m_lastVT1 += m_stepSize.value_;
-    INFO("GLIBManager::pauseAction ThresholdScan new VT1 " << (int)m_lastVT1);
+    CMSGEMOS_INFO("GLIBManager::pauseAction ThresholdScan new VT1 " << (int)m_lastVT1);
   }
-  INFO("GLIBManager::pauseAction end");
+  CMSGEMOS_INFO("GLIBManager::pauseAction end");
 }
 
 void gem::hw::glib::GLIBManager::resumeAction()
@@ -592,17 +592,17 @@ void gem::hw::glib::GLIBManager::resumeAction()
 {
   // what is required for resuming the GLIB?
   usleep(10);  // just for testing the timing of different applications
-  INFO("GLIBManager::resumeAction end");
+  CMSGEMOS_INFO("GLIBManager::resumeAction end");
 }
 
 void gem::hw::glib::GLIBManager::stopAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBManager::stopAction begin");
+  CMSGEMOS_INFO("GLIBManager::stopAction begin");
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);
-    DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
+    CMSGEMOS_DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
     GLIBInfo& info = m_glibInfo[slot].bag;
 
     if (!info.present)
@@ -623,12 +623,12 @@ void gem::hw::glib::GLIBManager::stopAction()
       // FIXME hard coded for now, but super hacky garbage
       statuscmd << "amc_info_uhal.py -s" << (slot+1)
                 << " --shelf="           << info.crateID.toString();
-      INFO("GLIBManager::stopAction running " << statuscmd.str() << " after configuration");
+      CMSGEMOS_INFO("GLIBManager::stopAction running " << statuscmd.str() << " after configuration");
       int retval = std::system(statuscmd.str().c_str());
       if (retval) {
         std::stringstream msg;
         msg << "GLIBManager::stopAction unable to check AMC status: " << retval;
-        WARN(msg.str());
+        CMSGEMOS_WARN(msg.str());
         // fireEvent("Fail");
         // XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
         // XCEPT_RAISE(gem::hw::glib::exception::ConfigurationProblem, msg.str());
@@ -639,17 +639,17 @@ void gem::hw::glib::GLIBManager::stopAction()
     }
   }
   usleep(10);  // just for testing the timing of different applications
-  INFO("GLIBManager::stopAction end");
+  CMSGEMOS_INFO("GLIBManager::stopAction end");
 }
 
 void gem::hw::glib::GLIBManager::haltAction()
   throw (gem::hw::glib::exception::Exception)
 {
   // what is required for halting the GLIB?
-  DEBUG("GLIBManager::resetAction begin");
+  CMSGEMOS_DEBUG("GLIBManager::resetAction begin");
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
-    DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
+    CMSGEMOS_DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
     GLIBInfo& info = m_glibInfo[slot].bag;
 
     if (!info.present)
@@ -669,12 +669,12 @@ void gem::hw::glib::GLIBManager::haltAction()
       // FIXME hard coded for now, but super hacky garbage
       statuscmd << "amc_info_uhal.py -s" << (slot+1)
                 << " --shelf="           << info.crateID.toString();
-      INFO("GLIBManager::haltAction running " << statuscmd.str() << " after halting");
+      CMSGEMOS_INFO("GLIBManager::haltAction running " << statuscmd.str() << " after halting");
       int retval = std::system(statuscmd.str().c_str());
       if (retval) {
         std::stringstream msg;
         msg << "GLIBManager::haltAction unable to check AMC status: " << retval;
-        WARN(msg.str());
+        CMSGEMOS_WARN(msg.str());
         // fireEvent("Fail");
         // XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
         // XCEPT_RAISE(gem::hw::glib::exception::ConfigurationProblem, msg.str());
@@ -684,7 +684,7 @@ void gem::hw::glib::GLIBManager::haltAction()
         m_glibMonitors.at(slot)->resumeMonitoring();
     }
   }
-  INFO("GLIBManager::haltAction end");
+  CMSGEMOS_INFO("GLIBManager::haltAction end");
 }
 
 void gem::hw::glib::GLIBManager::resetAction()
@@ -693,11 +693,11 @@ void gem::hw::glib::GLIBManager::resetAction()
   // what is required for resetting the GLIB?
   // unregister listeners and items in info spaces
 
-  DEBUG("GLIBManager::resetAction begin");
+  CMSGEMOS_DEBUG("GLIBManager::resetAction begin");
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);  // just for testing the timing of different applications
-    DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
+    CMSGEMOS_DEBUG("GLIBManager::looping over slots(" << (slot+1) << ") and finding infospace items");
     GLIBInfo& info = m_glibInfo[slot].bag;
 
     if (!info.present)
@@ -717,12 +717,12 @@ void gem::hw::glib::GLIBManager::resetAction()
       // FIXME hard coded for now, but super hacky garbage
       statuscmd << "amc_info_uhal.py -s" << (slot+1)
                 << " --shelf="           << info.crateID.toString();
-      INFO("GLIBManager::resetAction running " << statuscmd.str() << " after resetting");
+      CMSGEMOS_INFO("GLIBManager::resetAction running " << statuscmd.str() << " after resetting");
       int retval = std::system(statuscmd.str().c_str());
       if (retval) {
         std::stringstream msg;
         msg << "GLIBManager::resetAction unable to check AMC status: " << retval;
-        WARN(msg.str());
+        CMSGEMOS_WARN(msg.str());
         // fireEvent("Fail");
         // XCEPT_RAISE(gem::hw::glib::exception::Exception, msg.str());
         // XCEPT_RAISE(gem::hw::glib::exception::ConfigurationProblem, msg.str());
@@ -732,23 +732,23 @@ void gem::hw::glib::GLIBManager::resetAction()
     if (m_glibMonitors.at(slot))
       m_glibMonitors.at(slot)->reset();
 
-    DEBUG("GLIBManager::looking for hwCfgInfoSpace items for GLIB in slot " << (slot+1));
+    CMSGEMOS_DEBUG("GLIBManager::looking for hwCfgInfoSpace items for GLIB in slot " << (slot+1));
     toolbox::net::URN hwCfgURN("urn:gem:hw:"+toolbox::toString("gem.shelf%02d.amc%02d",
                                                                info.crateID.value_,
                                                                info.slotID.value_));
 
     if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-      DEBUG("GLIBManager::revoking config parameters infospace");
+      CMSGEMOS_DEBUG("GLIBManager::revoking config parameters infospace");
 
       // reset the hw infospace toolbox
       is_glibs.at(slot)->reset();
     } else {
-      DEBUG("GLIBManager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
+      CMSGEMOS_DEBUG("GLIBManager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
       continue;
     }
   }
   // gem::base::GEMFSMApplication::resetAction();
-  INFO("GLIBManager::resetAction end");
+  CMSGEMOS_INFO("GLIBManager::resetAction end");
 }
 
 /*

--- a/gemhardware/src/common/glib/GLIBManagerWeb.cc
+++ b/gemhardware/src/common/glib/GLIBManagerWeb.cc
@@ -26,7 +26,7 @@ void gem::hw::glib::GLIBManagerWeb::webDefault(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
   if (p_gemFSMApp)
-    DEBUG("current state is" << dynamic_cast<gem::hw::glib::GLIBManager*>(p_gemFSMApp)->getCurrentState());
+    CMSGEMOS_DEBUG("current state is" << dynamic_cast<gem::hw::glib::GLIBManager*>(p_gemFSMApp)->getCurrentState());
   *out << cgicc::script().set("type", "text/javascript")
     .set("src", "/gemdaq/gemhardware/html/scripts/glib/glib.js")
        << cgicc::script() << std::endl;
@@ -38,7 +38,7 @@ void gem::hw::glib::GLIBManagerWeb::webDefault(xgi::Input* in, xgi::Output* out)
 void gem::hw::glib::GLIBManagerWeb::monitorPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GLIBManagerWeb::monitorPage");
+  CMSGEMOS_DEBUG("GLIBManagerWeb::monitorPage");
 
   *out << "    <div class=\"xdaq-tab-wrapper\">" << std::endl;
   *out << "      <div class=\"xdaq-tab\" title=\"DAQ Link Monitoring\" >"  << std::endl;
@@ -55,7 +55,7 @@ void gem::hw::glib::GLIBManagerWeb::monitorPage(xgi::Input* in, xgi::Output* out
 void gem::hw::glib::GLIBManagerWeb::expertPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GLIBManagerWeb::expertPage");
+  CMSGEMOS_DEBUG("GLIBManagerWeb::expertPage");
   // fill this page with the expert views for the GLIBManager
   *out << "    <div class=\"xdaq-tab-wrapper\">" << std::endl;
   *out << "      <div class=\"xdaq-tab\" title=\"Register dump page\"/>"  << std::endl;
@@ -124,7 +124,7 @@ void gem::hw::glib::GLIBManagerWeb::buildCardSummaryTable(xgi::Input* in, xgi::O
 void gem::hw::glib::GLIBManagerWeb::cardPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GLIBManagerWeb::cardPage");
+  CMSGEMOS_DEBUG("GLIBManagerWeb::cardPage");
   // fill this page with the card views for the GLIBManager
   *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {
@@ -142,7 +142,7 @@ void gem::hw::glib::GLIBManagerWeb::cardPage(xgi::Input* in, xgi::Output* out)
 void gem::hw::glib::GLIBManagerWeb::registerDumpPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GLIBManagerWeb::registerDumpPage");
+  CMSGEMOS_DEBUG("GLIBManagerWeb::registerDumpPage");
   // dump registers for a given GLIB and display
 }
 
@@ -150,7 +150,7 @@ void gem::hw::glib::GLIBManagerWeb::registerDumpPage(xgi::Input* in, xgi::Output
 void gem::hw::glib::GLIBManagerWeb::fifoDumpPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GLIBManagerWeb::fifoDumpPage");
+  CMSGEMOS_DEBUG("GLIBManagerWeb::fifoDumpPage");
   // dump tracking fifo for given number of blocks
   //*out << cgicc::form() << std::endl;//.set("method","POST").set("action",);
   // input vs. button?
@@ -196,7 +196,7 @@ void gem::hw::glib::GLIBManagerWeb::fifoDumpPage(xgi::Input* in, xgi::Output* ou
 void gem::hw::glib::GLIBManagerWeb::jsonUpdate(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GLIBManagerWeb::jsonUpdate");
+  CMSGEMOS_DEBUG("GLIBManagerWeb::jsonUpdate");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {
@@ -217,7 +217,7 @@ void gem::hw::glib::GLIBManagerWeb::jsonUpdate(xgi::Input* in, xgi::Output* out)
 void gem::hw::glib::GLIBManagerWeb::dumpGLIBFIFO(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GLIBManagerWeb::dumpGLIBFIFO");
+  CMSGEMOS_DEBUG("GLIBManagerWeb::dumpGLIBFIFO");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {

--- a/gemhardware/src/common/glib/GLIBMonitor.cc
+++ b/gemhardware/src/common/glib/GLIBMonitor.cc
@@ -369,11 +369,11 @@ void gem::hw::glib::GLIBMonitor::updateMonitorables()
   // define how to update the desired values
   // get SYSTEM monitorables
   // can this be split into two loops, one just to do a list read, the second to fill the InfoSpace with the returned values
-  DEBUG("GLIBMonitor: Updating monitorables");
+  CMSGEMOS_DEBUG("GLIBMonitor: Updating monitorables");
   for (auto monlist = m_monitorableSetsMap.begin(); monlist != m_monitorableSetsMap.end(); ++monlist) {
-    DEBUG("GLIBMonitor: Updating monitorables in set " << monlist->first);
+    CMSGEMOS_DEBUG("GLIBMonitor: Updating monitorables in set " << monlist->first);
     for (auto monitem = monlist->second.begin(); monitem != monlist->second.end(); ++monitem) {
-      DEBUG("GLIBMonitor: Updating monitorable " << monitem->first);
+      CMSGEMOS_DEBUG("GLIBMonitor: Updating monitorable " << monitem->first);
       std::stringstream regName;
       regName << p_glib->getDeviceBaseNode() << "." << monitem->second.regname;
       uint32_t address = p_glib->getGEMHwInterface().getNode(regName.str()).getAddress();
@@ -413,7 +413,7 @@ void gem::hw::glib::GLIBMonitor::updateMonitorables()
       } else if (monitem->second.updatetype == GEMUpdateType::NOUPDATE) {
         continue;
       } else {
-        ERROR("GLIBMonitor: Unknown update type encountered");
+        CMSGEMOS_ERROR("GLIBMonitor: Unknown update type encountered");
         continue;
       }
     } // end loop over items in list
@@ -422,9 +422,9 @@ void gem::hw::glib::GLIBMonitor::updateMonitorables()
 
 void gem::hw::glib::GLIBMonitor::buildMonitorPage(xgi::Output* out)
 {
-  DEBUG("GLIBMonitor::buildMonitorPage");
+  CMSGEMOS_DEBUG("GLIBMonitor::buildMonitorPage");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
@@ -440,7 +440,7 @@ void gem::hw::glib::GLIBMonitor::buildMonitorPage(xgi::Output* out)
     } else if ((*monset).rfind("Trigger Status") != std::string::npos) {
       buildTriggerStatusTable(out);
     } else {
-      DEBUG("GLIBMonitor::buildMonitorPage building table " << *monset);
+      CMSGEMOS_DEBUG("GLIBMonitor::buildMonitorPage building table " << *monset);
       *out << "<div class=\"xdaq-tab\" title=\""  << *monset << "\" >"  << std::endl
            << "<table class=\"xdaq-table\" id=\"" << *monset << "_table\">" << std::endl
            << cgicc::thead() << std::endl
@@ -461,7 +461,7 @@ void gem::hw::glib::GLIBMonitor::buildMonitorPage(xgi::Output* out)
              << monitem->first
              << "</td>"   << std::endl;
 
-        DEBUG("GLIBMonitor::" << monitem->first << " formatted to "
+        CMSGEMOS_DEBUG("GLIBMonitor::" << monitem->first << " formatted to "
               << (monitem->second.infoSpace)->getFormattedItem(monitem->first,monitem->second.format));
         // this will be repeated for every GLIBMonitor in the GLIBManager..., need a better unique ID
         *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -488,25 +488,25 @@ void gem::hw::glib::GLIBMonitor::buildMonitorPage(xgi::Output* out)
 
 void gem::hw::glib::GLIBMonitor::buildDAQStatusTable(xgi::Output* out)
 {
-  DEBUG("GLIBMonitor::buildDAQStatusTable");
+  CMSGEMOS_DEBUG("GLIBMonitor::buildDAQStatusTable");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
   auto monsets = m_infoSpaceMonitorableSetMap.find("HWMonitoring")->second;
 
   if (std::find(monsets.begin(),monsets.end(),"DAQ Status") == monsets.end()) {
-    WARN("Unable to find item set 'DAQ Status' in list of HWMonitoring monitor sets");
+    CMSGEMOS_WARN("Unable to find item set 'DAQ Status' in list of HWMonitoring monitor sets");
     return;
   }
 
   auto monset = m_monitorableSetsMap.find("DAQ Status")->second;
-  DEBUG("GLIBMonitor::buildDAQStatusTable building DAQ Status table");
+  CMSGEMOS_DEBUG("GLIBMonitor::buildDAQStatusTable building DAQ Status table");
   *out << "<div class=\"xdaq-tab\" title=\"DAQ Status\">" << std::endl
        << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
 
-  DEBUG("GLIBMonitor::buildDAQStatusTable building Common DAQ Status table");
+  CMSGEMOS_DEBUG("GLIBMonitor::buildDAQStatusTable building Common DAQ Status table");
   *out << "<div class=\"xdaq-tab\" title=\"" << "Common DAQ Status" << "\">" << std::endl
        << "<table class=\"xdaq-table\" id=\"CommonDAQStatus_table\">" << std::endl
        << cgicc::thead() << std::endl
@@ -526,7 +526,7 @@ void gem::hw::glib::GLIBMonitor::buildDAQStatusTable(xgi::Output* out)
            << monpair->first
            << "</td>"   << std::endl;
 
-      INFO("GLIBMonitor::" << monpair->first << " formatted to "
+      CMSGEMOS_INFO("GLIBMonitor::" << monpair->first << " formatted to "
             << (monpair->second.infoSpace)->getFormattedItem(monpair->first,monpair->second.format));
       // this will be repeated for every GLIBMonitor in the GLIBManager..., need a better unique ID
       *out << "<td id=\"" << monpair->second.infoSpace->name() << "-" << monpair->first << "\">" << std::endl
@@ -548,7 +548,7 @@ void gem::hw::glib::GLIBMonitor::buildDAQStatusTable(xgi::Output* out)
   *out << "</table>" << std::endl;
   *out << "</div>"   << std::endl;  // closes Common DAQ Status tab
 
-  INFO("GLIBMonitor::buildDAQStatusTable building Per-link DAQ Status table");
+  CMSGEMOS_INFO("GLIBMonitor::buildDAQStatusTable building Per-link DAQ Status table");
   *out << "<div class=\"xdaq-tab\" title=\""  << "Per-link DAQ Status" << "\" >" << std::endl
        << "<table class=\"xdaq-table\" id=\"Per-linkDAQStatus_table\">" << std::endl
        << cgicc::thead() << std::endl
@@ -564,7 +564,7 @@ void gem::hw::glib::GLIBMonitor::buildDAQStatusTable(xgi::Output* out)
        << "<tbody>" << std::endl;
   for (auto monpair = monset.begin(); monpair != monset.end(); ++monpair) {
     if (monpair->first.find("OH0_STATUS") != std::string::npos) {
-      INFO("GLIBMonitor::buildDAQStatusTable " << monpair->first << " found, building per-link structure");
+      CMSGEMOS_INFO("GLIBMonitor::buildDAQStatusTable " << monpair->first << " found, building per-link structure");
       std::array<std::string, 6> linkarray = {{"STATUS",
                                                "EVN",
                                                "EOE_TIMEOUT",
@@ -580,7 +580,7 @@ void gem::hw::glib::GLIBMonitor::buildDAQStatusTable(xgi::Output* out)
              << "</td>"   << std::endl;
 
         for (int i = 0; i < 12; ++i) {
-          INFO("GLIBMonitor::buildDAQStatusTable creating OH" << i << " table header");
+          CMSGEMOS_INFO("GLIBMonitor::buildDAQStatusTable creating OH" << i << " table header");
           std::stringstream substr;
           substr << "OH" << i;
           *out << "<td id=\"" << monpair->second.infoSpace->name() << "-OH" << i << "_" << *regname  << "\">" << std::endl
@@ -608,20 +608,20 @@ void gem::hw::glib::GLIBMonitor::buildDAQStatusTable(xgi::Output* out)
 void gem::hw::glib::GLIBMonitor::buildTriggerStatusTable(xgi::Output* out)
 {
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
   auto monsets = m_infoSpaceMonitorableSetMap.find("HWMonitoring")->second;
 
   if (std::find(monsets.begin(),monsets.end(),"Trigger Status") == monsets.end()) {
-    WARN("Unable to find item set 'Trigger Status' in list of HWMonitoring monitor sets");
+    CMSGEMOS_WARN("Unable to find item set 'Trigger Status' in list of HWMonitoring monitor sets");
     return;
   }
 
   auto monset = m_monitorableSetsMap.find("Trigger Status")->second;
 
-  INFO("GLIBMonitor::buildTriggerStatusTable building Trigger Status table");
+  CMSGEMOS_INFO("GLIBMonitor::buildTriggerStatusTable building Trigger Status table");
   *out << "<div class=\"xdaq-tab\" title=\""  << "Trigger Status" << "\" >" << std::endl
        << "<table class=\"xdaq-table\" id=\"TriggerStatus_table\">" << std::endl
        << cgicc::thead() << std::endl
@@ -639,14 +639,14 @@ void gem::hw::glib::GLIBMonitor::buildTriggerStatusTable(xgi::Output* out)
     if (monpair->first.find("OH0_TRIGGER_RATE") != std::string::npos) {
       std::array<std::string, 2> linkarray = {{"TRIGGER_RATE", "TRIGGER_CNT"}};
       for (auto regname = linkarray.begin(); regname != linkarray.end(); ++regname) {
-        INFO("GLIBMonitor::buildTriggerStatusTable " << monpair->first << " found, building per-link structure");
+        CMSGEMOS_INFO("GLIBMonitor::buildTriggerStatusTable " << monpair->first << " found, building per-link structure");
         *out << "<tr>"    << std::endl
              << "<td>"    << std::endl
              << *regname
              << "</td>"   << std::endl;
 
         for (int i = 0; i < 12; ++i) {
-          INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
+          CMSGEMOS_INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
           *out << "<td id=\"" << monpair->second.infoSpace->name() << "-OH" << i << "_" << *regname << "\">" << std::endl
                << "N/A"
                << "</td>"   << std::endl;
@@ -671,7 +671,7 @@ void gem::hw::glib::GLIBMonitor::buildTriggerStatusTable(xgi::Output* out)
              << "</td>"   << std::endl;
 
         for (int i = 0; i < 12; ++i) {
-          INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
+          CMSGEMOS_INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
           *out << "<td id=\"" << monpair->second.infoSpace->name() << "-OH" << i << "_" << specregname.str() << "\">" << std::endl
                << "N/A"
                << "</td>"   << std::endl;
@@ -695,7 +695,7 @@ void gem::hw::glib::GLIBMonitor::buildTriggerStatusTable(xgi::Output* out)
              << "</td>"   << std::endl;
 
         for (int i = 0; i < 12; ++i) {
-          INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
+          CMSGEMOS_INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
           *out << "<td id=\"" << monpair->second.infoSpace->name() << "-OH" << i << "_" << specregname.str() << "\">" << std::endl
                << "N/A"
                << "</td>"   << std::endl;
@@ -719,7 +719,7 @@ void gem::hw::glib::GLIBMonitor::buildTriggerStatusTable(xgi::Output* out)
              << "</td>"   << std::endl;
 
         for (int i = 0; i < 12; ++i) {
-          INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
+          CMSGEMOS_INFO("GLIBMonitor::buildTriggerStatusTable creating OH" << i << " table header");
           *out << "<td id=\"" << monpair->second.infoSpace->name() << "-OH" << i << "_" << specregname.str() << "\">" << std::endl
                << "N/A"
                << "</td>"   << std::endl;
@@ -743,24 +743,24 @@ void gem::hw::glib::GLIBMonitor::buildTriggerStatusTable(xgi::Output* out)
 void gem::hw::glib::GLIBMonitor::reset()
 {
   // have to get rid of the timer
-  DEBUG("GEMMonitor::reset");
+  CMSGEMOS_DEBUG("GEMMonitor::reset");
   for (auto infoSpace = m_infoSpaceMap.begin(); infoSpace != m_infoSpaceMap.end(); ++infoSpace) {
-    DEBUG("GLIBMonitor::reset removing " << infoSpace->first << " from p_timer");
+    CMSGEMOS_DEBUG("GLIBMonitor::reset removing " << infoSpace->first << " from p_timer");
     try {
       p_timer->remove(infoSpace->first);
     } catch (toolbox::task::exception::Exception& te) {
-      ERROR("GLIBMonitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
+      CMSGEMOS_ERROR("GLIBMonitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
     }
   }
   stopMonitoring();
-  DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
+  CMSGEMOS_DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
   try {
     toolbox::task::getTimerFactory()->removeTimer(m_timerName);
   } catch (toolbox::task::exception::Exception& te) {
-    ERROR("GLIBMonitor::Caught exception while removing timer " << m_timerName << " " << te.what());
+    CMSGEMOS_ERROR("GLIBMonitor::Caught exception while removing timer " << m_timerName << " " << te.what());
   }
 
-  DEBUG("GLIBMonitor::reset - clearing all maps");
+  CMSGEMOS_DEBUG("GLIBMonitor::reset - clearing all maps");
   m_infoSpaceMap.clear();
   m_infoSpaceMonitorableSetMap.clear();
   m_monitorableSetInfoSpaceMap.clear();

--- a/gemhardware/src/common/glib/GLIBReadout.cc
+++ b/gemhardware/src/common/glib/GLIBReadout.cc
@@ -43,13 +43,13 @@ gem::hw::glib::GLIBReadout::GLIBReadout(xdaq::ApplicationStub* stub) :
 
 gem::hw::glib::GLIBReadout::~GLIBReadout()
 {
-  DEBUG("GLIBReadout::destructor called");
+  CMSGEMOS_DEBUG("GLIBReadout::destructor called");
 }
 
 void gem::hw::glib::GLIBReadout::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("GLIBReadout::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("GLIBReadout::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
   }
   // update monitoring variables
@@ -59,20 +59,20 @@ void gem::hw::glib::GLIBReadout::actionPerformed(xdata::Event& event)
 void gem::hw::glib::GLIBReadout::initializeAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::initializeAction begin");
+  CMSGEMOS_INFO("GLIBReadout::initializeAction begin");
   try {
     p_glib = glib_shared_ptr(new gem::hw::glib::HwGLIB(m_deviceName.toString(), m_connectionFile.toString()));
   } catch (gem::hw::glib::exception::Exception const& ex) {
-    ERROR("GLIBReadout::initializeAction caught exception " << ex.what());
+    CMSGEMOS_ERROR("GLIBReadout::initializeAction caught exception " << ex.what());
     XCEPT_RAISE(gem::hw::glib::exception::Exception, "initializeAction failed");
   } catch (toolbox::net::exception::MalformedURN const& ex) {
-    ERROR("GLIBReadout::initializeAction caught exception " << ex.what());
+    CMSGEMOS_ERROR("GLIBReadout::initializeAction caught exception " << ex.what());
     XCEPT_RAISE(gem::hw::glib::exception::Exception, "initializeAction failed");
   } catch (std::exception const& ex) {
-    ERROR("GLIBReadout::initializeAction caught exception " << ex.what());
+    CMSGEMOS_ERROR("GLIBReadout::initializeAction caught exception " << ex.what());
     XCEPT_RAISE(gem::hw::glib::exception::Exception, "initializeAction failed");
   }
-  DEBUG("GLIBReadout::initializeAction connected");
+  CMSGEMOS_DEBUG("GLIBReadout::initializeAction connected");
 
 }
 
@@ -80,7 +80,7 @@ void gem::hw::glib::GLIBReadout::initializeAction()
 void gem::hw::glib::GLIBReadout::configureAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::configureAction begin");
+  CMSGEMOS_INFO("GLIBReadout::configureAction begin");
   // grab these from the config, updated through SOAP too
   m_outFileName  = m_readoutSettings.bag.fileName.toString();
   m_errFileName  = m_outFileName + "_ERR";
@@ -95,48 +95,48 @@ void gem::hw::glib::GLIBReadout::configureAction()
 void gem::hw::glib::GLIBReadout::startAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::startAction begin");
+  CMSGEMOS_INFO("GLIBReadout::startAction begin");
 }
 
 void gem::hw::glib::GLIBReadout::pauseAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::pauseAction begin");
+  CMSGEMOS_INFO("GLIBReadout::pauseAction begin");
 }
 
 void gem::hw::glib::GLIBReadout::resumeAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::resumeAction begin");
+  CMSGEMOS_INFO("GLIBReadout::resumeAction begin");
 }
 
 void gem::hw::glib::GLIBReadout::stopAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::stopAction begin");
+  CMSGEMOS_INFO("GLIBReadout::stopAction begin");
 }
 
 void gem::hw::glib::GLIBReadout::haltAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::haltAction begin");
+  CMSGEMOS_INFO("GLIBReadout::haltAction begin");
 }
 
 void gem::hw::glib::GLIBReadout::resetAction()
   throw (gem::hw::glib::exception::Exception)
 {
-  INFO("GLIBReadout::resetAction begin");
+  CMSGEMOS_INFO("GLIBReadout::resetAction begin");
 }
 
 uint32_t* gem::hw::glib::GLIBReadout::dumpData(uint8_t const& readout_mask)
 {
 
-  INFO("info dump data parker");
-  DEBUG("Reading out dumpData(" << (int)readout_mask << ")");
+  CMSGEMOS_INFO("info dump data parker");
+  CMSGEMOS_DEBUG("Reading out dumpData(" << (int)readout_mask << ")");
   uint32_t *point = &m_counter[0];
   m_contvfats = 0;
   uint32_t* pDu = getGLIBData(readout_mask, m_counter);
-  DEBUG("point 0x" << std::hex << point << " pDu 0x" << pDu << std::dec);
+  CMSGEMOS_DEBUG("point 0x" << std::hex << point << " pDu 0x" << pDu << std::dec);
   if (pDu)
     for (unsigned count = 0; count < 5; ++count) m_counter[count] = *(pDu+count);
 
@@ -147,17 +147,17 @@ uint32_t* gem::hw::glib::GLIBReadout::getGLIBData(uint8_t const& gtx, uint32_t c
 {
   uint32_t *point = &counter[0];
 
-  DEBUG("GLIBReadout::getGLIBData Starting while loop readout "
+  CMSGEMOS_DEBUG("GLIBReadout::getGLIBData Starting while loop readout "
         << std::endl << "FIFO VFAT block depth 0x" << std::hex
         << p_glib->getFIFOVFATBlockOccupancy(gtx)
         << std::endl << "FIFO depth 0x" << std::hex
         << p_glib->getFIFOOccupancy(gtx)
         );
   while ( p_glib->getFIFOVFATBlockOccupancy(gtx) ) {
-    DEBUG("GLIBReadout::getGLIBData initiating call to getTrackingData(gtx,"
+    CMSGEMOS_DEBUG("GLIBReadout::getGLIBData initiating call to getTrackingData(gtx,"
           << p_glib->getFIFOVFATBlockOccupancy(gtx) << ")");
     std::vector<uint32_t> data = p_glib->getTrackingData(gtx, p_glib->getFIFOVFATBlockOccupancy(gtx));
-    DEBUG("GLIBReadout::getGLIBData"
+    CMSGEMOS_DEBUG("GLIBReadout::getGLIBData"
           << std::endl << "FIFO VFAT block depth 0x" << std::hex
           << p_glib->getFIFOVFATBlockOccupancy(gtx)
           << std::endl << "FIFO depth 0x" << std::hex
@@ -168,23 +168,23 @@ uint32_t* gem::hw::glib::GLIBReadout::getGLIBData(uint8_t const& gtx, uint32_t c
     for (auto iword = data.begin(); iword != data.end(); ++iword) {
       contqueue++;
       //gem::utils::LockGuard<gem::utils::Lock> guardedLock(m_queueLock);
-      DEBUG(" ::getGLIBData pushing into queue 0x"
+      CMSGEMOS_DEBUG(" ::getGLIBData pushing into queue 0x"
             << std::setfill('0') << std::setw(8) << std::hex << *iword << std::dec );
       m_dataque.push(*iword);
       if (contqueue%kUPDATE7 == 0 &&  contqueue != 0) {
         m_contvfats++;
-        DEBUG(" ::getGLIBData counter " << contqueue << " contvfats " << m_contvfats
+        CMSGEMOS_DEBUG(" ::getGLIBData counter " << contqueue << " contvfats " << m_contvfats
               << " m_dataque.size " << m_dataque.size());
       }
     }
-    DEBUG(" ::getGLIBData end of while loop do we go again?" << std::endl
+    CMSGEMOS_DEBUG(" ::getGLIBData end of while loop do we go again?" << std::endl
           << " FIFO VFAT block occupancy  0x" << std::hex << p_glib->getFIFOVFATBlockOccupancy(gtx)
           << std::endl
           << " FIFO occupancy             0x" << std::hex << p_glib->getFIFOOccupancy(gtx) << std::endl
           << " hasTrackingData            0x" << std::hex << p_glib->hasTrackingData(gtx)  << std::endl
           );
   }// while(p_glib->getFIFOVFATBlockOccupancy(gtx))
-  DEBUG("GLIBReadout::getGLIBData"
+  CMSGEMOS_DEBUG("GLIBReadout::getGLIBData"
         << std::endl
         << " FIFO VFAT block occupancy  0x" << std::hex << p_glib->getFIFOVFATBlockOccupancy(gtx)
         << std::endl
@@ -197,10 +197,10 @@ uint32_t* gem::hw::glib::GLIBReadout::getGLIBData(uint8_t const& gtx, uint32_t c
 uint32_t* gem::hw::glib::GLIBReadout::selectData(uint32_t counter[5])
 {
   for(int j = 0; j < 5; j++) {
-    INFO("GLIBReadout::selectData counter " << j <<  " "<< counter[j] );
+    CMSGEMOS_INFO("GLIBReadout::selectData counter " << j <<  " "<< counter[j] );
   }
   uint32_t *point = &counter[0];
-  DEBUG("GLIBReadout::selectData point  " << std::hex << point );
+  CMSGEMOS_DEBUG("GLIBReadout::selectData point  " << std::hex << point );
   uint32_t* pDQ = GEMEventMaker(counter);
   for (unsigned count = 0; count < 5; ++count) counter[count] = *(pDQ+count);
   return point;
@@ -220,9 +220,9 @@ uint32_t* gem::hw::glib::GLIBReadout::GEMEventMaker(uint32_t counter[5])
   uint64_t msVFAT, lsVFAT;
   uint32_t ES;
 
-  DEBUG("GLIBReadout::GEMEventMaker  " << std::hex << point );
+  CMSGEMOS_DEBUG("GLIBReadout::GEMEventMaker  " << std::hex << point );
   if (m_dataque.empty()) return point;
-  DEBUG(" ::GEMEventMaker m_dataque.size " << m_dataque.size() );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker m_dataque.size " << m_dataque.size() );
 
   this->readVFATblock(m_dataque);
 
@@ -237,7 +237,7 @@ uint32_t* gem::hw::glib::GLIBReadout::GEMEventMaker(uint32_t counter[5])
 
   // GEM Event selector
   ES = ( evn << 12 ) | bcn;
-  DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << " evn 0x"<< evn
+  CMSGEMOS_DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << " evn 0x"<< evn
         << " bcn 0x" << std::hex << bcn << std::dec << " vftas.size "
         << m_vfats.size() << " m_erros.size " << m_erros.size()
         << " chip ID 0x" << std::hex << (int)chipid << std::dec <<
@@ -261,7 +261,7 @@ uint32_t* gem::hw::glib::GLIBReadout::GEMEventMaker(uint32_t counter[5])
     m_isFirst = true;
 
     if ( m_vfats.size() != 0 || m_erros.size() != 0 ) {
-      DEBUG(" ::GEMEventMaker m_isFirst GEMevSelector ");
+      CMSGEMOS_DEBUG(" ::GEMEventMaker m_isFirst GEMevSelector ");
       GEMevSelector(m_ESexp);
     }
 
@@ -271,15 +271,15 @@ uint32_t* gem::hw::glib::GLIBReadout::GEMEventMaker(uint32_t counter[5])
     m_erros.reserve(MaxERRS);
     m_ESexp = ES;
   }
-  DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << std::dec << " bool " << m_isFirst );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker ES 0x" << std::hex << ES << std::dec << " bool " << m_isFirst );
   //if (islot < 0 || islot > 23) {
   //  if ( int(m_erros.size()) <MaxERRS ) m_erros.push_back(vfat);
-  //  DEBUG(" ::GEMEventMaker warning !!! islot is undefined " << islot << " m_erros.size " << int(m_erros.size()) );
+  //  CMSGEMOS_DEBUG(" ::GEMEventMaker warning !!! islot is undefined " << islot << " m_erros.size " << int(m_erros.size()) );
   //} else {
   // VFATs Pay Load
   if ( int(m_vfats.size()) <= MaxVFATS )
     m_vfats.push_back(vfat);
-  DEBUG(" ::GEMEventMaker m_event " << m_event << " m_vfats.size " << m_vfats.size() << std::hex << " ES 0x" << ES << std::dec );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker m_event " << m_event << " m_vfats.size " << m_vfats.size() << std::hex << " ES 0x" << ES << std::dec );
   //}//end of event selection
 
   m_queueDepth = m_dataque.size();
@@ -302,7 +302,7 @@ void gem::hw::glib::GLIBReadout::GEMevSelector(const  uint32_t& ES)
   AMCGEBData  geb;
   AMCVFATData vfat;
 
-  DEBUG(" ::GEMEventMaker m_vfats.size " << int(m_vfats.size()) << " m_rvent " << m_rvent << " event " << m_event);
+  CMSGEMOS_DEBUG(" ::GEMEventMaker m_vfats.size " << int(m_vfats.size()) << " m_rvent " << m_rvent << " event " << m_event);
 
   uint32_t locEvent = 0;
   uint32_t locError = 0;
@@ -316,7 +316,7 @@ void gem::hw::glib::GLIBReadout::GEMevSelector(const  uint32_t& ES)
     uint8_t ECff = ( (0x0ff0 & (*iVFAT).EC ) >> 4);
     uint32_t localEvent = ( ECff << 12 ) | ( 0x0fff & (*iVFAT).BC );
 
-    DEBUG(" ::GEMEventMaker vfats ES 0x" << std::hex << ( 0x00ffffff & ES) << " and from vfat 0x" <<
+    CMSGEMOS_DEBUG(" ::GEMEventMaker vfats ES 0x" << std::hex << ( 0x00ffffff & ES) << " and from vfat 0x" <<
           ( 0x00ffffff & localEvent ) << " EC 0x" << (int)ECff << " BC 0x" << ( 0x0fff & (*iVFAT).BC ) << std::dec );
 
     if ( ES == localEvent ) {
@@ -332,7 +332,7 @@ void gem::hw::glib::GLIBReadout::GEMevSelector(const  uint32_t& ES)
           GEMfillHeaders(m_event, nChip, gem, geb);
           GEMfillTrailers(gem, geb);
           // GEM Event Writing
-          DEBUG(" ::GEMEventMaker writing...  geb.vfats.size " << int(geb.vfats.size()) );
+          CMSGEMOS_DEBUG(" ::GEMEventMaker writing...  geb.vfats.size " << int(geb.vfats.size()) );
           TypeDataFlag = "PayLoad";
           if(int(geb.vfats.size()) != 0) writeGEMevent(m_outFileName, false, TypeDataFlag,
                                                        gem, geb, vfat);
@@ -348,18 +348,18 @@ void gem::hw::glib::GLIBReadout::GEMevSelector(const  uint32_t& ES)
   TypeDataFlag = "Errors";
 
   // contents all local events (one buffer, all links):
-  DEBUG(" ::GEMEventMaker END ES 0x" << std::hex << ES << std::dec << " errES " <<  m_erros.size() << " m_rvent " << m_rvent );
+  CMSGEMOS_DEBUG(" ::GEMEventMaker END ES 0x" << std::hex << ES << std::dec << " errES " <<  m_erros.size() << " m_rvent " << m_rvent );
 
   uint32_t nErro = 0;
   for (auto iErr=m_erros.begin(); iErr != m_erros.end(); ++iErr) {
 
     uint8_t ECff = ( (0x0ff0 & (*iErr).EC ) >> 4);
     uint32_t localErr = ( ECff << 12 ) | ( 0x0fff & (*iErr).BC );
-    DEBUG(" ::GEMEventMaker ERROR vfats ES 0x" << ES << " EC " << localErr );
+    CMSGEMOS_DEBUG(" ::GEMEventMaker ERROR vfats ES 0x" << ES << " EC " << localErr );
 
     if( ES == localErr ) {
       nErro++;
-      DEBUG(" ::GEMEventMaker " << " nErro " << nErro << " ES 0x" << std::hex << ES << std::dec );
+      CMSGEMOS_DEBUG(" ::GEMEventMaker " << " nErro " << nErro << " ES 0x" << std::hex << ES << std::dec );
       // VFATs Errors
       geb.vfats.push_back(*iErr);
       if ( m_erros.size() == nErro ) {
@@ -380,7 +380,7 @@ void gem::hw::glib::GLIBReadout::GEMevSelector(const  uint32_t& ES)
   geb.vfats.clear();
 
   if (m_event%kUPDATE == 0 &&  m_event != 0) {
-    DEBUG(" ::GEMEventMaker m_vfats.size " << std::setfill(' ') << std::setw(7) << int(m_vfats.size()) <<
+    CMSGEMOS_DEBUG(" ::GEMEventMaker m_vfats.size " << std::setfill(' ') << std::setw(7) << int(m_vfats.size()) <<
           " m_erros.size " << std::setfill(' ') << std::setw(3) << int(m_erros.size()) <<
           " locEvent   " << std::setfill(' ') << std::setw(6) << locEvent <<
           " locError   " << std::setfill(' ') << std::setw(3) << locError << " event " << m_event
@@ -406,7 +406,7 @@ bool gem::hw::glib::GLIBReadout::VFATfillData(/*int const& islot, */AMCGEBData& 
   ChamID =  (0x000000fff0000000 & geb.header) >> 28;
   sumVFAT=  (0x000000000fffffff & geb.header);
 
-  DEBUG(" ::VFATfillData ChamID 0x" << ChamID << std::dec
+  CMSGEMOS_DEBUG(" ::VFATfillData ChamID 0x" << ChamID << std::dec
         //<< " islot " << islot
         << " sumVFAT " << sumVFAT);
 
@@ -425,7 +425,7 @@ void gem::hw::glib::GLIBReadout::writeGEMevent(std::string  outFile, bool const&
                                                AMCGEMData&  gem, AMCGEBData&  geb, AMCVFATData& vfat)
 {
   if(OKprint) {
-    DEBUG(" ::writeGEMevent m_vfat " << m_vfat << " event " << m_event << " sumVFAT " << (0x000000000fffffff & geb.header) <<
+    CMSGEMOS_DEBUG(" ::writeGEMevent m_vfat " << m_vfat << " event " << m_event << " sumVFAT " << (0x000000000fffffff & geb.header) <<
           " geb.vfats.size " << int(geb.vfats.size()) );
   }
   // GEM Chamber's Data
@@ -493,7 +493,7 @@ void gem::hw::glib::GLIBReadout::GEMfillHeaders(uint32_t const& event, uint32_t 
   BXID     =  (0x00000000ffffffff & gem.header1) >> 20;
   DataLgth =  (0x00000000000fffff & gem.header1);
 
-  DEBUG(" ::GEMfillHeaders event " << event << " LV1ID " << LV1ID << " BXID " << BXID);
+  CMSGEMOS_DEBUG(" ::GEMfillHeaders event " << event << " LV1ID " << LV1ID << " BXID " << BXID);
 
   // GEM Event Headers [2]
   uint64_t User        = BOOST_BINARY( 1 );    // :32
@@ -519,7 +519,7 @@ void gem::hw::glib::GLIBReadout::GEMfillHeaders(uint32_t const& event, uint32_t 
   uint64_t MP7BordStat = BOOST_BINARY( 1 );    // :8
 
   gem.header3 = (BufStat << 40)|(DAVList << 16)|(DAVCount << 11)|(FormatVer << 8)|(MP7BordStat);
-  DEBUG("GEM HEADER 3 " << std::hex << gem.header3 << "\n");
+  CMSGEMOS_DEBUG("GEM HEADER 3 " << std::hex << gem.header3 << "\n");
 
   DAVList     = (0xffffff0000000000 & gem.header3) >> 40;
   BufStat     = (0x000000ffffff0000 & gem.header3) >> 16;
@@ -528,13 +528,13 @@ void gem::hw::glib::GLIBReadout::GEMfillHeaders(uint32_t const& event, uint32_t 
   FormatVer   = (0x0000000000000f00 & gem.header3) >> 8;
   MP7BordStat = (0x00000000000000ff & gem.header3);
 
-  DEBUG("DAVCount " << std::hex << DAVCount_check << "\n");
+  CMSGEMOS_DEBUG("DAVCount " << std::hex << DAVCount_check << "\n");
 
   // last geb header:
   uint64_t runhed;
   //geb.runhed = (m_runType << 24)|(m_latency << 16)|(m_VT1 << 8)|(m_VT2);
   geb.runhed = (m_runType << 24)|(m_runParams);
-  INFO("GEMfillHeadres" << geb.runhed);
+  CMSGEMOS_INFO("GEMfillHeadres" << geb.runhed);
 }// end GEMfillHeaders
 
 void gem::hw::glib::GLIBReadout::GEMfillTrailers(AMCGEMData&  gem,AMCGEBData&  geb)
@@ -569,7 +569,7 @@ void gem::hw::glib::GLIBReadout::GEMfillTrailers(AMCGEMData&  gem,AMCGEBData&  g
   OHwCount   = (0x0000ffff00000000 & geb.trailer) >> 32;
   ChamStatus = (0x00000000ffff0000 & geb.trailer) >> 16;
 
-  DEBUG(" OHcrc 0x" << std::hex << OHcrc << " OHwCount " << OHwCount << " ChamStatus " << ChamStatus << std::dec);
+  CMSGEMOS_DEBUG(" OHcrc 0x" << std::hex << OHcrc << " OHwCount " << OHwCount << " ChamStatus " << ChamStatus << std::dec);
 }
 
 void gem::hw::glib::GLIBReadout::readVFATblock(std::queue<uint32_t>& dataque)
@@ -577,7 +577,7 @@ void gem::hw::glib::GLIBReadout::readVFATblock(std::queue<uint32_t>& dataque)
   uint32_t datafront = 0;
   for (int iQue = 0; iQue < 7; iQue++){
     datafront = dataque.front();
-    DEBUG(" ::GEMEventMaker iQue " << iQue << " 0x"
+    CMSGEMOS_DEBUG(" ::GEMEventMaker iQue " << iQue << " 0x"
           << std::setfill('0') << std::setw(8) << std::hex << datafront << std::dec );
     //this never seems to get reset? maybe iQue%7 to read the words after the first block?
     if ((iQue%7) == 5 ) {
@@ -615,7 +615,7 @@ void gem::hw::glib::GLIBReadout::readVFATblock(std::queue<uint32_t>& dataque)
              since iQue stays the same and we removed 7 blocks
              -MD
           */
-          INFO(" ::GEMEventMaker found misaligned word 0x"
+          CMSGEMOS_INFO(" ::GEMEventMaker found misaligned word 0x"
                << std::setfill('0') << std::hex << datafront << std::dec
                << " queue m_dataque.size " << dataque.size() );
           dataque.pop();
@@ -631,9 +631,9 @@ void gem::hw::glib::GLIBReadout::readVFATblock(std::queue<uint32_t>& dataque)
     } else if ( (iQue%7) == 6 ) {
       BX      = datafront;
     }
-    DEBUG(" ::GEMEventMaker (pre pop) m_dataque.size " << dataque.size() );
+    CMSGEMOS_DEBUG(" ::GEMEventMaker (pre pop) m_dataque.size " << dataque.size() );
     dataque.pop();
-    DEBUG(" ::GEMEventMaker (post pop)  m_dataque.size " << dataque.size() );
+    CMSGEMOS_DEBUG(" ::GEMEventMaker (post pop)  m_dataque.size " << dataque.size() );
   }// end queue
 }
 
@@ -644,13 +644,13 @@ void gem::hw::glib::GLIBReadout::ScanRoutines(uint8_t latency, uint8_t VT1, uint
   m_latency = latency;
   m_VT1 = VT1;
   m_VT2 = VT2;
-  DEBUG("GLIBReadout::ScanRoutines Latency = " << (int)m_latency  << " VT1 = " << (int)m_VT1 << " VT2 = " << (int)m_VT2);
+  CMSGEMOS_DEBUG("GLIBReadout::ScanRoutines Latency = " << (int)m_latency  << " VT1 = " << (int)m_VT1 << " VT2 = " << (int)m_VT2);
 }
 
 xoap::MessageReference gem::hw::glib::GLIBReadout::updateScanParameters(xoap::MessageReference msg)
   throw (xoap::exception::Exception)
 {
-  INFO("GLIBReadout::updateScanParameters()");
+  CMSGEMOS_INFO("GLIBReadout::updateScanParameters()");
   if (msg.isNull()) {
     XCEPT_RAISE(xoap::exception::Exception,"Null message received!");
   }
@@ -662,10 +662,10 @@ xoap::MessageReference gem::hw::glib::GLIBReadout::updateScanParameters(xoap::Me
       = gem::utils::soap::GEMSOAPToolBox::extractCommandWithParameter(msg);
     commandName = command.first;
     parameterValue = command.second;
-    INFO("GLIBReadout received command " << commandName);
+    CMSGEMOS_INFO("GLIBReadout received command " << commandName);
   } catch(xoap::exception::Exception& err) {
     std::string msgBase = toolbox::toString("Unable to extract command from CommandWithParameter SOAP message");
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::readout::exception::SOAPCommandParameterProblem, top,
                          toolbox::toString("%s.", msgBase.c_str()), err);
     //p_gemApp->notifyQualified("error", top);
@@ -682,7 +682,7 @@ xoap::MessageReference gem::hw::glib::GLIBReadout::updateScanParameters(xoap::Me
   }
   //this has to be injected into the GEM header
   m_runParams = std::stoi(parameterValue);
-  DEBUG(toolbox::toString("GLIBReadout::updateScanParameters() received command '%s' with value. %s",
+  CMSGEMOS_DEBUG(toolbox::toString("GLIBReadout::updateScanParameters() received command '%s' with value. %s",
                           commandName.c_str(), parameterValue.c_str()));
   return gem::utils::soap::GEMSOAPToolBox::makeFSMSOAPReply(commandName, "ParametersUpdated");
 }
@@ -691,7 +691,7 @@ xoap::MessageReference gem::hw::glib::GLIBReadout::updateScanParameters(xoap::Me
 xoap::MessageReference gem::hw::glib::GLIBReadout::queueDepth(xoap::MessageReference msg)
   throw (xoap::exception::Exception)
 {
-  INFO("GLIBReadout::queueDepth()");
+  CMSGEMOS_INFO("GLIBReadout::queueDepth()");
   if (msg.isNull()) {
     XCEPT_RAISE(xoap::exception::Exception,"Null message received!");
   }
@@ -703,10 +703,10 @@ xoap::MessageReference gem::hw::glib::GLIBReadout::queueDepth(xoap::MessageRefer
       = gem::utils::soap::GEMSOAPToolBox::extractCommandWithParameter(msg);
     commandName = command.first;
     parameterValue = command.second;
-    INFO("GLIBReadout received command " << commandName);
+    CMSGEMOS_INFO("GLIBReadout received command " << commandName);
   } catch(xoap::exception::Exception& err) {
     std::string msgBase = toolbox::toString("Unable to extract command from CommandWithParameter SOAP message");
-    ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
+    CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
     XCEPT_DECLARE_NESTED(gem::readout::exception::SOAPCommandParameterProblem, top,
                          toolbox::toString("%s.", msgBase.c_str()), err);
     //p_gemApp->notifyQualified("error", top);
@@ -722,7 +722,7 @@ xoap::MessageReference gem::hw::glib::GLIBReadout::queueDepth(xoap::MessageRefer
     return reply;
   }
   //this has to be injected into the GEM header
-  DEBUG(toolbox::toString("GLIBReadout::queueDepth() received command '%s' with value. %s",
+  CMSGEMOS_DEBUG(toolbox::toString("GLIBReadout::queueDepth() received command '%s' with value. %s",
                           commandName.c_str(), parameterValue.c_str()));
   return gem::utils::soap::GEMSOAPToolBox::makeFSMSOAPReply(commandName, "ParametersUpdated");
 }

--- a/gemhardware/src/common/glib/HwGLIB.cc
+++ b/gemhardware/src/common/glib/HwGLIB.cc
@@ -6,7 +6,7 @@
 //   gem::hw::HwGenericAMC::HwGenericAMC("HwGLIB")
 //   // monGLIB_(0),
 // {
-//   INFO("HwGLIB ctor");
+//   CMSGEMOS_INFO("HwGLIB ctor");
 
 //   // use a connection file and connection manager?
 //   setDeviceID("GLIBHw");
@@ -14,19 +14,19 @@
 //   setDeviceBaseNode("GEM_AMC");
 //   setExpectedBoardID("GLIB");
 
-//   INFO("HwGLIB ctor done " << isHwConnected());
+//   CMSGEMOS_INFO("HwGLIB ctor done " << isHwConnected());
 // }
 
 gem::hw::glib::HwGLIB::HwGLIB(std::string const& glibDevice,
                               std::string const& connectionFile) :
   gem::hw::HwGenericAMC::HwGenericAMC(glibDevice, connectionFile)
 {
-  INFO("HwGLIB::trying to create HwGLIB(" << glibDevice << "," << connectionFile);
+  CMSGEMOS_INFO("HwGLIB::trying to create HwGLIB(" << glibDevice << "," << connectionFile);
 
   setDeviceBaseNode("GEM_AMC");
   setExpectedBoardID("GLIB");
 
-  INFO("HwGLIB ctor done " << isHwConnected());
+  CMSGEMOS_INFO("HwGLIB ctor done " << isHwConnected());
 }
 
 gem::hw::glib::HwGLIB::HwGLIB(std::string const& glibDevice,
@@ -35,41 +35,41 @@ gem::hw::glib::HwGLIB::HwGLIB(std::string const& glibDevice,
   gem::hw::HwGenericAMC::HwGenericAMC(glibDevice, connectionURI, addressTable)
 
 {
-  INFO("trying to create HwGLIB(" << glibDevice << "," << connectionURI << "," <<addressTable);
+  CMSGEMOS_INFO("trying to create HwGLIB(" << glibDevice << "," << connectionURI << "," <<addressTable);
 
   setDeviceBaseNode("GEM_AMC");
   setExpectedBoardID("GLIB");
 
-  INFO("HwGLIB ctor done " << isHwConnected());
+  CMSGEMOS_INFO("HwGLIB ctor done " << isHwConnected());
 }
 
 gem::hw::glib::HwGLIB::HwGLIB(std::string const& glibDevice,
                               uhal::HwInterface& uhalDevice) :
   gem::hw::HwGenericAMC::HwGenericAMC(glibDevice,uhalDevice)
 {
-  INFO("HwGLIB ctor");
+  CMSGEMOS_INFO("HwGLIB ctor");
 
   setDeviceBaseNode("GEM_AMC");
   setExpectedBoardID("GLIB");
 
-  INFO("HwGLIB ctor done " << isHwConnected());
+  CMSGEMOS_INFO("HwGLIB ctor done " << isHwConnected());
 }
 
 // gem::hw::glib::HwGLIB::HwGLIB(const int& crate, const int& slot) :
 //   gem::hw::HwGenericAMC(toolbox::toString("gem.shelf%02d.glib%02d",crate,slot),crate,slot)
 //   // monGLIB_(0),
 // {
-//   INFO("HwGLIB ctor");
+//   CMSGEMOS_INFO("HwGLIB ctor");
 
 //   // use a connection file and connection manager?
 //   setDeviceID(toolbox::toString("gem.shelf%02d.glib%02d",crate,slot));
 
 //   // uhal::ConnectionManager manager ( "file://${GEM_ADDRESS_TABLE_PATH}/connections.xml" );
-//   INFO("getting the ConnectionManager pointer");
+//   CMSGEMOS_INFO("getting the ConnectionManager pointer");
 //   p_gemConnectionManager.reset(new uhal::ConnectionManager("file://${GEM_ADDRESS_TABLE_PATH}/connections.xml"));
-//   INFO("getting HwInterface " << getDeviceID() << " pointer from ConnectionManager");
+//   CMSGEMOS_INFO("getting HwInterface " << getDeviceID() << " pointer from ConnectionManager");
 //   p_gemHW.reset(new uhal::HwInterface(p_gemConnectionManager->getDevice(this->getDeviceID())));
-//   INFO("setting the device base node");
+//   CMSGEMOS_INFO("setting the device base node");
 //   setDeviceBaseNode("GEM_AMC");
 //   setExpectedBoardID("GLIB");
 
@@ -81,7 +81,7 @@ gem::hw::glib::HwGLIB::HwGLIB(std::string const& glibDevice,
 //     m_ipBusCounters.push_back(tmpGTXCounter);
 //   }
 
-//   INFO("HwGLIB ctor done " << isHwConnected());
+//   CMSGEMOS_INFO("HwGLIB ctor done " << isHwConnected());
 // }
 
 gem::hw::glib::HwGLIB::~HwGLIB()
@@ -162,14 +162,14 @@ void gem::hw::glib::HwGLIB::XPointControl(bool xpoint2, uint8_t const& input, ui
 {
   if (xpoint2 && (input > 2 || output > 0)) {
     std::string msg = toolbox::toString("Invalid clock routing for XPoint2 %d -> %d",input,output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::glib::exception::InvalidXPoint2Routing,msg);
     return;
   }
 
   if ((input > 3 || output > 3)) {
     std::string msg = toolbox::toString( "Invalid clock routing for XPoint%d %d -> %d",xpoint2,input,output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::glib::exception::InvalidXPointRouting,msg);
     return;
   }
@@ -206,7 +206,7 @@ uint8_t gem::hw::glib::HwGLIB::XPointControl(bool xpoint2, uint8_t const& output
   /*
     if (xpoint2 && output > 0) {
     std::string msg = toolbox::toString("Invalid clock output for XPoint2 %d",output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::glib::exception::InvalidXPoint2Routing,msg);
     return output;
     }
@@ -214,7 +214,7 @@ uint8_t gem::hw::glib::HwGLIB::XPointControl(bool xpoint2, uint8_t const& output
 
   if (output > 3) {
     std::string msg = toolbox::toString( "Invalid clock output for XPoint%d %d",xpoint2,output);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::glib::exception::InvalidXPointRouting,msg);
     return output;
   }
@@ -247,7 +247,7 @@ uint8_t gem::hw::glib::HwGLIB::SFPStatus(uint8_t const& sfpcage)
   // gem::utils::LockGuard<gem::utils::Lock> guardedLock(hwLock_);
   if (sfpcage < 1 || sfpcage > 4) {
     std::string msg = toolbox::toString("Status requested for SFP (%d): outside expectation (1,4)", sfpcage);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::glib::exception::InvalidLink,msg);
     return 0;
   }

--- a/gemhardware/src/common/optohybrid/HwOptoHybrid.cc
+++ b/gemhardware/src/common/optohybrid/HwOptoHybrid.cc
@@ -19,7 +19,7 @@
 //   setDeviceBaseNode("GEM_AMC.OH.OH0");
 //   //gem::hw::optohybrid::HwOptoHybrid::initDevice();
 //   //set up which links are active, so that the control can be done without specifying a link
-//   INFO("HwOptoHybrid ctor done " << isHwConnected());
+//   CMSGEMOS_INFO("HwOptoHybrid ctor done " << isHwConnected());
 // }
 
 gem::hw::optohybrid::HwOptoHybrid::HwOptoHybrid(std::string const& optohybridDevice,
@@ -33,7 +33,7 @@ gem::hw::optohybrid::HwOptoHybrid::HwOptoHybrid(std::string const& optohybridDev
   std::stringstream basenode;
   basenode << "GEM_AMC.OH.OH" << *optohybridDevice.rbegin();
   setDeviceBaseNode(basenode.str());
-  INFO("HwOptoHybrid ctor done (basenode "
+  CMSGEMOS_INFO("HwOptoHybrid ctor done (basenode "
        << basenode.str() << ") " << isHwConnected());
 }
 
@@ -50,7 +50,7 @@ gem::hw::optohybrid::HwOptoHybrid::HwOptoHybrid(std::string const& optohybridDev
   std::stringstream basenode;
   basenode << "GEM_AMC.OH.OH" << *optohybridDevice.rbegin();
   setDeviceBaseNode(basenode.str());
-  INFO("HwOptoHybrid ctor done (basenode "
+  CMSGEMOS_INFO("HwOptoHybrid ctor done (basenode "
        << basenode.str() << ") " << isHwConnected());
 }
 
@@ -65,7 +65,7 @@ gem::hw::optohybrid::HwOptoHybrid::HwOptoHybrid(std::string const& optohybridDev
   std::stringstream basenode;
   basenode << "GEM_AMC.OH.OH" << *optohybridDevice.rbegin();
   setDeviceBaseNode(basenode.str());
-  INFO("HwOptoHybrid ctor done (basenode "
+  CMSGEMOS_INFO("HwOptoHybrid ctor done (basenode "
        << basenode.str() << ") " << isHwConnected());
 }
 
@@ -79,7 +79,7 @@ gem::hw::optohybrid::HwOptoHybrid::HwOptoHybrid(gem::hw::glib::HwGLIB const& gli
   m_controlLink(-1),
   m_slot((int)slot)
 {
-  INFO("HwOptoHybrid creating OptoHybrid device from GLIB device " << glibDevice.getLoggerName());
+  CMSGEMOS_INFO("HwOptoHybrid creating OptoHybrid device from GLIB device " << glibDevice.getLoggerName());
   //use a connection file and connection manager?
   setDeviceID(toolbox::toString("%s.optohybrid%02d",glibDevice.getDeviceID().c_str(),slot));
   //uhal::ConnectionManager manager ( "file://${GEM_ADDRESS_TABLE_PATH}/connections.xml" );
@@ -90,7 +90,7 @@ gem::hw::optohybrid::HwOptoHybrid::HwOptoHybrid(gem::hw::glib::HwGLIB const& gli
   std::stringstream basenode;
   basenode << "GEM_AMC.OH.OH" << (int)slot;
   setDeviceBaseNode(basenode.str());
-  INFO("HwOptoHybrid ctor done (basenode "
+  CMSGEMOS_INFO("HwOptoHybrid ctor done (basenode "
        << basenode.str() << ") " << isHwConnected());
 }
 
@@ -153,10 +153,10 @@ gem::hw::optohybrid::HwOptoHybrid::~HwOptoHybrid()
 bool gem::hw::optohybrid::HwOptoHybrid::isHwConnected()
 {
   if (b_is_connected) {
-    DEBUG("HwOptoHybrid connection good");
+    CMSGEMOS_DEBUG("HwOptoHybrid connection good");
     return true;
   } else if (gem::hw::GEMHwDevice::isHwConnected()) {
-    DEBUG("Checking hardware connection");
+    CMSGEMOS_DEBUG("Checking hardware connection");
 
     // FIXME IN FIRMWARE, need better check of connectivity...
     if ((this->getFirmwareDateString()).rfind("15") != std::string::npos ||
@@ -164,19 +164,19 @@ bool gem::hw::optohybrid::HwOptoHybrid::isHwConnected()
         (this->getFirmwareDateString()).rfind("17") != std::string::npos ||
         (this->getFirmwareDateString()).rfind("18") != std::string::npos) {
       b_is_connected = true;
-      INFO("OptoHybrid present ("
+      CMSGEMOS_INFO("OptoHybrid present ("
            << this->getFirmwareVersionString() << "/0x"
            << std::hex << this->getFirmwareDate() << std::dec << ")");
       return true;
     } else {
       b_is_connected = false;
-      DEBUG("OptoHybrid not reachable (unable to find 15 or 16 in the firmware string)."
+      CMSGEMOS_DEBUG("OptoHybrid not reachable (unable to find 15 or 16 in the firmware string)."
             << " Obviously we need a better strategy to check connectivity");
       return false;
     }
   }
   //shouldn't get to here unless HW isn't connected
-  DEBUG("OptoHybrid not reachable (!b_is_connected && !GEMHwDevice::isHwConnnected)");
+  CMSGEMOS_DEBUG("OptoHybrid not reachable (!b_is_connected && !GEMHwDevice::isHwConnnected)");
   return false;
 }
 
@@ -223,12 +223,12 @@ std::vector<uint32_t> gem::hw::optohybrid::HwOptoHybrid::broadcastRead(std::stri
   readReg(getDeviceBaseNode(),toolbox::toString("GEB.Broadcast.Request.%s", name.c_str()));
 
   while (readReg(getDeviceBaseNode(),"GEB.Broadcast.Running")) {
-    TRACE("HwOptoHybrid::broadcastRead transaction on "
+    CMSGEMOS_TRACE("HwOptoHybrid::broadcastRead transaction on "
           << name << " is still running...");
     usleep(10);
   }
   auto t2 = std::chrono::high_resolution_clock::now();
-  TRACE("HwOptoHybrid::broadcastRead transaction on " << name << " lasted "
+  CMSGEMOS_TRACE("HwOptoHybrid::broadcastRead transaction on " << name << " lasted "
         << std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count() << "ns");
   std::stringstream regName;
   regName << getDeviceBaseNode() << ".GEB.Broadcast.Results";
@@ -248,12 +248,12 @@ void gem::hw::optohybrid::HwOptoHybrid::broadcastWrite(std::string const& name,
   writeReg(getDeviceBaseNode(),toolbox::toString("GEB.Broadcast.Mask"),mask);
   writeReg(getDeviceBaseNode(),toolbox::toString("GEB.Broadcast.Request.%s", name.c_str()),value);
   while (readReg(getDeviceBaseNode(),"GEB.Broadcast.Running")) {
-    TRACE("HwOptoHybrid::broadcastWrite transaction on "
+    CMSGEMOS_TRACE("HwOptoHybrid::broadcastWrite transaction on "
           << name << " is still running...");
     usleep(10);
   }
   auto t2 = std::chrono::high_resolution_clock::now();
-  TRACE("HwOptoHybrid::broadcastWrite transaction on " << name << " lasted "
+  CMSGEMOS_TRACE("HwOptoHybrid::broadcastWrite transaction on " << name << " lasted "
         << std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count() << "ns");
 }
 
@@ -263,7 +263,7 @@ std::vector<std::pair<uint8_t,uint32_t> > gem::hw::optohybrid::HwOptoHybrid::get
   if (update || b_is_initial) {
     std::vector<uint32_t> chips0 = broadcastRead("ChipID0",ALL_VFATS_BCAST_MASK,false);
     std::vector<uint32_t> chips1 = broadcastRead("ChipID1",ALL_VFATS_BCAST_MASK,false);
-    DEBUG("HwOptoHybrid::getConnectedVFATs chips0 size:" << chips0.size() <<  ", chips1 size:" << chips1.size());
+    CMSGEMOS_DEBUG("HwOptoHybrid::getConnectedVFATs chips0 size:" << chips0.size() <<  ", chips1 size:" << chips1.size());
 
     std::vector<std::pair<uint8_t, uint32_t> > chipIDs;
     std::vector<std::pair<uint32_t,uint32_t> > chipPairs;
@@ -277,7 +277,7 @@ std::vector<std::pair<uint8_t,uint32_t> > gem::hw::optohybrid::HwOptoHybrid::get
       if (((chip->first) >> 16) != 0x3) {
         uint8_t slot = ((chip->first)>>8)&0xff;
         uint32_t chipID = (((chip->first)&0xff)<<8)+((chip->second)&0xff);
-        DEBUG("HwOptoHybrid::getConnectedVFATs GEB slot: " << (int)slot
+        CMSGEMOS_DEBUG("HwOptoHybrid::getConnectedVFATs GEB slot: " << (int)slot
               << ", chipID1: 0x" << std::hex << chip->first   << std::dec
               << ", chipID2: 0x" << std::hex << chip->second  << std::dec
               << ", chipID: 0x"  << std::hex << chipID        << std::dec);
@@ -297,13 +297,13 @@ uint32_t gem::hw::optohybrid::HwOptoHybrid::getConnectedVFATMask(bool update)
     std::vector<uint32_t> allChips = broadcastRead("ChipID0",ALL_VFATS_BCAST_MASK);
     uint32_t connectedMask = 0x0; // high means don't broadcast
     uint32_t disabledMask  = 0x0; // high means ignore data
-    DEBUG("HwOptoHybrid::getConnectedVFATMask Reading ChipID0 from all possible slots");
+    CMSGEMOS_DEBUG("HwOptoHybrid::getConnectedVFATMask Reading ChipID0 from all possible slots");
     for (auto id = allChips.begin(); id != allChips.end(); ++id) {
       // 0x00XXYYZZ
       // XX = status (00000EVR)
       // YY = chip number
       // ZZ = register contents
-      INFO("HwOptoHybrid::getConnectedVFATMask result 0x" << std::setw(8) << std::setfill('0') << std::hex << *id << std::dec);
+      CMSGEMOS_INFO("HwOptoHybrid::getConnectedVFATMask result 0x" << std::setw(8) << std::setfill('0') << std::hex << *id << std::dec);
       // bool e_bit(((*id)>>18)&0x1),v_bit(((*id)>>17)&0x1),r_bit(((*id)>>16)&0x1);
 
       // if (v_bit && !e_bit) {
@@ -312,18 +312,18 @@ uint32_t gem::hw::optohybrid::HwOptoHybrid::getConnectedVFATMask(bool update)
         connectedMask |= (0x1 << shift);
         disabledMask  |= (0x1 << shift);
       }
-      DEBUG("HwOptoHybrid::getConnectedVFATMask mask is " << std::hex << connectedMask << std::dec);
+      CMSGEMOS_DEBUG("HwOptoHybrid::getConnectedVFATMask mask is " << std::hex << connectedMask << std::dec);
   }
 
-    DEBUG("HwOptoHybrid::getConnectedVFATMask previous mask is 0x" << std::setw(8) << std::setfill('0')
+    CMSGEMOS_DEBUG("HwOptoHybrid::getConnectedVFATMask previous mask is 0x" << std::setw(8) << std::setfill('0')
           << std::hex << connectedMask << std::dec);
     connectedMask = ~connectedMask;
     disabledMask  = ~disabledMask ;
-    DEBUG("HwOptoHybrid::getConnectedVFATMask intermediate mask is 0x" << std::setw(8) << std::setfill('0')
+    CMSGEMOS_DEBUG("HwOptoHybrid::getConnectedVFATMask intermediate mask is 0x" << std::setw(8) << std::setfill('0')
           << std::hex << connectedMask << std::dec);
     connectedMask |= ALL_VFATS_BCAST_MASK;
     disabledMask  |= ALL_VFATS_BCAST_MASK;
-    DEBUG("HwOptoHybrid::getConnectedVFATMask final mask is 0x" << std::setw(8) << std::setfill('0')
+    CMSGEMOS_DEBUG("HwOptoHybrid::getConnectedVFATMask final mask is 0x" << std::setw(8) << std::setfill('0')
           << std::hex << connectedMask << std::dec);
 
      m_disabledMask  = connectedMask;
@@ -342,9 +342,9 @@ void gem::hw::optohybrid::HwOptoHybrid::setVFATsToDefaults(uint8_t  const& vt1,
   // regName << getDeviceBaseNode() << ".GEB.Broadcast.Results";
   // std::vector<uint32_t> res;
   // res = readBlock(regName.str(),std::bitset<32>(~broadcastMask).count());
-  // WARN("HwOptoHybrid::setVFATsToDefaults::Latency");
+  // CMSGEMOS_WARN("HwOptoHybrid::setVFATsToDefaults::Latency");
   // for (auto r = res.begin(); r != res.end(); ++r) {
-  //   WARN(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
+  //   CMSGEMOS_WARN(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
   // }
 
   broadcastWrite("ContReg0",   0x36, broadcastMask);
@@ -480,7 +480,7 @@ uint32_t gem::hw::optohybrid::HwOptoHybrid::getADCVAUX(uint8_t const& vaux)
 {
   if (vaux > 15) {
     std::string msg = toolbox::toString("Invalid VAUX requested (%d): outside expectation (0-15)",int(vaux));
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::optohybrid::exception::ValueError,msg);
   }
   std::stringstream vauxInput;
@@ -492,7 +492,7 @@ uint32_t gem::hw::optohybrid::HwOptoHybrid::getVFATDACOutV(uint8_t const& column
 {
   if (column > 2) {
     std::string msg = toolbox::toString("Invalid column requested (%d): outside expectation (0-2)",int(column));
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::optohybrid::exception::ValueError,msg);
   }
 
@@ -506,7 +506,7 @@ uint32_t gem::hw::optohybrid::HwOptoHybrid::getVFATDACOutV(uint8_t const& column
     vauxInput << "ADC.VPVN";
   default:
     std::string msg = toolbox::toString("Invalid column requested (%d): outside expectation (0-2)",int(column));
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     return 0;
   }
   return readReg(getDeviceBaseNode(),vauxInput.str());
@@ -516,7 +516,7 @@ uint32_t gem::hw::optohybrid::HwOptoHybrid::getVFATDACOutI(uint8_t const& column
 {
   if (column > 2) {
     std::string msg = toolbox::toString("Invalid column requested (%d): outside expectation (0-2)",int(column));
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::optohybrid::exception::ValueError,msg);
   }
 
@@ -530,7 +530,7 @@ uint32_t gem::hw::optohybrid::HwOptoHybrid::getVFATDACOutI(uint8_t const& column
     vauxInput << "ADC.VAUX.VAL_13";
   default:
     std::string msg = toolbox::toString("Invalid column requested (%d): outside expectation (0-2)",int(column));
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     return 0;
   }
   return readReg(getDeviceBaseNode(),vauxInput.str());
@@ -618,7 +618,7 @@ uint8_t gem::hw::optohybrid::HwOptoHybrid::getScanStatus(bool useUltra)
 std::vector<uint32_t> gem::hw::optohybrid::HwOptoHybrid::getScanResults(uint32_t const& npoints)
 {
   while (readReg(getDeviceBaseNode(),"ScanController.THLAT.MONITOR.STATUS") > 0) {
-    INFO("Scan still running, not returning results");
+    CMSGEMOS_INFO("Scan still running, not returning results");
     usleep(10);
   }
   std::stringstream regname;
@@ -629,7 +629,7 @@ std::vector<uint32_t> gem::hw::optohybrid::HwOptoHybrid::getScanResults(uint32_t
 std::vector<std::vector<uint32_t> > gem::hw::optohybrid::HwOptoHybrid::getUltraScanResults(uint32_t const& npoints)
 {
   while (readReg(getDeviceBaseNode(),"ScanController.ULTRA.MONITOR.STATUS") > 0) {
-    INFO("Scan still running, not returning results");
+    CMSGEMOS_INFO("Scan still running, not returning results");
     usleep(10);
   }
   std::vector<std::vector<uint32_t> > results;

--- a/gemhardware/src/common/optohybrid/OptoHybridManager.cc
+++ b/gemhardware/src/common/optohybrid/OptoHybridManager.cc
@@ -149,10 +149,10 @@ gem::hw::optohybrid::OptoHybridManager::OptoHybridManager(xdaq::ApplicationStub*
   p_appInfoSpace->addItemChangedListener( "ConnectionFile",     this);
 
   // initialize the OptoHybrid application objects
-  DEBUG("OptoHybridManager::Connecting to the OptoHybridManagerWeb interface");
+  CMSGEMOS_DEBUG("OptoHybridManager::Connecting to the OptoHybridManagerWeb interface");
   p_gemWebInterface = new gem::hw::optohybrid::OptoHybridManagerWeb(this);
   // p_gemMonitor      = new gem::hw::optohybrid::OptoHybridHwMonitor(this);
-  DEBUG("OptoHybridManager::done");
+  CMSGEMOS_DEBUG("OptoHybridManager::done");
 
   // set up the info hwCfgInfoSpace
   init();
@@ -168,7 +168,7 @@ gem::hw::optohybrid::OptoHybridManager::~OptoHybridManager() {
 void gem::hw::optohybrid::OptoHybridManager::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("OptoHybridManager::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("OptoHybridManager::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
 
     // how to handle passing in various values nested in a vector in a bag
@@ -176,15 +176,15 @@ void gem::hw::optohybrid::OptoHybridManager::actionPerformed(xdata::Event& event
       // if (board->bag.present.value_) {
       if (board->bag.crateID.value_ > -1) {
         board->bag.present = true;
-        INFO("OptoHybridManager::Found attribute:" << board->bag.toString());
+        CMSGEMOS_INFO("OptoHybridManager::Found attribute:" << board->bag.toString());
         uint32_t tmpBroadcastMask = gem::hw::utils::parseVFATMaskList(board->bag.vfatBroadcastList.toString());
-        INFO("OptoHybridManager::Parsed vfatBroadcastList = " << board->bag.vfatBroadcastList.toString()
+        CMSGEMOS_INFO("OptoHybridManager::Parsed vfatBroadcastList = " << board->bag.vfatBroadcastList.toString()
              << " to broadcastMask 0x" << std::hex << tmpBroadcastMask << std::dec);
         board->bag.vfatBroadcastMask = tmpBroadcastMask;
         // board->bag.vfatBroadcastMask.push_back(parseVFATMaskList(board->bag.vfatBroadcastList.toString()));
 
         uint32_t tmpSBitMask = gem::hw::utils::parseVFATMaskList(board->bag.vfatSBitList.toString());
-        INFO("OptoHybridManager::Parsed vfatSBitList = " << board->bag.vfatSBitList.toString()
+        CMSGEMOS_INFO("OptoHybridManager::Parsed vfatSBitList = " << board->bag.vfatSBitList.toString()
              << " to sbitMask 0x" << std::hex << tmpSBitMask << std::dec);
         board->bag.vfatSBitMask = tmpSBitMask;
       }
@@ -203,16 +203,16 @@ void gem::hw::optohybrid::OptoHybridManager::init()
 void gem::hw::optohybrid::OptoHybridManager::initializeAction()
   throw (gem::hw::optohybrid::exception::Exception)
 {
-  DEBUG("OptoHybridManager::initializeAction begin");
+  CMSGEMOS_DEBUG("OptoHybridManager::initializeAction begin");
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
-    DEBUG("OptoHybridManager::initializeAction looping over slots(" << (slot+1) << ") and finding expected cards");
+    CMSGEMOS_DEBUG("OptoHybridManager::initializeAction looping over slots(" << (slot+1) << ") and finding expected cards");
     for (unsigned link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link) {
-      DEBUG("OptoHybridManager::initializeAction looping over links(" << link << ") and finding expected cards");
+      CMSGEMOS_DEBUG("OptoHybridManager::initializeAction looping over links(" << link << ") and finding expected cards");
       unsigned int index = (slot*MAX_OPTOHYBRIDS_PER_AMC)+link;
-      DEBUG("OptoHybridManager::initializeAction index = " << index);
+      CMSGEMOS_DEBUG("OptoHybridManager::initializeAction index = " << index);
       OptoHybridInfo& info = m_optohybridInfo[index].bag;
-      DEBUG("OptoHybridManager::initializeAction bag"
+      CMSGEMOS_DEBUG("OptoHybridManager::initializeAction bag"
             << "crate " << info.crateID.value_
             << " slot " << info.slotID.value_
             << " link " << info.linkID.value_);
@@ -220,8 +220,8 @@ void gem::hw::optohybrid::OptoHybridManager::initializeAction()
       if (!info.present)
         continue;
 
-      DEBUG("OptoHybridManager::initializeAction: info is: " << info.toString());
-      DEBUG("OptoHybridManager::initializeAction creating pointer to board connected on link "
+      CMSGEMOS_DEBUG("OptoHybridManager::initializeAction: info is: " << info.toString());
+      CMSGEMOS_DEBUG("OptoHybridManager::initializeAction creating pointer to board connected on link "
             << link << " to AMC in slot " << (slot+1));
       std::string deviceName = info.cardName.toString();
       if (deviceName.empty())
@@ -232,66 +232,66 @@ void gem::hw::optohybrid::OptoHybridManager::initializeAction()
       toolbox::net::URN hwCfgURN("urn:gem:hw:"+deviceName);
 
       if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-        DEBUG("OptoHybridManager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
+        CMSGEMOS_DEBUG("OptoHybridManager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
         is_optohybrids.at(slot).at(link) = is_toolbox_ptr(new gem::base::utils::GEMInfoSpaceToolBox(this,
                                                                                                     hwCfgURN.toString(),
                                                                                                     true));
 
       } else {
-        DEBUG("OptoHybridManager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
+        CMSGEMOS_DEBUG("OptoHybridManager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
         is_optohybrids.at(slot).at(link) = is_toolbox_ptr(new gem::base::utils::GEMInfoSpaceToolBox(this,
                                                                                                     hwCfgURN.toString(),
                                                                                                     true));
       }
 
       try {
-        DEBUG("OptoHybridManager::initializeAction obtaining pointer to HwOptoHybrid " << deviceName
+        CMSGEMOS_DEBUG("OptoHybridManager::initializeAction obtaining pointer to HwOptoHybrid " << deviceName
               << " (slot " << slot+1 << ")"
               << " (link " << link   << ")");
         m_optohybrids.at(slot).at(link) = optohybrid_shared_ptr(new gem::hw::optohybrid::HwOptoHybrid(deviceName,m_connectionFile.toString()));
       } catch (gem::hw::optohybrid::exception::Exception const& e) {
         std::stringstream msg;
         msg << "OptoHybridManager::initializeAction caught exception " << e.what();
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       } catch (toolbox::net::exception::MalformedURN const& e) {
         std::stringstream msg;
         msg << "OptoHybridManager::initializeAction caught exception " << e.what();
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       } catch (std::exception const& e) {
         std::stringstream msg;
         msg << "OptoHybridManager::initializeAction caught exception " << e.what();
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       }
-      DEBUG("OptoHybridManager::initializeAction connected");
+      CMSGEMOS_DEBUG("OptoHybridManager::initializeAction connected");
       // set the web view to be empty or grey
       // if (!info.present.value_) continue;
       // p_gemWebInterface->optohybridInSlot(slot);
 
-      DEBUG("OptoHybridManager::initializeAction grabbing pointer to hardware device");
+      CMSGEMOS_DEBUG("OptoHybridManager::initializeAction grabbing pointer to hardware device");
       optohybrid_shared_ptr optohybrid = m_optohybrids.at(slot).at(link);
       if (optohybrid->isHwConnected()) {
         // get connected VFATs
         m_vfatMapping.at(slot).at(link)   = optohybrid->getConnectedVFATs(true);
-        INFO("OptoHybridManager::initializeAction Obtained vfatMapping");
+        CMSGEMOS_INFO("OptoHybridManager::initializeAction Obtained vfatMapping");
         // all the rest of these are related to the first by bitwise logic, can avoid doing the 4 calls
         m_trackingMask.at(slot).at(link)  = optohybrid->getConnectedVFATMask(true);
-        INFO("OptoHybridManager::initializeAction Obtained trackingMask");
+        CMSGEMOS_INFO("OptoHybridManager::initializeAction Obtained trackingMask");
         m_broadcastList.at(slot).at(link) = m_trackingMask.at(slot).at(link);
-        INFO("OptoHybridManager::initializeAction Obtained broadcastList");
+        CMSGEMOS_INFO("OptoHybridManager::initializeAction Obtained broadcastList");
         m_sbitMask.at(slot).at(link) = m_trackingMask.at(slot).at(link);
-        INFO("OptoHybridManager::initializeAction Obtained sbitMask");
+        CMSGEMOS_INFO("OptoHybridManager::initializeAction Obtained sbitMask");
 
         createOptoHybridInfoSpaceItems(is_optohybrids.at(slot).at(link), optohybrid);
-        INFO("OptoHybridManager::initializeAction looping over created VFAT devices");
+        CMSGEMOS_INFO("OptoHybridManager::initializeAction looping over created VFAT devices");
         for (auto mapit = m_vfatMapping.at(slot).at(link).begin();
              mapit != m_vfatMapping.at(slot).at(link).end(); ++mapit) {
-          INFO("OptoHybridManager::initializeAction VFAT" << (int)mapit->first << " has chipID "
+          CMSGEMOS_INFO("OptoHybridManager::initializeAction VFAT" << (int)mapit->first << " has chipID "
                << std::hex << (int)mapit->second << std::dec << " (from map)");
           // gem::hw::vfat::HwVFAT2& vfatDevice = optohybrid->getVFATDevice(mapit->first);
-          // INFO("OptoHybridManager::initializeAction VFAT" << (int)mapit->first << " has chipID "
+          // CMSGEMOS_INFO("OptoHybridManager::initializeAction VFAT" << (int)mapit->first << " has chipID "
           //      << std::hex << (int)vfatDevice.getChipID() << std::dec << " (from HW device) ");
         }
 
@@ -302,7 +302,7 @@ void gem::hw::optohybrid::OptoHybridManager::initializeAction()
           m_optohybridMonitors.at(slot).at(link)->startMonitoring();
         }
 
-        INFO("OptoHybridManager::initializeAction OptoHybrid connected on link "
+        CMSGEMOS_INFO("OptoHybridManager::initializeAction OptoHybrid connected on link "
              << link << " to AMC in slot " << (slot+1) << std::endl
              << "Tracking mask: 0x" << std::hex << std::setw(8) << std::setfill('0')
              << m_trackingMask.at(slot).at(link)
@@ -321,7 +321,7 @@ void gem::hw::optohybrid::OptoHybridManager::initializeAction()
         std::stringstream msg;
         msg << "OptoHybridManager::initializeAction OptoHybrid connected on link "
             << link << " to AMC in slot " << (slot+1) << " is not responding";
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         // fireEvent("Fail");
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       }
@@ -329,13 +329,13 @@ void gem::hw::optohybrid::OptoHybridManager::initializeAction()
       // hardware should be connected, can update ldqm_db for teststand/local runs
     }
   }
-  INFO("OptoHybridManager::initializeAction end");
+  CMSGEMOS_INFO("OptoHybridManager::initializeAction end");
 }
 
 void gem::hw::optohybrid::OptoHybridManager::configureAction()
   throw (gem::hw::optohybrid::exception::Exception)
 {
-  DEBUG("OptoHybridManager::configureAction");
+  CMSGEMOS_DEBUG("OptoHybridManager::configureAction");
   // std::ofstream of
 
   std::map<int,std::set<int> > hwMapping;
@@ -352,34 +352,34 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
     for (unsigned link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link) {
       // usleep(10); // just for testing the timing of different applications
       unsigned int index = (slot*MAX_OPTOHYBRIDS_PER_AMC)+link;
-      DEBUG("OptoHybridManager::index = " << index);
+      CMSGEMOS_DEBUG("OptoHybridManager::index = " << index);
       OptoHybridInfo& info = m_optohybridInfo[index].bag;
 
-      DEBUG("OptoHybridManager::configureAction::info is: " << info.toString());
+      CMSGEMOS_DEBUG("OptoHybridManager::configureAction::info is: " << info.toString());
       if (!info.present)
         continue;
 
-      DEBUG("OptoHybridManager::configureAction::grabbing pointer to hardware device");
+      CMSGEMOS_DEBUG("OptoHybridManager::configureAction::grabbing pointer to hardware device");
       optohybrid_shared_ptr optohybrid = m_optohybrids.at(slot).at(link);
 
       if (optohybrid->isHwConnected()) {
         hwMapping[slot+1].insert(link);
 
-        DEBUG("OptoHybridManager::configureAction::setting trigger source to 0x"
+        CMSGEMOS_DEBUG("OptoHybridManager::configureAction::setting trigger source to 0x"
              << std::hex << info.triggerSource.value_ << std::dec);
         optohybrid->setTrigSource(info.triggerSource.value_);
 
-        // DEBUG("OptoHybridManager::configureAction::setting sbit source to 0x"
+        // CMSGEMOS_DEBUG("OptoHybridManager::configureAction::setting sbit source to 0x"
         //      << std::hex << info.sbitSource.value_ << std::dec);
         // optohybrid->setSBitSource(info.sbitSource.value_);
-        DEBUG("OptoHybridManager::setting reference clock source to 0x"
+        CMSGEMOS_DEBUG("OptoHybridManager::setting reference clock source to 0x"
              << std::hex << info.refClkSrc.value_ << std::dec);
         optohybrid->setReferenceClock(info.refClkSrc.value_);
 
         /*
-        DEBUG("OptoHybridManager::setting vfat clock source to 0x" << std::hex << info.vfatClkSrc.value_ << std::dec);
+        CMSGEMOS_DEBUG("OptoHybridManager::setting vfat clock source to 0x" << std::hex << info.vfatClkSrc.value_ << std::dec);
         optohybrid->setVFATClock(info.vfatClkSrc.value_,);
-        DEBUG("OptoHybridManager::setting cdce clock source to 0x" << std::hex << info.cdceClkSrc.value_ << std::dec);
+        CMSGEMOS_DEBUG("OptoHybridManager::setting cdce clock source to 0x" << std::hex << info.cdceClkSrc.value_ << std::dec);
         optohybrid->setSBitSource(info.cdceClkSrc.value_);
         */
         /*
@@ -387,7 +387,7 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
         }
         */
 
-        DEBUG("OptoHybridManager::configureAction Setting output s-bit configuration parameters");
+        CMSGEMOS_DEBUG("OptoHybridManager::configureAction Setting output s-bit configuration parameters");
         optohybrid->setHDMISBitMode(info.sbitConfig.bag.Mode.value_);
 
         std::array<uint8_t, 6> sbitSources = {{
@@ -405,13 +405,13 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
 
         for (auto chip = chipIDs.begin(); chip != chipIDs.end(); ++chip)
           if (chip->second)
-            INFO("VFAT found in GEB slot " << std::setw(2) << (int)chip->first << " has ChipID "
+            CMSGEMOS_INFO("VFAT found in GEB slot " << std::setw(2) << (int)chip->first << " has ChipID "
                  << "0x" << std::hex << std::setw(4) << chip->second << std::dec);
           else
-            INFO("No VFAT found in GEB slot " << std::setw(2) << (int)chip->first);
+            CMSGEMOS_INFO("No VFAT found in GEB slot " << std::setw(2) << (int)chip->first);
 
         uint32_t vfatMask = m_broadcastList.at(slot).at(link);
-        INFO("Setting VFAT parameters with broadcast write using mask " << std::hex << vfatMask << std::dec);
+        CMSGEMOS_INFO("Setting VFAT parameters with broadcast write using mask " << std::hex << vfatMask << std::dec);
 
         std::map<std::string, uint8_t > vfatSettings;
         vfatSettings["ContReg0"   ] = (uint8_t)(info.commonVFATSettings.bag.ContReg0.value_);
@@ -429,7 +429,7 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
         vfatSettings["Latency"    ] = (uint8_t)(info.commonVFATSettings.bag.Latency.value_);
 
         if (m_scanType.value_ == 2) {
-          INFO("OptoHybridManager::configureAction configureAction: FIRST Latency  " << m_scanMin.value_);
+          CMSGEMOS_INFO("OptoHybridManager::configureAction configureAction: FIRST Latency  " << m_scanMin.value_);
           vfatSettings["Latency"    ] = (uint8_t)(m_scanMin.value_);
           // FIXME optohybrid->setVFATsToDefaults(vfatSettings, vfatMask);
           // HACK
@@ -443,7 +443,7 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
           uint32_t initialVT1 = m_scanMin.value_;
           // uint32_t VT1 = (m_scanMax.value_ - m_scanMin.value_);
           uint32_t initialVT2 = 0; //std::max(0,(uint32_t)m_scanMax.value_);
-          INFO("OptoHybridManager::configureAction FIRST VT1 " << initialVT1 << " VT2 " << initialVT2);
+          CMSGEMOS_INFO("OptoHybridManager::configureAction FIRST VT1 " << initialVT1 << " VT2 " << initialVT2);
           vfatSettings["VThreshold1"] = (uint8_t)(initialVT1&0xff);
           vfatSettings["VThreshold2"] = (uint8_t)(initialVT2&0xff);
           // FIXME optohybrid->setVFATsToDefaults(vfatSettings, vfatMask);
@@ -455,12 +455,12 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
                                                   "IShaper", "IShaperFeed", "IComp", "Latency",
                                                   "VThreshold1", "VThreshold2"}};
 
-        INFO("Reading back values after setting defaults:");
+        CMSGEMOS_INFO("Reading back values after setting defaults:");
         for (auto reg = setupregs.begin(); reg != setupregs.end(); ++reg) {
           std::vector<uint32_t> res = optohybrid->broadcastRead(*reg,vfatMask);
-          INFO(*reg);
+          CMSGEMOS_INFO(*reg);
           for (auto r = res.begin(); r != res.end(); ++r) {
-            INFO(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
+            CMSGEMOS_INFO(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
           }
         }
 
@@ -479,12 +479,12 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
         optohybrid->writeReg("GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK", gtxMask);
         optohybrid->writeReg("GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK", inputMask);
         msg << " to " << std::hex << inputMask  << std::dec << std::endl;
-        INFO(msg.str());
+        CMSGEMOS_INFO(msg.str());
       } else {
         std::stringstream msg;
         msg << "OptoHybridManager::configureAction::OptoHybrid connected on link " << (int)link
             << " to AMC in slot " << (int)(slot+1) << " is not responding";
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         // fireEvent("Fail");
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       }
@@ -495,7 +495,7 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
         m_optohybridMonitors.at(slot).at(link)->resumeMonitoring();
   }
 
-  INFO("OptoHybridManager::configureAction end");
+  CMSGEMOS_INFO("OptoHybridManager::configureAction end");
 }
 
 void gem::hw::optohybrid::OptoHybridManager::startAction()
@@ -509,7 +509,7 @@ void gem::hw::optohybrid::OptoHybridManager::startAction()
     m_lastVT1 = m_scanMin.value_;
   }
 
-  DEBUG("OptoHybridManager::startAction");
+  CMSGEMOS_DEBUG("OptoHybridManager::startAction");
   // will the manager operate for all connected optohybrids, or only those connected to certain AMCs?
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
@@ -523,13 +523,13 @@ void gem::hw::optohybrid::OptoHybridManager::startAction()
     for (unsigned link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link) {
       // usleep(10); // just for testing the timing of different applications
       unsigned int index = (slot*MAX_OPTOHYBRIDS_PER_AMC)+link;
-      DEBUG("OptoHybridManager::index = " << index);
+      CMSGEMOS_DEBUG("OptoHybridManager::index = " << index);
       OptoHybridInfo& info = m_optohybridInfo[index].bag;
 
       if (!info.present)
         continue;
 
-      DEBUG("OptoHybridManager::startAction::grabbing pointer to hardware device");
+      CMSGEMOS_DEBUG("OptoHybridManager::startAction::grabbing pointer to hardware device");
       optohybrid_shared_ptr optohybrid = m_optohybrids.at(slot).at(link);
 
       if (optohybrid->isHwConnected()) {
@@ -541,17 +541,17 @@ void gem::hw::optohybrid::OptoHybridManager::startAction()
         // optohybrid->resetVFATCRCCount();
 
         std::vector<uint32_t> res = optohybrid->broadcastRead("ContReg0",vfatMask);
-        INFO("ContReg0: vfatMask = " << std::hex << std::setw(8) << std::setfill('0') << vfatMask);
+        CMSGEMOS_INFO("ContReg0: vfatMask = " << std::hex << std::setw(8) << std::setfill('0') << vfatMask);
         for (auto r = res.begin(); r != res.end(); ++r)
-          INFO(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
+          CMSGEMOS_INFO(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
 
         // perhaps don't hardcode the full control register here, simply turn on the run bit?
         optohybrid->broadcastWrite("ContReg0", 0x37, vfatMask);
         res.clear();
         res = optohybrid->broadcastRead("ContReg0",vfatMask);
-        INFO("OptoHybridManager::startAction ContReg0");
+        CMSGEMOS_INFO("OptoHybridManager::startAction ContReg0");
         for (auto r = res.begin(); r != res.end(); ++r)
-          INFO(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
+          CMSGEMOS_INFO(" 0x" << std::hex << std::setw(8) << std::setfill('0') << *r << std::dec);
 
         // FIXME, should not be here or done like this
         uint32_t gtxMask = optohybrid->readReg("GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK");
@@ -568,13 +568,13 @@ void gem::hw::optohybrid::OptoHybridManager::startAction()
         msg << "OptoHybridManager::startAction::OptoHybrid connected on link " << (int)link
             << " to AMC in slot " << (int)(slot+1) << " found, starting run with INPUT_ENABLE_MASK "
 	    << std::hex << inputMask << std::dec;
-	INFO(msg.str());
+        CMSGEMOS_INFO(msg.str());
         // what resets to do
       } else {
         std::stringstream msg;
         msg << "OptoHybridManager::startAction::OptoHybrid connected on link " << (int)link
             << " to AMC in slot " << (int)(slot+1) << " is not responding";
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         // fireEvent("Fail");
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       }
@@ -584,7 +584,7 @@ void gem::hw::optohybrid::OptoHybridManager::startAction()
       if (m_optohybridMonitors.at(slot).at(link))
         m_optohybridMonitors.at(slot).at(link)->resumeMonitoring();
   }
-  INFO("OptoHybridManager::startAction end");
+  CMSGEMOS_INFO("OptoHybridManager::startAction end");
 }
 
 void gem::hw::optohybrid::OptoHybridManager::pauseAction()
@@ -602,13 +602,13 @@ void gem::hw::optohybrid::OptoHybridManager::pauseAction()
     for (unsigned link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link) {
       // usleep(10); // just for testing the timing of different applications
       unsigned int index = (slot*MAX_OPTOHYBRIDS_PER_AMC)+link;
-      DEBUG("OptoHybridManager::index = " << index);
+      CMSGEMOS_DEBUG("OptoHybridManager::index = " << index);
       OptoHybridInfo& info = m_optohybridInfo[index].bag;
 
       if (!info.present)
         continue;
 
-      DEBUG("OptoHybridManager::pauseAction::grabbing pointer to hardware device");
+      CMSGEMOS_DEBUG("OptoHybridManager::pauseAction::grabbing pointer to hardware device");
       optohybrid_shared_ptr optohybrid = m_optohybrids.at(slot).at(link);
 
       if (optohybrid->isHwConnected()) {
@@ -616,14 +616,14 @@ void gem::hw::optohybrid::OptoHybridManager::pauseAction()
         uint32_t vfatMask = m_broadcastList.at(slot).at(link);
 	if (m_scanType.value_ == 2) {
 	  uint8_t updatedLatency = m_lastLatency + m_stepSize.value_;
-	  INFO("OptoHybridManager::LatencyScan OptoHybrid on link " << (int)link
+	  CMSGEMOS_INFO("OptoHybridManager::LatencyScan OptoHybrid on link " << (int)link
 	       << " AMC slot " << (slot+1) << " Latency  " << (int)updatedLatency);
 
           optohybrid->broadcastWrite("Latency", updatedLatency, vfatMask);
       } else if (m_scanType.value_ == 3) {
 	  uint8_t updatedVT1 = m_lastVT1 + m_stepSize.value_;
 	  uint8_t VT2 = 0;  // std::max(0,(int)m_scanMax.value_);
-	  INFO("OptoHybridManager::ThresholdScan OptoHybrid on link " << (int)link
+	  CMSGEMOS_INFO("OptoHybridManager::ThresholdScan OptoHybrid on link " << (int)link
 	       << " AMC slot " << (slot+1) << " VT1 " << (int)updatedVT1
                << " VT2 " << VT2 << " StepSize " << m_stepSize.value_);
 
@@ -635,7 +635,7 @@ void gem::hw::optohybrid::OptoHybridManager::pauseAction()
         std::stringstream msg;
         msg << "OptoHybridManager::pauseAction OptoHybrid connected on link " << (int)link
             << " to AMC in slot " << (int)(slot+1) << " is not responding";
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         // fireEvent("Fail");
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       }
@@ -647,15 +647,15 @@ void gem::hw::optohybrid::OptoHybridManager::pauseAction()
   }
   // Update the scan parameters
   if (m_scanType.value_ == 2) {
-    INFO("OptoHybridManager::pauseAction LatencyScan old Latency " << (int)m_lastLatency);
+    CMSGEMOS_INFO("OptoHybridManager::pauseAction LatencyScan old Latency " << (int)m_lastLatency);
     m_lastLatency += m_stepSize.value_;
-    INFO("OptoHybridManager::pauseAction LatencyScan new Latency " << (int)m_lastLatency);
+    CMSGEMOS_INFO("OptoHybridManager::pauseAction LatencyScan new Latency " << (int)m_lastLatency);
   } else if (m_scanType.value_ == 3) {
-    INFO("OptoHybridManager::pauseAction ThresholdScan old VT1 " << (int)m_lastVT1);
+    CMSGEMOS_INFO("OptoHybridManager::pauseAction ThresholdScan old VT1 " << (int)m_lastVT1);
     m_lastVT1 += m_stepSize.value_;
-    INFO("OptoHybridManager::pauseAction ThresholdScan new VT1 " << (int)m_lastVT1);
+    CMSGEMOS_INFO("OptoHybridManager::pauseAction ThresholdScan new VT1 " << (int)m_lastVT1);
   }
-  INFO("OptoHybridManager::pauseAction end");
+  CMSGEMOS_INFO("OptoHybridManager::pauseAction end");
 }
 
 void gem::hw::optohybrid::OptoHybridManager::resumeAction()
@@ -663,13 +663,13 @@ void gem::hw::optohybrid::OptoHybridManager::resumeAction()
 {
   // put all connected VFATs into run mode?
   usleep(10);
-  INFO("OptoHybridManager::resumeAction end");
+  CMSGEMOS_INFO("OptoHybridManager::resumeAction end");
 }
 
 void gem::hw::optohybrid::OptoHybridManager::stopAction()
   throw (gem::hw::optohybrid::exception::Exception)
 {
-  DEBUG("OptoHybridManager::stopAction");
+  CMSGEMOS_DEBUG("OptoHybridManager::stopAction");
   // will the manager operate for all connected optohybrids, or only those connected to certain AMCs?
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
@@ -683,13 +683,13 @@ void gem::hw::optohybrid::OptoHybridManager::stopAction()
     for (unsigned link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link) {
       // usleep(10); // just for testing the timing of different applications
       unsigned int index = (slot*MAX_OPTOHYBRIDS_PER_AMC)+link;
-      DEBUG("OptoHybridManager::index = " << index);
+      CMSGEMOS_DEBUG("OptoHybridManager::index = " << index);
       OptoHybridInfo& info = m_optohybridInfo[index].bag;
 
       if (!info.present)
         continue;
 
-      DEBUG("OptoHybridManager::stopAction::grabbing pointer to hardware device");
+      CMSGEMOS_DEBUG("OptoHybridManager::stopAction::grabbing pointer to hardware device");
       optohybrid_shared_ptr optohybrid = m_optohybrids.at(slot).at(link);
 
       if (optohybrid->isHwConnected()) {
@@ -730,7 +730,7 @@ void gem::hw::optohybrid::OptoHybridManager::stopAction()
         std::stringstream msg;
         msg << "OptoHybridManager::stopAction::OptoHybrid connected on link " << (int)link
             << " to AMC in slot " << (int)(slot+1) << " is not responding";
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
         // fireEvent("Fail");
         XCEPT_RAISE(gem::hw::optohybrid::exception::Exception, msg.str());
       }
@@ -740,7 +740,7 @@ void gem::hw::optohybrid::OptoHybridManager::stopAction()
       if (m_optohybridMonitors.at(slot).at(link))
         m_optohybridMonitors.at(slot).at(link)->resumeMonitoring();
   }
-  INFO("OptoHybridManager::stopAction end");
+  CMSGEMOS_INFO("OptoHybridManager::stopAction end");
 }
 
 void gem::hw::optohybrid::OptoHybridManager::haltAction()
@@ -748,18 +748,18 @@ void gem::hw::optohybrid::OptoHybridManager::haltAction()
 {
   // put all connected VFATs into sleep mode?
   usleep(10);
-  INFO("OptoHybridManager::haltAction end");
+  CMSGEMOS_INFO("OptoHybridManager::haltAction end");
 }
 
 void gem::hw::optohybrid::OptoHybridManager::resetAction()
   throw (gem::hw::optohybrid::exception::Exception)
 {
   // unregister listeners and items in info spaces
-  DEBUG("OptoHybridManager::resetAction begin");
+  CMSGEMOS_DEBUG("OptoHybridManager::resetAction begin");
   // FIXME make me more streamlined
   for (unsigned slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);
-    DEBUG("OptoHybridManager::looping over slots(" << (slot+1) << ") and finding expected cards");
+    CMSGEMOS_DEBUG("OptoHybridManager::looping over slots(" << (slot+1) << ") and finding expected cards");
     uint32_t inputMask = 0x0;
 
     for (unsigned link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link)
@@ -768,9 +768,9 @@ void gem::hw::optohybrid::OptoHybridManager::resetAction()
 
     for (unsigned link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link) {
       // usleep(10);
-      DEBUG("OptoHybridManager::looping over links(" << link << ") and finding expected cards");
+      CMSGEMOS_DEBUG("OptoHybridManager::looping over links(" << link << ") and finding expected cards");
       unsigned int index = (slot*MAX_OPTOHYBRIDS_PER_AMC)+link;
-      DEBUG("OptoHybridManager::index = " << index);
+      CMSGEMOS_DEBUG("OptoHybridManager::index = " << index);
       OptoHybridInfo& info = m_optohybridInfo[index].bag;
 
       if (!info.present)
@@ -782,24 +782,24 @@ void gem::hw::optohybrid::OptoHybridManager::resetAction()
       if (m_optohybridMonitors.at(slot).at(link))
         m_optohybridMonitors.at(slot).at(link)->reset();
 
-      DEBUG("OptoHybridManager::revoking hwCfgInfoSpace items for board connected on link "
+      CMSGEMOS_DEBUG("OptoHybridManager::revoking hwCfgInfoSpace items for board connected on link "
             << link << " to AMC in slot " << (slot+1));
       toolbox::net::URN hwCfgURN("urn:gem:hw:"+toolbox::toString("gem.shelf%02d.amc%02d.optohybrid%02d",
                                                                  info.crateID.value_,
                                                                  info.slotID.value_,
                                                                  info.linkID.value_));
       if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-        DEBUG("OptoHybridManager::revoking config parameters into infospace");
+        CMSGEMOS_DEBUG("OptoHybridManager::revoking config parameters into infospace");
 
         // reset the hw infospace toolbox
         is_optohybrids.at(slot).at(link)->reset();
       } else {
-        DEBUG("OptoHybridManager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
+        CMSGEMOS_DEBUG("OptoHybridManager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
         continue;
       }
     }  // end loop on link < MAX_OPTOHYBRIDS_PER_AMC
   }  // end loop on slot < MAX_AMCS_PER_CRATE
-  INFO("OptoHybridManager::resetAction end");
+  CMSGEMOS_INFO("OptoHybridManager::resetAction end");
 }
 
 /*

--- a/gemhardware/src/common/optohybrid/OptoHybridManagerWeb.cc
+++ b/gemhardware/src/common/optohybrid/OptoHybridManagerWeb.cc
@@ -26,7 +26,7 @@ void gem::hw::optohybrid::OptoHybridManagerWeb::webDefault(xgi::Input * in, xgi:
   throw (xgi::exception::Exception)
 {
   if (p_gemFSMApp)
-    DEBUG("current state is" << dynamic_cast<gem::hw::optohybrid::OptoHybridManager*>(p_gemFSMApp)->getCurrentState());
+    CMSGEMOS_DEBUG("current state is" << dynamic_cast<gem::hw::optohybrid::OptoHybridManager*>(p_gemFSMApp)->getCurrentState());
   *out << cgicc::style().set("type", "text/css")
     .set("src", "/gemdaq/gemhardware/html/css/optohybrid/optohybrid.css")
        << cgicc::style() << std::endl;
@@ -42,7 +42,7 @@ void gem::hw::optohybrid::OptoHybridManagerWeb::webDefault(xgi::Input * in, xgi:
 void gem::hw::optohybrid::OptoHybridManagerWeb::monitorPage(xgi::Input * in, xgi::Output * out)
   throw (xgi::exception::Exception)
 {
-  INFO("OptoHybridManagerWeb::monitorPage");
+  CMSGEMOS_INFO("OptoHybridManagerWeb::monitorPage");
   //fill this page with the generic views for the OptoHybridManager
   //different tabs for certain functions
   *out << "    <div class=\"xdaq-tab-wrapper\">" << std::endl;
@@ -54,7 +54,7 @@ void gem::hw::optohybrid::OptoHybridManagerWeb::monitorPage(xgi::Input * in, xgi
 void gem::hw::optohybrid::OptoHybridManagerWeb::expertPage(xgi::Input * in, xgi::Output * out)
   throw (xgi::exception::Exception)
 {
-  INFO("OptoHybridManagerWeb::expertPage");
+  CMSGEMOS_INFO("OptoHybridManagerWeb::expertPage");
   //fill this page with the expert views for the OptoHybridManager
   *out << "expertPage</br>" << std::endl;
 }
@@ -63,7 +63,7 @@ void gem::hw::optohybrid::OptoHybridManagerWeb::expertPage(xgi::Input * in, xgi:
 void gem::hw::optohybrid::OptoHybridManagerWeb::applicationPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  INFO("OptoHybridManagerWeb::applicationPage");
+  CMSGEMOS_INFO("OptoHybridManagerWeb::applicationPage");
   std::string cardURL = "/" + p_gemApp->getApplicationDescriptor()->getURN() + "/boardPage";
   *out << "  <div class=\"xdaq-tab\" title=\"Board page\"/>"  << std::endl;
   boardPage(in, out);
@@ -74,7 +74,7 @@ void gem::hw::optohybrid::OptoHybridManagerWeb::applicationPage(xgi::Input* in, 
 void gem::hw::optohybrid::OptoHybridManagerWeb::boardPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  INFO("OptoHybridManagerWeb::boardPage");
+  CMSGEMOS_INFO("OptoHybridManagerWeb::boardPage");
   // fill this page with the card views for the OptoHybridManager
   *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {
@@ -93,7 +93,7 @@ void gem::hw::optohybrid::OptoHybridManagerWeb::boardPage(xgi::Input* in, xgi::O
 void gem::hw::optohybrid::OptoHybridManagerWeb::jsonUpdate(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("OptoHybridManagerWeb::jsonUpdate");
+  CMSGEMOS_DEBUG("OptoHybridManagerWeb::jsonUpdate");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   for (unsigned int i = 0; i < gem::base::GEMFSMApplication::MAX_AMCS_PER_CRATE; ++i) {

--- a/gemhardware/src/common/optohybrid/OptoHybridMonitor.cc
+++ b/gemhardware/src/common/optohybrid/OptoHybridMonitor.cc
@@ -240,11 +240,11 @@ void gem::hw::optohybrid::OptoHybridMonitor::updateMonitorables()
   // define how to update the desired values
   // get SYSTEM monitorables
   // can this be split into two loops, one just to do a list read, the second to fill the InfoSpace with the returned values
-  DEBUG("OptoHybridMonitor: Updating monitorables");
+  CMSGEMOS_DEBUG("OptoHybridMonitor: Updating monitorables");
   for (auto monlist = m_monitorableSetsMap.begin(); monlist != m_monitorableSetsMap.end(); ++monlist) {
-    DEBUG("OptoHybridMonitor: Updating monitorables in set " << monlist->first);
+    CMSGEMOS_DEBUG("OptoHybridMonitor: Updating monitorables in set " << monlist->first);
     for (auto monitem = monlist->second.begin(); monitem != monlist->second.end(); ++monitem) {
-      DEBUG("OptoHybridMonitor: Updating monitorable " << monitem->first);
+      CMSGEMOS_DEBUG("OptoHybridMonitor: Updating monitorable " << monitem->first);
       std::stringstream regName;
       regName << p_optohybrid->getDeviceBaseNode() << "." << monitem->second.regname;
       uint32_t address = p_optohybrid->getGEMHwInterface().getNode(regName.str()).getAddress();
@@ -284,7 +284,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::updateMonitorables()
       } else if (monitem->second.updatetype == GEMUpdateType::NOUPDATE) {
         continue;
       } else {
-        ERROR("OptoHybridMonitor: Unknown update type encountered");
+        CMSGEMOS_ERROR("OptoHybridMonitor: Unknown update type encountered");
         continue;
       }
     } // end loop over items in list
@@ -293,9 +293,9 @@ void gem::hw::optohybrid::OptoHybridMonitor::updateMonitorables()
 
 void gem::hw::optohybrid::OptoHybridMonitor::buildMonitorPage(xgi::Output* out)
 {
-  DEBUG("OptoHybridMonitor::buildMonitorPage");
+  CMSGEMOS_DEBUG("OptoHybridMonitor::buildMonitorPage");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
@@ -362,7 +362,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildMonitorPage(xgi::Output* out)
              << monitem->first
              << "</td>"   << std::endl;
 
-        DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
+        CMSGEMOS_DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
               << formatted);
         //this will be repeated for every OptoHybridMonitor in the OptoHybridManager..., need a better unique ID
         *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -394,16 +394,16 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildMonitorPage(xgi::Output* out)
 
 void gem::hw::optohybrid::OptoHybridMonitor::buildWishboneCounterTable(xgi::Output* out)
 {
-  DEBUG("OptoHybridMonitor::buildWishboneCounterTable");
+  CMSGEMOS_DEBUG("OptoHybridMonitor::buildWishboneCounterTable");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
   auto monsets = m_infoSpaceMonitorableSetMap.find("HWMonitoring")->second;
 
   if (std::find(monsets.begin(),monsets.end(),"Wishbone Counters") == monsets.end()) {
-    WARN("Unable to find item set 'Wishbone Counters' in monitor");
+    CMSGEMOS_WARN("Unable to find item set 'Wishbone Counters' in monitor");
     return;
   }
 
@@ -429,7 +429,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildWishboneCounterTable(xgi::Outp
 
         std::string formatted = (monitem->second.infoSpace)->getFormattedItem(monitem->first,monitem->second.format);
 
-        DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
+        CMSGEMOS_DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
               << formatted);
 
         *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -468,7 +468,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildWishboneCounterTable(xgi::Outp
 
         std::string formatted = (monitem->second.infoSpace)->getFormattedItem(monitem->first,monitem->second.format);
 
-        DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
+        CMSGEMOS_DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
               << formatted);
 
         *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -491,16 +491,16 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildWishboneCounterTable(xgi::Outp
 
 void gem::hw::optohybrid::OptoHybridMonitor::buildVFATCRCCounterTable(xgi::Output* out)
 {
-  DEBUG("OptoHybridMonitor::buildVFATCRCCounterTable");
+  CMSGEMOS_DEBUG("OptoHybridMonitor::buildVFATCRCCounterTable");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
   auto monsets = m_infoSpaceMonitorableSetMap.find("HWMonitoring")->second;
 
   if (std::find(monsets.begin(),monsets.end(),"VFAT CRCs") == monsets.end()) {
-    WARN("Unable to find item set 'VFAT CRCs' in list of HWMonitoring monitor sets");
+    CMSGEMOS_WARN("Unable to find item set 'VFAT CRCs' in list of HWMonitoring monitor sets");
     return;
   }
 
@@ -533,7 +533,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildVFATCRCCounterTable(xgi::Outpu
 
         std::string formatted = (monitem->second.infoSpace)->getFormattedItem(monitem->first,monitem->second.format);
 
-        DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
+        CMSGEMOS_DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
               << formatted);
 
         *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -560,16 +560,16 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildVFATCRCCounterTable(xgi::Outpu
 
 void gem::hw::optohybrid::OptoHybridMonitor::buildT1CounterTable(xgi::Output* out)
 {
-  DEBUG("OptoHybridMonitor::buildT1CounterTable");
+  CMSGEMOS_DEBUG("OptoHybridMonitor::buildT1CounterTable");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
   auto monsets = m_infoSpaceMonitorableSetMap.find("HWMonitoring")->second;
 
   if (std::find(monsets.begin(),monsets.end(),"T1 Counters") == monsets.end()) {
-    WARN("Unable to find item set 'T1 Counters' in list of HWMonitoring monitor sets");
+    CMSGEMOS_WARN("Unable to find item set 'T1 Counters' in list of HWMonitoring monitor sets");
     return;
   }
 
@@ -599,7 +599,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildT1CounterTable(xgi::Output* ou
 
         std::string formatted = (monitem->second.infoSpace)->getFormattedItem(monitem->first,monitem->second.format);
 
-        DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
+        CMSGEMOS_DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
               << formatted);
 
         *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -622,16 +622,16 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildT1CounterTable(xgi::Output* ou
 
 void gem::hw::optohybrid::OptoHybridMonitor::buildOtherCounterTable(xgi::Output* out)
 {
-  DEBUG("OptoHybridMonitor::buildOtherCounterTable");
+  CMSGEMOS_DEBUG("OptoHybridMonitor::buildOtherCounterTable");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
   auto monsets = m_infoSpaceMonitorableSetMap.find("HWMonitoring")->second;
 
   if (std::find(monsets.begin(),monsets.end(),"Other Counters") == monsets.end()) {
-    WARN("Unable to find item set 'Other Counters' in list of HWMonitoring monitor sets");
+    CMSGEMOS_WARN("Unable to find item set 'Other Counters' in list of HWMonitoring monitor sets");
     return;
   }
 
@@ -647,7 +647,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildOtherCounterTable(xgi::Output*
          << monitem->first
          << "</td>"   << std::endl;
 
-    DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
+    CMSGEMOS_DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to "
           << formatted);
 
     // count
@@ -674,16 +674,16 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildOtherCounterTable(xgi::Output*
 
 void gem::hw::optohybrid::OptoHybridMonitor::buildFirmwareScanTable(xgi::Output* out)
 {
-  DEBUG("OptoHybridMonitor::buildFirmwareScanTable");
+  CMSGEMOS_DEBUG("OptoHybridMonitor::buildFirmwareScanTable");
   if (m_infoSpaceMonitorableSetMap.find("HWMonitoring") == m_infoSpaceMonitorableSetMap.end()) {
-    WARN("Unable to find item set HWMonitoring in monitor");
+    CMSGEMOS_WARN("Unable to find item set HWMonitoring in monitor");
     return;
   }
 
   auto monsets = m_infoSpaceMonitorableSetMap.find("HWMonitoring")->second;
 
   if (std::find(monsets.begin(),monsets.end(),"Firmware Scan Controller") == monsets.end()) {
-    WARN("Unable to find item set 'Firmware Scan Controller' in list of HWMonitoring monitor sets");
+    CMSGEMOS_WARN("Unable to find item set 'Firmware Scan Controller' in list of HWMonitoring monitor sets");
     return;
   }
 
@@ -730,7 +730,7 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildFirmwareScanTable(xgi::Output*
              << monname.erase(0,scan->first.length())
              << "</td>"   << std::endl;
 
-        DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to " << formatted);
+        CMSGEMOS_DEBUG("OptoHybridMonitor::" << monitem->first << " formatted to " << formatted);
 
         // count
         *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
@@ -759,24 +759,24 @@ void gem::hw::optohybrid::OptoHybridMonitor::buildFirmwareScanTable(xgi::Output*
 void gem::hw::optohybrid::OptoHybridMonitor::reset()
 {
   // have to get rid of the timer
-  DEBUG("GEMMonitor::reset");
+  CMSGEMOS_DEBUG("GEMMonitor::reset");
   for (auto infoSpace = m_infoSpaceMap.begin(); infoSpace != m_infoSpaceMap.end(); ++infoSpace) {
-    DEBUG("OptoHybridMonitor::reset removing " << infoSpace->first << " from p_timer");
+    CMSGEMOS_DEBUG("OptoHybridMonitor::reset removing " << infoSpace->first << " from p_timer");
     try {
       p_timer->remove(infoSpace->first);
     } catch (toolbox::task::exception::Exception& te) {
-      ERROR("OptoHybridMonitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
+      CMSGEMOS_ERROR("OptoHybridMonitor::Caught exception while removing timer task " << infoSpace->first << " " << te.what());
     }
   }
   stopMonitoring();
-  DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
+  CMSGEMOS_DEBUG("GEMMonitor::reset removing timer " << m_timerName << " from timerFactory");
   try {
     toolbox::task::getTimerFactory()->removeTimer(m_timerName);
   } catch (toolbox::task::exception::Exception& te) {
-    ERROR("OptoHybridMonitor::Caught exception while removing timer " << m_timerName << " " << te.what());
+    CMSGEMOS_ERROR("OptoHybridMonitor::Caught exception while removing timer " << m_timerName << " " << te.what());
   }
 
-  DEBUG("OptoHybridMonitor::reset - clearing all maps");
+  CMSGEMOS_DEBUG("OptoHybridMonitor::reset - clearing all maps");
   m_infoSpaceMap.clear();
   m_infoSpaceMonitorableSetMap.clear();
   m_monitorableSetInfoSpaceMap.clear();

--- a/gemhardware/src/common/utils/GEMCrateUtils.cc
+++ b/gemhardware/src/common/utils/GEMCrateUtils.cc
@@ -20,16 +20,16 @@ uint16_t gem::hw::utils::parseAMCEnableList(std::string const& enableList)
   std::vector<std::string> slots;
 
   boost::split(slots, enableList, boost::is_any_of(", "), boost::token_compress_on);
-  DEBUG("GEMCrateUtils::parseAMCEnableList::AMC input enable list is " << enableList);
+  CMSGEMOS_DEBUG("GEMCrateUtils::parseAMCEnableList::AMC input enable list is " << enableList);
   // would be great to multithread this portion
   for (auto slot = slots.begin(); slot != slots.end(); ++slot) {
-    DEBUG("GEMCrateUtils::parseAMCEnableList::slot is " << *slot);
+    CMSGEMOS_DEBUG("GEMCrateUtils::parseAMCEnableList::slot is " << *slot);
     if (slot->find('-') != std::string::npos) {  // found a possible range
-      DEBUG("GEMCrateUtils::parseAMCEnableList::found a hyphen in " << *slot);
+      CMSGEMOS_DEBUG("GEMCrateUtils::parseAMCEnableList::found a hyphen in " << *slot);
       std::vector<std::string> range;
       boost::split(range, *slot, boost::is_any_of("-"), boost::token_compress_on);
       if (range.size() > 2) {
-        WARN("GEMCrateUtils::parseAMCEnableList::Found poorly formatted range " << *slot);
+        CMSGEMOS_WARN("GEMCrateUtils::parseAMCEnableList::Found poorly formatted range " << *slot);
         continue;
       }
       if (isValidSlotNumber(HWType::uTCA, range.at(0)) && isValidSlotNumber(HWType::uTCA, range.at(1))) {
@@ -40,11 +40,11 @@ uint16_t gem::hw::utils::parseAMCEnableList(std::string const& enableList)
         ss1 >> max;
 
         if (min == max) {
-          WARN("GEMCrateUtils::parseAMCEnableList::Found poorly formatted range " << *slot);
+          CMSGEMOS_WARN("GEMCrateUtils::parseAMCEnableList::Found poorly formatted range " << *slot);
           continue;
         }
         if (min > max) {  // elements in the wrong order
-          WARN("GEMCrateUtils::parseAMCEnableList::Found poorly formatted range " << *slot);
+          CMSGEMOS_WARN("GEMCrateUtils::parseAMCEnableList::Found poorly formatted range " << *slot);
           continue;
         }
 
@@ -53,14 +53,14 @@ uint16_t gem::hw::utils::parseAMCEnableList(std::string const& enableList)
         }  //  end loop over range of list
       }  // end check on valid values
     } else {  //not a range
-      DEBUG("GEMCrateUtils::parseAMCEnableList::found no hyphen in " << *slot);
+      CMSGEMOS_DEBUG("GEMCrateUtils::parseAMCEnableList::found no hyphen in " << *slot);
       if (slot->length() > 2) {
-        WARN("GEMCrateUtils::parseAMCEnableList::Found longer value than expected (1-12) " << *slot);
+        CMSGEMOS_WARN("GEMCrateUtils::parseAMCEnableList::Found longer value than expected (1-12) " << *slot);
         continue;
       }
 
       if (!isValidSlotNumber(HWType::uTCA, *slot)) {
-        WARN("GEMCrateUtils::parseAMCEnableList::Found invalid value " << *slot);
+        CMSGEMOS_WARN("GEMCrateUtils::parseAMCEnableList::Found invalid value " << *slot);
         continue;
       }
       std::stringstream ss(*slot);
@@ -69,7 +69,7 @@ uint16_t gem::hw::utils::parseAMCEnableList(std::string const& enableList)
       slotMask |= (0x1 << (slotNum-1));
     }  // done processing single values
   }  // done looping over extracted values
-  DEBUG("GEMCrateUtils::parseAMCEnableList::Parsed enabled list 0x" << std::hex << slotMask << std::dec);
+  CMSGEMOS_DEBUG("GEMCrateUtils::parseAMCEnableList::Parsed enabled list 0x" << std::hex << slotMask << std::dec);
   return slotMask;
 }
 
@@ -83,15 +83,15 @@ uint32_t gem::hw::utils::parseVFATMaskList(std::string const& enableList)
   std::vector<std::string> slots;
 
   boost::split(slots, enableList, boost::is_any_of(", "), boost::token_compress_on);
-  DEBUG("GEMCrateUtils::parseVFATMaskList::VFAT broadcast enable list is " << enableList);
+  CMSGEMOS_DEBUG("GEMCrateUtils::parseVFATMaskList::VFAT broadcast enable list is " << enableList);
   for (auto slot = slots.begin(); slot != slots.end(); ++slot) {
-    DEBUG("GEMCrateUtils::parseVFATMaskList::slot is " << *slot);
+    CMSGEMOS_DEBUG("GEMCrateUtils::parseVFATMaskList::slot is " << *slot);
     if (slot->find('-') != std::string::npos) {  // found a possible range
-      DEBUG("GEMCrateUtils::parseVFATMaskList::found a hyphen in " << *slot);
+      CMSGEMOS_DEBUG("GEMCrateUtils::parseVFATMaskList::found a hyphen in " << *slot);
       std::vector<std::string> range;
       boost::split(range, *slot, boost::is_any_of("-"), boost::token_compress_on);
       if (range.size() > 2) {
-        WARN("GEMCrateUtils::parseVFATMaskList::Found poorly formatted range " << *slot);
+        CMSGEMOS_WARN("GEMCrateUtils::parseVFATMaskList::Found poorly formatted range " << *slot);
         continue;
       }
       if (isValidSlotNumber(HWType::GEB, range.at(0)) && isValidSlotNumber(HWType::GEB, range.at(1))) {
@@ -102,11 +102,11 @@ uint32_t gem::hw::utils::parseVFATMaskList(std::string const& enableList)
         ss1 >> max;
 
         if (min == max) {
-          WARN("GEMCrateUtils::parseVFATMaskList::Found poorly formatted range " << *slot);
+          CMSGEMOS_WARN("GEMCrateUtils::parseVFATMaskList::Found poorly formatted range " << *slot);
           continue;
         }
         if (min > max) {  // elements in the wrong order
-          WARN("GEMCrateUtils::parseVFATMaskList::Found poorly formatted range " << *slot);
+          CMSGEMOS_WARN("GEMCrateUtils::parseVFATMaskList::Found poorly formatted range " << *slot);
           continue;
         }
 
@@ -115,14 +115,14 @@ uint32_t gem::hw::utils::parseVFATMaskList(std::string const& enableList)
         }  //  end loop over range of list
       }  // end check on valid values
     } else {  //not a range
-      DEBUG("GEMCrateUtils::parseVFATMaskList::found no hyphen in " << *slot);
+      CMSGEMOS_DEBUG("GEMCrateUtils::parseVFATMaskList::found no hyphen in " << *slot);
       if (slot->length() > 2) {
-        WARN("GEMCrateUtils::parseVFATMaskList::Found longer value than expected (0-23) " << *slot);
+        CMSGEMOS_WARN("GEMCrateUtils::parseVFATMaskList::Found longer value than expected (0-23) " << *slot);
         continue;
       }
 
       if (!isValidSlotNumber(HWType::GEB, *slot)) {
-        WARN("GEMCrateUtils::parseVFATMaskList::Found invalid value " << *slot);
+        CMSGEMOS_WARN("GEMCrateUtils::parseVFATMaskList::Found invalid value " << *slot);
         continue;
       }
       std::stringstream ss(*slot);
@@ -132,7 +132,7 @@ uint32_t gem::hw::utils::parseVFATMaskList(std::string const& enableList)
     }  //done processing single values
   }  //done looping over extracted values
 
-  DEBUG("GEMCrateUtils::parseVFATMaskList::Parsed enabled list 0x" << std::hex << broadcastMask << std::dec
+  CMSGEMOS_DEBUG("GEMCrateUtils::parseVFATMaskList::Parsed enabled list 0x" << std::hex << broadcastMask << std::dec
         << " bits set " << std::bitset<32>(broadcastMask).count()
         << " inverted: 0x" << std::hex << ~broadcastMask << std::dec
         << " bits set " << std::bitset<32>(~broadcastMask).count()
@@ -156,21 +156,21 @@ bool gem::hw::utils::isValidSlotNumber(HWType const& type, std::string const& s)
       rangeMin = 0;
       rangeMax = 23;
     } else {
-      ERROR("GEMCrateUtils::isValidSlotNumber::invalid HWType specified " << (int)type);
+      CMSGEMOS_ERROR("GEMCrateUtils::isValidSlotNumber::invalid HWType specified " << (int)type);
       return false;
     }
 
     i_val = std::stoi(s);
     if (!(i_val >= rangeMin && i_val <= rangeMax)) {
-      ERROR("GEMCrateUtils::isValidSlotNumber::Found value outside expected ("
+      CMSGEMOS_ERROR("GEMCrateUtils::isValidSlotNumber::Found value outside expected ("
             << rangeMin << " - " << rangeMax << ") " << i_val);
       return false;
     }
   } catch (std::invalid_argument const& err) {
-    ERROR("GEMCrateUtils::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
+    CMSGEMOS_ERROR("GEMCrateUtils::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
     return false;
   } catch (std::out_of_range const& err) {
-    ERROR("GEMCrateUtils::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
+    CMSGEMOS_ERROR("GEMCrateUtils::isValidSlotNumber::Unable to convert to integer type " << s << std::endl << err.what());
     return false;
   }
   // if you get here, should be possible to parse as an integer in the range [rangeMin, rangeMax]

--- a/gemhardware/src/common/vfat/HwVFAT2.cc
+++ b/gemhardware/src/common/vfat/HwVFAT2.cc
@@ -10,7 +10,7 @@ gem::hw::vfat::HwVFAT2::HwVFAT2(std::string const& vfatDevice,
   // need to fix the hard coded '0', how to get it in from the constructor in a sensible way? /**JS Oct 8**/
   setDeviceBaseNode("GEM_AMC.OH.OH0.GEB.VFATS."+vfatDevice);
   m_slot = (readReg(getDeviceBaseNode(),"ChipID0")>>16)&0xff;
-  INFO("HwVFAT2 ctor done " << isHwConnected());
+  CMSGEMOS_INFO("HwVFAT2 ctor done " << isHwConnected());
 }
 
 gem::hw::vfat::HwVFAT2::HwVFAT2(std::string const& vfatDevice,
@@ -22,7 +22,7 @@ gem::hw::vfat::HwVFAT2::HwVFAT2(std::string const& vfatDevice,
   // need to fix the hard coded '0', how to get it in from the constructor in a sensible way? /**JS Oct 8**/
   setDeviceBaseNode("GEM_AMC.OH.OH0.GEB.VFATS."+vfatDevice);
   m_slot = (readReg(getDeviceBaseNode(),"ChipID0")>>16)&0xff;
-  INFO("HwVFAT2 ctor done " << isHwConnected());
+  CMSGEMOS_INFO("HwVFAT2 ctor done " << isHwConnected());
 }
 
 gem::hw::vfat::HwVFAT2::HwVFAT2(std::string const& vfatDevice,
@@ -33,7 +33,7 @@ gem::hw::vfat::HwVFAT2::HwVFAT2(std::string const& vfatDevice,
   // need to fix the hard coded '0', how to get it in from the constructor in a sensible way? /**JS Oct 8**/
   setDeviceBaseNode(vfatDevice);
   m_slot = (readReg(getDeviceBaseNode(),"ChipID0")>>16)&0xff;
-  INFO("HwVFAT2 ctor done " << isHwConnected());
+  CMSGEMOS_INFO("HwVFAT2 ctor done " << isHwConnected());
 }
 
 gem::hw::vfat::HwVFAT2::HwVFAT2(gem::hw::optohybrid::HwOptoHybrid const& ohDevice,
@@ -42,14 +42,14 @@ gem::hw::vfat::HwVFAT2::HwVFAT2(gem::hw::optohybrid::HwOptoHybrid const& ohDevic
                                     ohDevice.getOptoHybridHwInterface()),
   m_slot((int)vfatDevice)
 {
-  INFO("HwVFAT2 ctor");
-  INFO("HwVFAT2 creating VFAT device from OH device " << ohDevice.getLoggerName());
+  CMSGEMOS_INFO("HwVFAT2 ctor");
+  CMSGEMOS_INFO("HwVFAT2 creating VFAT device from OH device " << ohDevice.getLoggerName());
   // need to fix the hard coded '0', how to get it in from the constructor in a sensible way? /**JS Oct 8**/
   std::stringstream baseNode;
   baseNode << ohDevice.getDeviceBaseNode() << ".GEB.VFATS.VFAT" << (int)vfatDevice;
   setDeviceBaseNode(baseNode.str());
   m_slot = (readReg(getDeviceBaseNode(),"ChipID0")>>16)&0xff;
-  INFO("HwVFAT2 ctor done " << isHwConnected());
+  CMSGEMOS_INFO("HwVFAT2 ctor done " << isHwConnected());
 }
 
 // gem::hw::vfat::HwVFAT2::HwVFAT2(std::string const& vfatDevice) :
@@ -81,7 +81,7 @@ gem::hw::vfat::HwVFAT2::HwVFAT2(gem::hw::optohybrid::HwOptoHybrid const& ohDevic
 //   // hardware is running
 //   m_slot = (readReg(getDeviceBaseNode(),"ChipID0")>>16)&0xff;
 
-//   INFO("HwVFAT2 ctor done " << isHwConnected());
+//   CMSGEMOS_INFO("HwVFAT2 ctor done " << isHwConnected());
 // }
 /*
 gem::hw::vfat::HwVFAT2::HwVFAT2(GEMHwDevice const& ohDevice, uint8_t const& position)
@@ -106,7 +106,7 @@ std::string gem::hw::vfat::HwVFAT2::printErrorCounts() const {
             << "Invalid:    " << m_vfatErrors.Invalid    << std::endl
             << "RWMismatch: " << m_vfatErrors.RWMismatch << std::endl
             << gem::hw::GEMHwDevice::printErrorCounts() << std::endl;
-  DEBUG(errstream);
+  CMSGEMOS_DEBUG(errstream);
   return errstream.str();
 }
 
@@ -189,10 +189,10 @@ bool gem::hw::vfat::HwVFAT2::isHwConnected()
     return true;
 
   else if (gem::hw::GEMHwDevice::isHwConnected()) {
-    DEBUG("Checking hardware connection" << std::endl);
+    CMSGEMOS_DEBUG("Checking hardware connection" << std::endl);
     try {
       uint32_t chipTest = readVFATReg("ChipID0", true);
-      INFO("read chipID0 0x" << std::hex << chipTest << std::dec << std::endl);
+      CMSGEMOS_INFO("read chipID0 0x" << std::hex << chipTest << std::dec << std::endl);
       b_is_connected = true;
 
       return true;
@@ -234,17 +234,17 @@ uint8_t gem::hw::vfat::HwVFAT2::readVFATReg(std::string const& regName, bool deb
   if ((readVal >> 26) & 0x1) {
     std::string msg = toolbox::toString("VFAT transaction error bit set reading register %s", regName.c_str());
     ++m_vfatErrors.Error;
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::vfat::exception::TransactionError, msg);
   } else if ((readVal >> 25) & 0x0) {
     std::string msg = toolbox::toString("VFAT transaction invalid bit set reading register %s", regName.c_str());
     ++m_vfatErrors.Invalid;
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::vfat::exception::InvalidTransaction, msg);
   } else if ((readVal >> 24) & 0x0) {
     std::string msg = toolbox::toString("VFAT read transaction returned write on register %s", regName.c_str());
     ++m_vfatErrors.RWMismatch;
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     XCEPT_RAISE(gem::hw::vfat::exception::WrongTransaction, msg);
   } else {
     return (readVal & 0xff);
@@ -282,11 +282,11 @@ void gem::hw::vfat::HwVFAT2::readVFAT2Counters()
     m_vfatParams.upsetCounter = getUpsetCount();
     m_vfatParams.hitCounter   = getHitCount();
   } catch (gem::hw::vfat::exception::TransactionError& e) {
-    DEBUG(e.what());
+    CMSGEMOS_DEBUG(e.what());
   } catch (gem::hw::vfat::exception::InvalidTransaction& e) {
-    DEBUG(e.what());
+    CMSGEMOS_DEBUG(e.what());
   } catch (gem::hw::vfat::exception::WrongTransaction& e) {
-    DEBUG(e.what());
+    CMSGEMOS_DEBUG(e.what());
   }
 }
 
@@ -302,7 +302,7 @@ void gem::hw::vfat::HwVFAT2::readVFAT2Channel(uint8_t channel)
   m_vfatParams.channels[channel-1].calPulse    = ((chanSettings&VFAT2ChannelBitMasks::CHANCAL ) << VFAT2ChannelBitShifts::CHANCAL );
   m_vfatParams.channels[channel-1].mask        = ((chanSettings&VFAT2ChannelBitMasks::ISMASKED) << VFAT2ChannelBitShifts::ISMASKED);
   m_vfatParams.channels[channel-1].trimDAC     = ((chanSettings&VFAT2ChannelBitMasks::TRIMDAC ) << VFAT2ChannelBitShifts::TRIMDAC );
-  DEBUG("readVFAT2Channel " << (unsigned)channel << " - 0x"
+  CMSGEMOS_DEBUG("readVFAT2Channel " << (unsigned)channel << " - 0x"
         << std::hex << static_cast<unsigned>(m_vfatParams.channels[channel-1].fullChannelReg) << std::dec << "::<"
         << std::hex << static_cast<unsigned>(m_vfatParams.channels[channel-1].calPulse0     ) << std::dec << ":"
         << std::hex << static_cast<unsigned>(m_vfatParams.channels[channel-1].calPulse      ) << std::dec << ":"
@@ -316,7 +316,7 @@ void gem::hw::vfat::HwVFAT2::readVFAT2Channels()
   for (uint8_t chan = 1; chan < 129; ++chan) {
     //readVFAT2Channel(m_vfatParams, chan);
     readVFAT2Channel(chan);
-    DEBUG("chan = "<< (unsigned)chan << "; activeChannel = " <<(unsigned)m_vfatParams.activeChannel << std::endl);
+    CMSGEMOS_DEBUG("chan = "<< (unsigned)chan << "; activeChannel = " <<(unsigned)m_vfatParams.activeChannel << std::endl);
   }
 }
 
@@ -393,7 +393,7 @@ void gem::hw::vfat::HwVFAT2::getAllSettings()
   // maybe find a way to do a single transaction, using the vector read/write?
   // what is the performance cost/benefit
 
-  DEBUG("getting all settings in HwVFAT2.cc");
+  CMSGEMOS_DEBUG("getting all settings in HwVFAT2.cc");
   try {
     uint8_t cont0 = readVFATReg("ContReg0");
     uint8_t cont1 = readVFATReg("ContReg1");
@@ -424,11 +424,11 @@ void gem::hw::vfat::HwVFAT2::getAllSettings()
     m_vfatParams.padBandGap      = static_cast<VFAT2PadBandgap   >(getBandgapPad(     cont3));
     m_vfatParams.sendTestPattern = static_cast<VFAT2DFTestPattern>(getTestPatternMode(cont3));
   } catch (gem::hw::vfat::exception::TransactionError const& e) {
-    WARN("Problem reading the control registers, transaction error bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, transaction error bit set");
   } catch (gem::hw::vfat::exception::InvalidTransaction const& e) {
-    WARN("Problem reading the control registers, invalid transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, invalid transaction bit set");
   } catch (gem::hw::vfat::exception::WrongTransaction const& e) {
-    WARN("Problem reading the control registers, wrong transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, wrong transaction bit set");
   }
 
   try {
@@ -446,49 +446,49 @@ void gem::hw::vfat::HwVFAT2::getAllSettings()
     m_vfatParams.vThresh2 = getVThreshold2();
     m_vfatParams.calPhase = getCalPhase();
   } catch (gem::hw::vfat::exception::TransactionError const& e) {
-    WARN("Problem reading the analog settings registers, transaction error bit set");
+    CMSGEMOS_WARN("Problem reading the analog settings registers, transaction error bit set");
   } catch (gem::hw::vfat::exception::InvalidTransaction const& e) {
-    WARN("Problem reading the analog settings registers, invalid transaction bit set");
+    CMSGEMOS_WARN("Problem reading the analog settings registers, invalid transaction bit set");
   } catch (gem::hw::vfat::exception::WrongTransaction const& e) {
-    WARN("Problem reading the analog settings registers, wrong transaction bit set");
+    CMSGEMOS_WARN("Problem reading the analog settings registers, wrong transaction bit set");
   }
 
   // counters
-  DEBUG("getting all counters in HwVFAT2.cc");
+  CMSGEMOS_DEBUG("getting all counters in HwVFAT2.cc");
   // readVFAT2Counters(params);
   try {
     readVFAT2Counters();
   } catch (gem::hw::vfat::exception::TransactionError const& e) {
-    WARN("Problem reading the VFAT counter registers, transaction error bit set");
+    CMSGEMOS_WARN("Problem reading the VFAT counter registers, transaction error bit set");
   } catch (gem::hw::vfat::exception::InvalidTransaction const& e) {
-    WARN("Problem reading the VFAT counter registers, invalid transaction bit set");
+    CMSGEMOS_WARN("Problem reading the VFAT counter registers, invalid transaction bit set");
   } catch (gem::hw::vfat::exception::WrongTransaction const& e) {
-    WARN("Problem reading the VFAT counter registers, wrong transaction bit set");
+    CMSGEMOS_WARN("Problem reading the VFAT counter registers, wrong transaction bit set");
   }
 
   // set the channel settings here
-  DEBUG("getting all channel settings in HwVFAT2.cc");
+  CMSGEMOS_DEBUG("getting all channel settings in HwVFAT2.cc");
   // readVFAT2Channels(params);
   try {
     readVFAT2Channels();
   } catch (gem::hw::vfat::exception::TransactionError const& e) {
-    WARN("Problem reading the VFAT channel registers, transaction error bit set");
+    CMSGEMOS_WARN("Problem reading the VFAT channel registers, transaction error bit set");
   } catch (gem::hw::vfat::exception::InvalidTransaction const& e) {
-    WARN("Problem reading the VFAT channel registers, invalid transaction bit set");
+    CMSGEMOS_WARN("Problem reading the VFAT channel registers, invalid transaction bit set");
   } catch (gem::hw::vfat::exception::WrongTransaction const& e) {
-    WARN("Problem reading the VFAT channel registers, wrong transaction bit set");
+    CMSGEMOS_WARN("Problem reading the VFAT channel registers, wrong transaction bit set");
   }
-  DEBUG("done getting all settings in HwVFAT2.cc");
+  CMSGEMOS_DEBUG("done getting all settings in HwVFAT2.cc");
 }
 
 void gem::hw::vfat::HwVFAT2::enableCalPulseToChannel(uint8_t channel, bool on)
 {
-  DEBUG(toolbox::toString("setting cal pulse for channel %d HwVFAT2.cc", (unsigned)channel));
+  CMSGEMOS_DEBUG(toolbox::toString("setting cal pulse for channel %d HwVFAT2.cc", (unsigned)channel));
   // channel should be 0 to 128
   if (channel > 128) {
     std::string msg =
       toolbox::toString("Channel specified (%d) larger than expected (128)", channel);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::vfat::exception::NonexistentChannel, msg);
     return;
   }
@@ -505,23 +505,23 @@ void gem::hw::vfat::HwVFAT2::enableCalPulseToChannel(uint8_t channel, bool on)
     else
       writeVFATReg(registerName, (channelSettings&~VFAT2ChannelBitMasks::CHANCAL)|(on ? 0x40 : 0x0));
   } catch (gem::hw::vfat::exception::TransactionError const& e) {
-    WARN("Problem reading the control registers, transaction error bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, transaction error bit set");
   } catch (gem::hw::vfat::exception::InvalidTransaction const& e) {
-    WARN("Problem reading the control registers, invalid transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, invalid transaction bit set");
   } catch (gem::hw::vfat::exception::WrongTransaction const& e) {
-    WARN("Problem reading the control registers, wrong transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, wrong transaction bit set");
   }
 
 }
 
 void gem::hw::vfat::HwVFAT2::maskChannel(uint8_t channel, bool on)
 {
-  DEBUG(toolbox::toString("setting mask for channel %d HwVFAT2.cc", (unsigned)channel));
+  CMSGEMOS_DEBUG(toolbox::toString("setting mask for channel %d HwVFAT2.cc", (unsigned)channel));
   // channel should be 1 to 128
   if ((channel > 128) || (channel < 1)) {
     std::string msg =
       toolbox::toString("Channel specified (%d) outside expectation (1-128)", channel);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::vfat::exception::NonexistentChannel, msg);
     return;
   }
@@ -530,22 +530,22 @@ void gem::hw::vfat::HwVFAT2::maskChannel(uint8_t channel, bool on)
     uint8_t channelSettings = (readVFATReg(registerName)&~VFAT2ChannelBitMasks::ISMASKED);
     writeVFATReg(registerName, channelSettings|(on ? 0x20 : 0x0));
   } catch (gem::hw::vfat::exception::TransactionError const& e) {
-    WARN("Problem reading the control registers, transaction error bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, transaction error bit set");
   } catch (gem::hw::vfat::exception::InvalidTransaction const& e) {
-    WARN("Problem reading the control registers, invalid transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, invalid transaction bit set");
   } catch (gem::hw::vfat::exception::WrongTransaction const& e) {
-    WARN("Problem reading the control registers, wrong transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, wrong transaction bit set");
   }
 }
 
 uint8_t gem::hw::vfat::HwVFAT2::getChannelTrimDAC(uint8_t channel)
 {
-  DEBUG(toolbox::toString("getting trim DAC for channel %d HwVFAT2.cc", (unsigned)channel));
+  CMSGEMOS_DEBUG(toolbox::toString("getting trim DAC for channel %d HwVFAT2.cc", (unsigned)channel));
   // channel should be 1 to 128
   if ((channel > 128) || (channel < 1)) {
     std::string msg =
       toolbox::toString("Channel specified (%d) outside expectation (1-128)", channel);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::vfat::exception::NonexistentChannel, msg);
     return 0xff;
   }
@@ -555,12 +555,12 @@ uint8_t gem::hw::vfat::HwVFAT2::getChannelTrimDAC(uint8_t channel)
 
 void gem::hw::vfat::HwVFAT2::setChannelTrimDAC(uint8_t channel, uint8_t trimDAC)
 {
-  DEBUG(toolbox::toString("setting trim DAC for channel %d HwVFAT2.cc", (unsigned)channel));
+  CMSGEMOS_DEBUG(toolbox::toString("setting trim DAC for channel %d HwVFAT2.cc", (unsigned)channel));
   // channel should be 1 to 128
   if ((channel > 128) || (channel < 1)) {
     std::string msg =
       toolbox::toString("Channel specified (%d) outside expectation (1-128)", channel);
-    ERROR(msg);
+    CMSGEMOS_ERROR(msg);
     // XCEPT_RAISE(gem::hw::vfat::exception::NonexistentChannel, msg);
     return;
   }
@@ -569,11 +569,11 @@ void gem::hw::vfat::HwVFAT2::setChannelTrimDAC(uint8_t channel, uint8_t trimDAC)
     uint8_t channelSettings = (readVFATReg(registerName)&~VFAT2ChannelBitMasks::TRIMDAC)|trimDAC;
     writeVFATReg(registerName, channelSettings|trimDAC);
   } catch (gem::hw::vfat::exception::TransactionError const& e) {
-    WARN("Problem reading the control registers, transaction error bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, transaction error bit set");
   } catch (gem::hw::vfat::exception::InvalidTransaction const& e) {
-    WARN("Problem reading the control registers, invalid transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, invalid transaction bit set");
   } catch (gem::hw::vfat::exception::WrongTransaction const& e) {
-    WARN("Problem reading the control registers, wrong transaction bit set");
+    CMSGEMOS_WARN("Problem reading the control registers, wrong transaction bit set");
   }
 }
 

--- a/gemhardware/src/common/vfat/VFATManager.cc
+++ b/gemhardware/src/common/vfat/VFATManager.cc
@@ -57,10 +57,10 @@ gem::hw::vfat::VFATManager::VFATManager(xdaq::ApplicationStub* stub) :
   p_appInfoSpace->addItemChangedListener( "ConnectionFile",     this);
 
   //initialize the VFAT application objects
-  DEBUG("VFATManager::Connecting to the VFATManagerWeb interface");
+  CMSGEMOS_DEBUG("VFATManager::Connecting to the VFATManagerWeb interface");
   p_gemWebInterface = new gem::hw::vfat::VFATManagerWeb(this);
   //p_gemMonitor      = new gem::hw::vfat::VFATHwMonitor(this);
-  DEBUG("VFATManager::done");
+  CMSGEMOS_DEBUG("VFATManager::done");
 
   //set up the info hwCfgInfoSpace
   init();
@@ -76,13 +76,13 @@ gem::hw::vfat::VFATManager::~VFATManager() {
 void gem::hw::vfat::VFATManager::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("VFATManager::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("VFATManager::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
 
     //how to handle passing in various values nested in a vector in a bag
     for (auto board = m_vfatInfo.begin(); board != m_vfatInfo.end(); ++board) {
       if (board->bag.present.value_)
-        DEBUG("VFATManager::Found attribute:" << board->bag.toString());
+        CMSGEMOS_DEBUG("VFATManager::Found attribute:" << board->bag.toString());
     }
     //p_gemMonitor->startMonitoring();
   }
@@ -98,21 +98,21 @@ void gem::hw::vfat::VFATManager::init()
 void gem::hw::vfat::VFATManager::initializeAction()
   throw (gem::hw::vfat::exception::Exception)
 {
-  DEBUG("VFATManager::initializeAction begin");
+  CMSGEMOS_DEBUG("VFATManager::initializeAction begin");
   for (int slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);
-    DEBUG("VFATManager::looping over slots(" << (slot+1) << ") and finding expected cards");
+    CMSGEMOS_DEBUG("VFATManager::looping over slots(" << (slot+1) << ") and finding expected cards");
     for (int link = 0; link < MAX_VFATS_PER_AMC; ++link) {
       // usleep(10);
-      DEBUG("VFATManager::looping over links(" << link << ") and finding expected cards");
+      CMSGEMOS_DEBUG("VFATManager::looping over links(" << link << ") and finding expected cards");
       unsigned int index = (slot*MAX_VFATS_PER_AMC)+link;
       VFATInfo& info = m_vfatInfo[index].bag;
 
       if (!info.present)
         continue;
 
-      DEBUG("VFATManager::line 118: info is: " << info.toString());
-      DEBUG("VFATManager::creating pointer to board connected on link " << link << " to GLIB in slot " << (slot+1));
+      CMSGEMOS_DEBUG("VFATManager::line 118: info is: " << info.toString());
+      CMSGEMOS_DEBUG("VFATManager::creating pointer to board connected on link " << link << " to GLIB in slot " << (slot+1));
       std::string deviceName = toolbox::toString("gem.shelf%02d.glib%02d.vfat%02d",
                                                  info.crateID.value_,
                                                  info.slotID.value_,
@@ -120,14 +120,14 @@ void gem::hw::vfat::VFATManager::initializeAction()
       toolbox::net::URN hwCfgURN("urn:gem:hw:"+deviceName);
 
       if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-        DEBUG("VFATManager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
+        CMSGEMOS_DEBUG("VFATManager::initializeAction::infospace " << hwCfgURN.toString() << " already exists, getting");
         is_vfats[slot] = xdata::getInfoSpaceFactory()->get(hwCfgURN.toString());
       } else {
-        DEBUG("VFATManager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
+        CMSGEMOS_DEBUG("VFATManager::initializeAction::infospace " << hwCfgURN.toString() << " does not exist, creating");
         is_vfats[slot] = xdata::getInfoSpaceFactory()->create(hwCfgURN.toString());
       }
 
-      DEBUG("VFATManager::exporting config parameters into infospace");
+      CMSGEMOS_DEBUG("VFATManager::exporting config parameters into infospace");
       /* figure out how to make it work like this
          probably just have to define begin/end for VFATInfo class and iterators
       for (auto monitorable = info.begin(); monitorable != info.end(); ++monitorable)
@@ -152,12 +152,12 @@ void gem::hw::vfat::VFATManager::initializeAction()
       if (!is_vfats[slot]->hasItem("IPBusPort"))
         is_vfats[slot]->fireItemAvailable("IPBusPort",         &info.ipBusPort);
 
-      DEBUG("VFATManager::InfoSpace found item: ControlHubAddress " << is_vfats[slot]->find("ControlHubAddress"));
-      DEBUG("VFATManager::InfoSpace found item: IPBusProtocol "     << is_vfats[slot]->find("IPBusProtocol")    );
-      DEBUG("VFATManager::InfoSpace found item: DeviceIPAddress "   << is_vfats[slot]->find("DeviceIPAddress")  );
-      DEBUG("VFATManager::InfoSpace found item: AddressTable "      << is_vfats[slot]->find("AddressTable")     );
-      DEBUG("VFATManager::InfoSpace found item: ControlHubPort "    << is_vfats[slot]->find("ControlHubPort")   );
-      DEBUG("VFATManager::InfoSpace found item: IPBusPort "         << is_vfats[slot]->find("IPBusPort")        );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace found item: ControlHubAddress " << is_vfats[slot]->find("ControlHubAddress"));
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace found item: IPBusProtocol "     << is_vfats[slot]->find("IPBusProtocol")    );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace found item: DeviceIPAddress "   << is_vfats[slot]->find("DeviceIPAddress")  );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace found item: AddressTable "      << is_vfats[slot]->find("AddressTable")     );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace found item: ControlHubPort "    << is_vfats[slot]->find("ControlHubPort")   );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace found item: IPBusPort "         << is_vfats[slot]->find("IPBusPort")        );
 
       is_vfats[slot]->fireItemValueRetrieve("ControlHubAddress");
       is_vfats[slot]->fireItemValueRetrieve("IPBusProtocol");
@@ -173,16 +173,16 @@ void gem::hw::vfat::VFATManager::initializeAction()
       is_vfats[slot]->fireItemValueChanged("ControlHubPort");
       is_vfats[slot]->fireItemValueChanged("IPBusPort");
 
-      DEBUG("VFATManager::initializeAction::info:" << info.toString());
-      DEBUG("VFATManager::InfoSpace item value: ControlHubAddress " << info.controlHubAddress.toString());
-      DEBUG("VFATManager::InfoSpace item value: IPBusProtocol "     << info.ipBusProtocol.toString()    );
-      DEBUG("VFATManager::InfoSpace item value: DeviceIPAddress "   << info.deviceIPAddress.toString()  );
-      DEBUG("VFATManager::InfoSpace item value: AddressTable "      << info.addressTable.toString()     );
-      DEBUG("VFATManager::InfoSpace item value: ControlHubPort "    << info.controlHubPort.toString()   );
-      DEBUG("VFATManager::InfoSpace item value: IPBusPort "         << info.ipBusPort.toString()        );
+      CMSGEMOS_DEBUG("VFATManager::initializeAction::info:" << info.toString());
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace item value: ControlHubAddress " << info.controlHubAddress.toString());
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace item value: IPBusProtocol "     << info.ipBusProtocol.toString()    );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace item value: DeviceIPAddress "   << info.deviceIPAddress.toString()  );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace item value: AddressTable "      << info.addressTable.toString()     );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace item value: ControlHubPort "    << info.controlHubPort.toString()   );
+      CMSGEMOS_DEBUG("VFATManager::InfoSpace item value: IPBusPort "         << info.ipBusPort.toString()        );
 
       try {
-        DEBUG("VFATManager::obtaining pointer to HwVFAT2 " << deviceName
+        CMSGEMOS_DEBUG("VFATManager::obtaining pointer to HwVFAT2 " << deviceName
              << " (slot " << slot+1 << ")"
              << " (link " << link   << ")");
         m_vfats[index] = vfat_shared_ptr(new gem::hw::vfat::HwVFAT2(deviceName,m_connectionFile.toString()));
@@ -195,13 +195,13 @@ void gem::hw::vfat::VFATManager::initializeAction()
         //std::string tmpURI = toolbox::toString();
         std::stringstream tmpURI;
         if (info.controlHubAddress.toString().size() > 0) {
-          DEBUG("VFATManager::Using control hub at address '" << info.controlHubAddress.toString()
+          CMSGEMOS_DEBUG("VFATManager::Using control hub at address '" << info.controlHubAddress.toString()
                << ", port number "              << info.controlHubPort.toString() << "'.");
           tmpURI << "chtcp-"<< info.ipBusProtocol.toString() << "://"
                  << info.controlHubAddress.toString() << ":" << info.controlHubPort.toString()
                  << "?target=" << info.deviceIPAddress.toString() << ":" << info.ipBusPort.toString();
         } else {
-          DEBUG("VFATManager::No control hub address specified -> continuing with a direct connection.");
+          CMSGEMOS_DEBUG("VFATManager::No control hub address specified -> continuing with a direct connection.");
           tmpURI << "ipbusudp-" << info.ipBusProtocol.toString() << "://"
                  << info.deviceIPAddress.toString() << ":" << info.ipBusPort.toString();
         }
@@ -210,39 +210,39 @@ void gem::hw::vfat::VFATManager::initializeAction()
         //DEBUG("VFATManager::connecting to device");
         //m_vfats[index]->connectDevice();
         */
-        DEBUG("VFATManager::connected");
+        CMSGEMOS_DEBUG("VFATManager::connected");
       } catch (gem::hw::vfat::exception::Exception const& ex) {
-        ERROR("VFATManager::caught exception " << ex.what());
+        CMSGEMOS_ERROR("VFATManager::caught exception " << ex.what());
         XCEPT_RAISE(gem::hw::vfat::exception::Exception, "initializeAction failed");
       } catch (toolbox::net::exception::MalformedURN const& ex) {
-        ERROR("VFATManager::caught exception " << ex.what());
+        CMSGEMOS_ERROR("VFATManager::caught exception " << ex.what());
         XCEPT_RAISE(gem::hw::vfat::exception::Exception, "initializeAction failed");
       } catch (std::exception const& ex) {
-        ERROR("VFATManager::caught exception " << ex.what());
+        CMSGEMOS_ERROR("VFATManager::caught exception " << ex.what());
         XCEPT_RAISE(gem::hw::vfat::exception::Exception, "initializeAction failed");
       }
       //set the web view to be empty or grey
       //if (!info.present.value_) continue;
       //p_gemWebInterface->vfatInSlot(slot);
 
-      DEBUG("VFATManager::grabbing pointer to hardware device");
+      CMSGEMOS_DEBUG("VFATManager::grabbing pointer to hardware device");
       vfat_shared_ptr vfat = m_vfats[index];
 
       if (vfat->isHwConnected()) {
         //return;
-        DEBUG("VFATManager::VFAT connected on link " << link << " to GLIB in slot " << (slot+1));
+        CMSGEMOS_DEBUG("VFATManager::VFAT connected on link " << link << " to GLIB in slot " << (slot+1));
       } else {
-        WARN("VFATManager::VFAT connected on link " << link << " to GLIB in slot " << (slot+1) << " is not responding");
+        CMSGEMOS_WARN("VFATManager::VFAT connected on link " << link << " to GLIB in slot " << (slot+1) << " is not responding");
       }
     }
   }
-  DEBUG("VFATManager::initializeAction end");
+  CMSGEMOS_DEBUG("VFATManager::initializeAction end");
 }
 
 void gem::hw::vfat::VFATManager::configureAction()
   throw (gem::hw::vfat::exception::Exception)
 {
-  DEBUG("VFATManager::configureAction");
+  CMSGEMOS_DEBUG("VFATManager::configureAction");
   //will the manager operate for all connected vfats, or only those connected to certain GLIBs?
   for (int slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);
@@ -251,16 +251,16 @@ void gem::hw::vfat::VFATManager::configureAction()
       unsigned int index = (slot*MAX_VFATS_PER_AMC)+link;
       VFATInfo& info = m_vfatInfo[index].bag;
 
-      DEBUG("VFATManager::line 231: info is: " << info.toString());
+      CMSGEMOS_DEBUG("VFATManager::line 231: info is: " << info.toString());
       if (!info.present)
         continue;
 
-      DEBUG("VFATManager::grabbing pointer to hardware device");
+      CMSGEMOS_DEBUG("VFATManager::grabbing pointer to hardware device");
       vfat_shared_ptr vfat = m_vfats[index];
 
       if (vfat->isHwConnected()) {
         /*
-        DEBUG("VFATManager::setting cdce clock source to 0x" << std::hex << info.cdceClkSrc.value_ << std::dec);
+        CMSGEMOS_DEBUG("VFATManager::setting cdce clock source to 0x" << std::hex << info.cdceClkSrc.value_ << std::dec);
         vfat->setSBitSource(info.cdceClkSrc.value_);
         */
         for (unsigned olink = 0; olink < 3; ++olink) {
@@ -269,12 +269,12 @@ void gem::hw::vfat::VFATManager::configureAction()
         //need to reset optical links?
         //reset counters?
       } else {
-        WARN("VFATManager::VFAT connected on link " << link << " to GLIB in slot " << (slot+1) << " is not responding");
+        CMSGEMOS_WARN("VFATManager::VFAT connected on link " << link << " to GLIB in slot " << (slot+1) << " is not responding");
       }
     }
   }
 
-  DEBUG("VFATManager::configureAction end");
+  CMSGEMOS_DEBUG("VFATManager::configureAction end");
 }
 
 void gem::hw::vfat::VFATManager::startAction()
@@ -311,13 +311,13 @@ void gem::hw::vfat::VFATManager::resetAction()
   throw (gem::hw::vfat::exception::Exception)
 {
   //unregister listeners and items in info spaces
-  DEBUG("VFATManager::resetAction begin");
+  CMSGEMOS_DEBUG("VFATManager::resetAction begin");
   for (int slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
     // usleep(10);
-    DEBUG("VFATManager::looping over slots(" << (slot+1) << ") and finding expected cards");
+    CMSGEMOS_DEBUG("VFATManager::looping over slots(" << (slot+1) << ") and finding expected cards");
     for (int link = 0; link < MAX_VFATS_PER_AMC; ++link) {
       // usleep(10);
-      DEBUG("VFATManager::looping over links(" << link << ") and finding expected cards");
+      CMSGEMOS_DEBUG("VFATManager::looping over links(" << link << ") and finding expected cards");
       unsigned int index = (slot*MAX_VFATS_PER_AMC)+link;
       VFATInfo& info = m_vfatInfo[index].bag;
 
@@ -326,20 +326,20 @@ void gem::hw::vfat::VFATManager::resetAction()
       // set up the info space here rather than in initialize (where it can then get unset in reset?
       // should a value be set up for all of them by default?
 
-      DEBUG("VFATManager::revoking hwCfgInfoSpace items for board connected on link " << link << " to GLIB in slot " << (slot+1));
+      CMSGEMOS_DEBUG("VFATManager::revoking hwCfgInfoSpace items for board connected on link " << link << " to GLIB in slot " << (slot+1));
       toolbox::net::URN hwCfgURN("urn:gem:hw:"+toolbox::toString("gem.shelf%02d.glib%02d.vfat%02d",
                                                                  info.crateID.value_,
                                                                  info.slotID.value_,
                                                                  info.linkID.value_));
       if (xdata::getInfoSpaceFactory()->hasItem(hwCfgURN.toString())) {
-        DEBUG("VFATManager::resetAction::infospace " << hwCfgURN.toString() << " already exists, getting");
+        CMSGEMOS_DEBUG("VFATManager::resetAction::infospace " << hwCfgURN.toString() << " already exists, getting");
         is_vfats[slot] = xdata::getInfoSpaceFactory()->get(hwCfgURN.toString());
       } else {
-        DEBUG("VFATManager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
+        CMSGEMOS_DEBUG("VFATManager::resetAction::infospace " << hwCfgURN.toString() << " does not exist, no further action");
         continue;
       }
 
-      DEBUG("VFATManager::revoking config parameters into infospace");
+      CMSGEMOS_DEBUG("VFATManager::revoking config parameters into infospace");
       if (is_vfats[slot]->hasItem("ControlHubAddress"))
         is_vfats[slot]->fireItemRevoked("ControlHubAddress");
 

--- a/gemreadout/src/common/GEMReadoutApplication.cc
+++ b/gemreadout/src/common/GEMReadoutApplication.cc
@@ -64,7 +64,7 @@ gem::readout::GEMReadoutApplication::GEMReadoutApplication(xdaq::ApplicationStub
   m_usecPerEvent(0.0),
   m_usecUsed(0.0)
 {
-  DEBUG("GEMReadoutApplication ctor begin");
+  CMSGEMOS_DEBUG("GEMReadoutApplication ctor begin");
   //i2o::bind(this,&ReadoutApplication::onReadoutNotify,I2O_READOUT_NOTIFY,XDAQ_ORGANIZATION_ID);
   //xoap::bind(this,&ReadoutApplication::getReadoutCredits,"GetReadoutCredits","urn:GEMReadoutApplication-soap:1");
   p_appInfoSpace->fireItemAvailable("ReadoutSettings",&m_readoutSettings);
@@ -89,12 +89,12 @@ gem::readout::GEMReadoutApplication::GEMReadoutApplication(xdaq::ApplicationStub
 
   ////set up the info hwCfgInfoSpace
   //init();
-  DEBUG("GEMReadoutApplication::GEMReadoutApplication() "      << std::endl
+  CMSGEMOS_DEBUG("GEMReadoutApplication::GEMReadoutApplication() "      << std::endl
         << " m_deviceName:"     << m_deviceName.toString()     << std::endl
         << " m_connectionFile:" << m_connectionFile.toString() << std::endl
         << " m_eventsReadout:"  << m_eventsReadout.toString()  << std::endl
         );
-  DEBUG("GEMReadoutApplication ctor end");
+  CMSGEMOS_DEBUG("GEMReadoutApplication ctor end");
 }
 
 gem::readout::GEMReadoutApplication::~GEMReadoutApplication()
@@ -105,14 +105,14 @@ gem::readout::GEMReadoutApplication::~GEMReadoutApplication()
 void gem::readout::GEMReadoutApplication::actionPerformed(xdata::Event& event)
 {
   if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
-    DEBUG("GEMReadoutApplication::actionPerformed() setDefaultValues" <<
+    CMSGEMOS_DEBUG("GEMReadoutApplication::actionPerformed() setDefaultValues" <<
           "Default configuration values have been loaded from xml profile");
     importConfigurationParameters();
     importMonitoringParameters();
     //p_gemMonitor->startMonitoring();
   }
   // update monitoring variables
-  DEBUG("GEMReadoutApplication::actionPerformed() " << event.type() << std::endl
+  CMSGEMOS_DEBUG("GEMReadoutApplication::actionPerformed() " << event.type() << std::endl
         << " m_connectionFile:" << m_connectionFile.toString()      << std::endl
         << " m_deviceName:"     << m_deviceName.toString()          << std::endl
         << " m_eventsReadout:"  << m_eventsReadout.toString()       << std::endl
@@ -125,7 +125,7 @@ void gem::readout::GEMReadoutApplication::actionPerformed(xdata::Event& event)
 void gem::readout::GEMReadoutApplication::initializeAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::initializeAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::initializeAction begin");
   if (!m_task) {
     m_task = std::make_shared<gem::readout::GEMReadoutTask>(this);
     m_task->activate();
@@ -156,13 +156,13 @@ void gem::readout::GEMReadoutApplication::initializeAction()
 void gem::readout::GEMReadoutApplication::configureAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::configureAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::configureAction begin");
 }
 
 void gem::readout::GEMReadoutApplication::startAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::startAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::startAction begin");
   // build output filename
 
   // Times for output files
@@ -199,28 +199,28 @@ void gem::readout::GEMReadoutApplication::startAction()
 void gem::readout::GEMReadoutApplication::pauseAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::pauseAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::pauseAction begin");
   m_cmdQueue.push(ReadoutCommands::CMD_PAUSE);
 }
 
 void gem::readout::GEMReadoutApplication::resumeAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::resumeAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::resumeAction begin");
   m_cmdQueue.push(ReadoutCommands::CMD_RESUME);
 }
 
 void gem::readout::GEMReadoutApplication::stopAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::stopAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::stopAction begin");
   m_cmdQueue.push(ReadoutCommands::CMD_STOP);
 }
 
 void gem::readout::GEMReadoutApplication::haltAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::haltAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::haltAction begin");
   if (m_task)
     m_cmdQueue.push(ReadoutCommands::CMD_STOP);
 }
@@ -228,7 +228,7 @@ void gem::readout::GEMReadoutApplication::haltAction()
 void gem::readout::GEMReadoutApplication::resetAction()
   /*throw (gem::readout::exception::Exception)*/
 {
-  DEBUG("gem::readout::GEMReadoutApplication::resetAction begin");
+  CMSGEMOS_DEBUG("gem::readout::GEMReadoutApplication::resetAction begin");
 }
 
 void gem::readout::GEMReadoutApplication::failAction(toolbox::Event::Reference e)
@@ -285,27 +285,27 @@ int gem::readout::GEMReadoutApplication::readoutTask()
         std::stringstream msg;
         msg << "GEMReadoutApplication::readoutTask error "
             << xcept::stdformat_exception_history(e);
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
       } catch (xcept::Exception& e) {
         std::stringstream msg;
         msg << "GEMReadoutApplication::readoutTask error "
             << xcept::stdformat_exception_history(e);
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
       } catch (std::exception& e) {
         std::stringstream msg;
         msg << "GEMReadoutApplication::readoutTask error "
             << e.what();
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
       } catch (...) {
         std::stringstream msg;
         msg << "GEMReadoutApplication::readoutTask error (unknown exception)";
-        ERROR(msg.str());
+        CMSGEMOS_ERROR(msg.str());
       }
 
-      DEBUG("GEMReadoutApplication::readoutTask read " << nevtsRead << " events");
+      CMSGEMOS_DEBUG("GEMReadoutApplication::readoutTask read " << nevtsRead << " events");
       /*
       for (int i = 0; i < nevtsRead; i++) {
-        DEBUG("GEMReadoutApplication::readoutTask releaseing data[" << i << "]");
+        CMSGEMOS_DEBUG("GEMReadoutApplication::readoutTask releaseing data[" << i << "]");
         data[i]->release();
       }
       */

--- a/gemreadout/src/common/GEMReadoutWebApplication.cc
+++ b/gemreadout/src/common/GEMReadoutWebApplication.cc
@@ -25,7 +25,7 @@ void gem::readout::GEMReadoutWebApplication::webDefault(xgi::Input* in, xgi::Out
   throw (xgi::exception::Exception)
 {
   if (p_gemFSMApp)
-    DEBUG("current state is" << dynamic_cast<gem::readout::GEMReadoutApplication*>(p_gemFSMApp)->getCurrentState());
+    CMSGEMOS_DEBUG("current state is" << dynamic_cast<gem::readout::GEMReadoutApplication*>(p_gemFSMApp)->getCurrentState());
   *out << cgicc::script().set("type", "text/javascript")
     .set("src", "/gemdaq/gemreadout/html/scripts/readout.js")
        << cgicc::script() << std::endl;
@@ -37,21 +37,21 @@ void gem::readout::GEMReadoutWebApplication::webDefault(xgi::Input* in, xgi::Out
 void gem::readout::GEMReadoutWebApplication::monitorPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMReadoutWebApplication::monitorPage");
+  CMSGEMOS_DEBUG("GEMReadoutWebApplication::monitorPage");
 }
 
 /*To be filled in with the expert page code*/
 void gem::readout::GEMReadoutWebApplication::expertPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMReadoutWebApplication::expertPage");
+  CMSGEMOS_DEBUG("GEMReadoutWebApplication::expertPage");
 }
 
 /*To be filled in with the application page code*/
 void gem::readout::GEMReadoutWebApplication::applicationPage(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMReadoutWebApplication::applicationPage");
+  CMSGEMOS_DEBUG("GEMReadoutWebApplication::applicationPage");
   *out << "  <div class=\"xdaq-tab\" title=\"Application page\"/>"  << std::endl;
   *out << "  </div>" << std::endl;
 }
@@ -59,7 +59,7 @@ void gem::readout::GEMReadoutWebApplication::applicationPage(xgi::Input* in, xgi
 void gem::readout::GEMReadoutWebApplication::jsonUpdate(xgi::Input* in, xgi::Output* out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMReadoutWebApplication::jsonUpdate");
+  CMSGEMOS_DEBUG("GEMReadoutWebApplication::jsonUpdate");
   out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
   *out << " { " << std::endl;
   *out << " } " << std::endl;

--- a/gemsupervisor/src/common/GEMGLIBSupervisorWeb.cc
+++ b/gemsupervisor/src/common/GEMGLIBSupervisorWeb.cc
@@ -163,7 +163,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::actionPerformed(xdata::Event& event)
       chip != confParams_.bag.deviceName.end(); ++chip, ++num) {
         ss << "Device name: " << chip->toString() << std::endl;
       }
-    INFO(ss.str());
+    CMSGEMOS_INFO(ss.str());
     slotInfo = std::unique_ptr<gem::readout::GEMslotContents>(new gem::readout::GEMslotContents(confParams_.bag.slotFileName.toString()));
   }
 
@@ -523,8 +523,8 @@ void gem::supervisor::GEMGLIBSupervisorWeb::webConfigure(xgi::Input * in, xgi::O
         // can consider using this as the tracking/broadcast mask (initializing to 0xffffffff (everything masked off)
         // readout_mask &= (0xffffffff & 0x0 <<;
         readout_mask |= 0x1 << islot;
-        INFO(" webConfigure : DeviceName " << VfatName );
-        INFO(" webConfigure : readout_mask 0x" << std::hex << (int)readout_mask << std::dec );
+        CMSGEMOS_INFO(" webConfigure : DeviceName " << VfatName );
+        CMSGEMOS_INFO(" webConfigure : readout_mask 0x" << std::hex << (int)readout_mask << std::dec );
       }
     }// end if VfatName
   }// end for chip
@@ -536,7 +536,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::webConfigure(xgi::Input * in, xgi::O
   // Initiate configure workloop
   wl_->submit(configure_signature_);
 
-  INFO(" webConfigure : readout_mask 0x" << std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_INFO(" webConfigure : readout_mask 0x" << std::hex << (int)readout_mask << std::dec);
   // Go back to main web interface
   this->webRedirect(in, out);
 }
@@ -569,7 +569,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::webTrigger(xgi::Input * in, xgi::Out
   // Send L1A signal
   hw_semaphore_.take();
 
-  INFO(" webTrigger: sending L1A");
+  CMSGEMOS_INFO(" webTrigger: sending L1A");
   cgicc::Cgicc cgi(in);
   optohybridDevice_->sendL1A(cgi["NTrigs"]->getIntegerValue(),
                              cgi["Rate"]->getIntegerValue());
@@ -587,7 +587,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::webTrigger(xgi::Input * in, xgi::Out
 void gem::supervisor::GEMGLIBSupervisorWeb::webL1ACalPulse(xgi::Input * in, xgi::Output * out ) {
   // Send L1A signal
   hw_semaphore_.take();
-  INFO("webCalPulse: CalPulses with L1As delayed");
+  CMSGEMOS_INFO("webCalPulse: CalPulses with L1As delayed");
   cgicc::Cgicc cgi(in);
   optohybridDevice_->sendL1ACal(cgi["NTrigs"]->getIntegerValue(),
                                 cgi["Delay"]->getIntegerValue(),
@@ -607,7 +607,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::webResync(xgi::Input * in, xgi::Outp
   // Send L1A signal
   hw_semaphore_.take();
 
-  INFO("webResync: sending Resync");
+  CMSGEMOS_INFO("webResync: sending Resync");
   cgicc::Cgicc cgi(in);
   optohybridDevice_->sendResync(cgi["NResyncs"]->getIntegerValue(),
                                 cgi["Rate"]->getIntegerValue());
@@ -625,7 +625,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::webBC0(xgi::Input * in, xgi::Output 
   // Send L1A signal
   hw_semaphore_.take();
 
-  INFO("webBC0: sending BC0");
+  CMSGEMOS_INFO("webBC0: sending BC0");
   cgicc::Cgicc cgi(in);
   optohybridDevice_->sendBC0(cgi["NBC0s"]->getIntegerValue(),
                              cgi["Rate"]->getIntegerValue());
@@ -688,7 +688,7 @@ bool gem::supervisor::GEMGLIBSupervisorWeb::runAction(toolbox::task::WorkLoop *w
   wl_semaphore_.give();
   hw_semaphore_.give();
 
-  DEBUG("Combined bufferDepth = 0x" << std::hex << bufferDepth << std::dec);
+  CMSGEMOS_DEBUG("Combined bufferDepth = 0x" << std::hex << bufferDepth << std::dec);
 
   // If GLIB data buffer has non-zero size, initiate read workloop
   if (bufferDepth>3) {
@@ -757,7 +757,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::configureAction(toolbox::Event::Refe
   optohybridDevice_ = optohybrid_shared_ptr(new gem::hw::optohybrid::HwOptoHybrid(ohDeviceName, tmpURI.str(),
   //optohybridDevice_ = optohybrid_shared_ptr(new gem::hw::optohybrid::HwOptoHybrid("HwOptoHybrid0", tmpURI.str(),
                                                                                   "file://${GEM_ADDRESS_TABLE_PATH}/glib_address_table.xml"));
-  INFO("setTrigSource OH mode 1");
+  CMSGEMOS_INFO("setTrigSource OH mode 1");
   optohybridDevice_->setTrigSource(0x1);
 
   // Times for output files
@@ -774,7 +774,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::configureAction(toolbox::Event::Refe
   std::replace(SetupFileName.begin(), SetupFileName.end(), ' ', '_' );
   std::replace(SetupFileName.begin(), SetupFileName.end(), ':', '-');
 
-  INFO("::configureAction Created Setup file " << SetupFileName );
+  CMSGEMOS_INFO("::configureAction Created Setup file " << SetupFileName );
 
   std::ofstream SetupFile(SetupFileName.c_str(), std::ios::app );
   if (SetupFile.is_open()){
@@ -867,15 +867,15 @@ void gem::supervisor::GEMGLIBSupervisorWeb::configureAction(toolbox::Event::Refe
       Failure of any of the conditions at the moment does't take the FSM to error, should it? J.S. Sep 13
   */
   if (glibDevice_->isHwConnected()) {
-    INFO("GLIB device connected");
+    CMSGEMOS_INFO("GLIB device connected");
     if (optohybridDevice_->isHwConnected()) {
-      INFO("OptoHybrid device connected");
+      CMSGEMOS_INFO("OptoHybrid device connected");
       for (auto chip = vfatDevice_.begin(); chip != vfatDevice_.end(); ++chip) {
         if ((*chip)->isHwConnected()) {
-          INFO("VFAT device connected: chip ID = 0x"
+          CMSGEMOS_INFO("VFAT device connected: chip ID = 0x"
                << std::setw(4) << std::setfill('0') << std::hex
                << (uint32_t)((*chip)->getChipID())  << std::dec);
-          INFO((*chip)->printErrorCounts());
+          CMSGEMOS_INFO((*chip)->printErrorCounts());
 
           int islot = slotInfo->GEBslotIndex( (uint32_t)((*chip)->getChipID()));
 
@@ -888,7 +888,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::configureAction(toolbox::Event::Refe
           }
           is_configured_  = true;
         } else {
-          INFO("VFAT device not connected, breaking out");
+          CMSGEMOS_INFO("VFAT device not connected, breaking out");
           is_configured_  = false;
           is_working_     = false;
           hw_semaphore_.give();
@@ -898,7 +898,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::configureAction(toolbox::Event::Refe
         }
       }
     } else {
-      INFO("OptoHybrid device not connected, breaking out");
+      CMSGEMOS_INFO("OptoHybrid device not connected, breaking out");
       is_configured_  = false;
       is_working_     = false;
       hw_semaphore_.give();
@@ -907,7 +907,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::configureAction(toolbox::Event::Refe
       return;
     }
   } else {
-    INFO("GLIB device not connected, breaking out");
+    CMSGEMOS_INFO("GLIB device not connected, breaking out");
     is_configured_  = false;
     is_working_     = false;
     hw_semaphore_.give();
@@ -932,16 +932,16 @@ void gem::supervisor::GEMGLIBSupervisorWeb::startAction(toolbox::Event::Referenc
 
   hw_semaphore_.take();
 
-  INFO("setTrigSource OH mode 0");
+  CMSGEMOS_INFO("setTrigSource OH mode 0");
   optohybridDevice_->setTrigSource(0x0);
 
-  INFO("Enabling run mode for selected VFATs");
+  CMSGEMOS_INFO("Enabling run mode for selected VFATs");
   for (auto chip = vfatDevice_.begin(); chip != vfatDevice_.end(); ++chip)
     (*chip)->setRunMode(1);
 
   // flush FIFO, how to disable a specific, misbehaving, chip
-  INFO("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
-  DEBUG("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
+  CMSGEMOS_INFO("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_DEBUG("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
   glibDevice_->flushFIFO(readout_mask);
   while (glibDevice_->hasTrackingData(readout_mask)) {
     glibDevice_->flushFIFO(readout_mask);
@@ -952,11 +952,11 @@ void gem::supervisor::GEMGLIBSupervisorWeb::startAction(toolbox::Event::Referenc
   glibDevice_->flushFIFO(readout_mask);
 
   // send resync
-  INFO("Sending a resync");
+  CMSGEMOS_INFO("Sending a resync");
   optohybridDevice_->sendResync();
 
   // reset counters
-  INFO("Resetting counters");
+  CMSGEMOS_INFO("Resetting counters");
   optohybridDevice_->resetL1ACount(0x5);
   optohybridDevice_->resetResyncCount(0x5);
   optohybridDevice_->resetBC0Count(0x5);
@@ -970,7 +970,7 @@ void gem::supervisor::GEMGLIBSupervisorWeb::startAction(toolbox::Event::Referenc
     m_bc0Count[count]      = optohybridDevice_->getBC0Count(count);
   }
 
-  INFO("setTrigSource OH Trigger source 0x" << std::hex << confParams_.bag.triggerSource << std::dec);
+  CMSGEMOS_INFO("setTrigSource OH Trigger source 0x" << std::hex << confParams_.bag.triggerSource << std::dec);
   glibDevice_->flushFIFO(readout_mask);
   optohybridDevice_->sendResync();
   optohybridDevice_->sendBC0();
@@ -995,16 +995,16 @@ void gem::supervisor::GEMGLIBSupervisorWeb::stopAction(toolbox::Event::Reference
   sumVFAT_  = 0;
   //m_counter = {0,0,0,0,0}; do not reset displaying counters
 
-  INFO("setTrigSource GLIB, OH mode 0");
+  CMSGEMOS_INFO("setTrigSource GLIB, OH mode 0");
   optohybridDevice_->setTrigSource(0x1);
 
   // turn off all chips?
   for (auto chip = vfatDevice_.begin(); chip != vfatDevice_.end(); ++chip) {
     (*chip)->setRunMode(0);
-    INFO((*chip)->printErrorCounts());
+    CMSGEMOS_INFO((*chip)->printErrorCounts());
   }
   // flush FIFO, how to disable a specific, misbehaving, chip
-  INFO("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_INFO("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
   glibDevice_->flushFIFO(readout_mask);
   while (glibDevice_->hasTrackingData(readout_mask)) {
     glibDevice_->flushFIFO(readout_mask);
@@ -1024,10 +1024,10 @@ void gem::supervisor::GEMGLIBSupervisorWeb::haltAction(toolbox::Event::Reference
 
   for (auto chip = vfatDevice_.begin(); chip != vfatDevice_.end(); ++chip) {
     (*chip)->setRunMode(0);
-    INFO((*chip)->printErrorCounts());
+    CMSGEMOS_INFO((*chip)->printErrorCounts());
   }
   // flush FIFO, how to disable a specific, misbehaving, chip
-  INFO("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_INFO("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
   glibDevice_->flushFIFO(readout_mask);
   while (glibDevice_->hasTrackingData(readout_mask)) {
     glibDevice_->flushFIFO(readout_mask);

--- a/gemsupervisor/src/common/GEMSupervisorMonitor.cc
+++ b/gemsupervisor/src/common/GEMSupervisorMonitor.cc
@@ -25,7 +25,7 @@ gem::supervisor::GEMSupervisorMonitor::~GEMSupervisorMonitor()
 
 void gem::supervisor::GEMSupervisorMonitor::setupAppStateMonitoring()
 {
-  DEBUG("GEMSupervisorMonitor::setupAppStateMonitoring");
+  CMSGEMOS_DEBUG("GEMSupervisorMonitor::setupAppStateMonitoring");
   // create the values to be monitored in the info space
   addMonitorableSet("AppStates", "AppStateMonitoring");
 
@@ -47,7 +47,7 @@ void gem::supervisor::GEMSupervisorMonitor::setupAppStateMonitoring()
     // if (monlist && monlist)
     //   continue;
 
-    DEBUG("GEMSupervisorMonitor::setupAppStateMonitoring adding monitored app '"
+    CMSGEMOS_DEBUG("GEMSupervisorMonitor::setupAppStateMonitoring adding monitored app '"
           << appNameID.str() << "' with source URN '" << appURN.str() << "' to 'AppStates' in info space 'AppStateMonitoring'");
 
     if (appNameID.str().find("tcds")          != std::string::npos ||
@@ -73,34 +73,34 @@ void gem::supervisor::GEMSupervisorMonitor::updateMonitorables()
 
 void gem::supervisor::GEMSupervisorMonitor::updateApplicationStates()
 {
-  DEBUG("GEMSupervisorMonitor::updateApplicationStates Updating AppStates monitorables");
+  CMSGEMOS_DEBUG("GEMSupervisorMonitor::updateApplicationStates Updating AppStates monitorables");
   if (!(m_monitorableSetsMap.count("AppStates"))) {
-    WARN("GEMSupervisorMonitor::updateApplicationStates Unable to find 'AppStates' in monitor");
+    CMSGEMOS_WARN("GEMSupervisorMonitor::updateApplicationStates Unable to find 'AppStates' in monitor");
     return;
   }
   auto monlist = m_monitorableSetsMap.find("AppStates");
   if (monlist == m_monitorableSetsMap.end()) {
-    WARN("GEMSupervisorMonitor::updateApplicationStates Unable to find 'AppStates' in monitor");
+    CMSGEMOS_WARN("GEMSupervisorMonitor::updateApplicationStates Unable to find 'AppStates' in monitor");
     return;
   }
-  DEBUG("GEMSupervisorMonitor::updateApplicationStates Updating monitorables in set " << monlist->first);
+  CMSGEMOS_DEBUG("GEMSupervisorMonitor::updateApplicationStates Updating monitorables in set " << monlist->first);
   for (auto monitem = monlist->second.begin(); monitem != monlist->second.end(); ++monitem) {
-    DEBUG("GEMSupervisorMonitor::updateApplicationStates Updating monitorable " << monitem->first);
+    CMSGEMOS_DEBUG("GEMSupervisorMonitor::updateApplicationStates Updating monitorable " << monitem->first);
     std::string state;
     if (monitem->second.updatetype == GEMUpdateType::PROCESS) {
       try {
         xdata::InfoSpace* is = xdata::getInfoSpaceFactory()->get(monitem->second.regname);
-        DEBUG("GEMSupervisorMonitor::updateApplicationStates infospace: " << is->name() << " has item StateName "
+        CMSGEMOS_DEBUG("GEMSupervisorMonitor::updateApplicationStates infospace: " << is->name() << " has item StateName "
               << is->hasItem("StateName"));
         state = gem::base::utils::GEMInfoSpaceToolBox::getString(is, "StateName");
       } catch (xdata::exception::Exception const& err) {
         std::string msg = "Error trying to read from InfoSpace '" + monitem->second.regname + "' state " + state + ".";
-        ERROR("GEMSupervisorMonitor::updateApplicationStates " << msg << " " << err.what());
+        CMSGEMOS_ERROR("GEMSupervisorMonitor::updateApplicationStates " << msg << " " << err.what());
         XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
         return;
       } catch (std::exception const& err) {
         std::string msg = "Error trying to read from InfoSpace '" + monitem->second.regname + "' state " + state + ".";
-        ERROR("GEMSupervisorMonitor::updateApplicationStates " << msg << " " << err.what());
+        CMSGEMOS_ERROR("GEMSupervisorMonitor::updateApplicationStates " << msg << " " << err.what());
         XCEPT_RAISE(gem::base::utils::exception::InfoSpaceProblem, msg);
         return;
       }
@@ -116,35 +116,35 @@ void gem::supervisor::GEMSupervisorMonitor::updateApplicationStates()
         // appNameID << (*app)->getClassName() << ":lid:" << (*app)->getLocalId();
         if (appNameID.str().find(monitem->first) != std::string::npos) {
           try {
-            DEBUG("GEMSupervisorMonitor::updateApplicationStates trying to get application state via SOAP for application: "
+            CMSGEMOS_DEBUG("GEMSupervisorMonitor::updateApplicationStates trying to get application state via SOAP for application: "
                   << (*app)->getClassName() << " with URN "
                   << (*app)->getURN());
             state = gem::utils::soap::GEMSOAPToolBox::getApplicationState(superContext, superDesc, &(**app));
           } catch(xcept::Exception e) {
-            ERROR("GEMSupervisorMonitor::updateApplicationStates caught xcept::Exception: "
+            CMSGEMOS_ERROR("GEMSupervisorMonitor::updateApplicationStates caught xcept::Exception: "
                   << e.what());
             state = e.what();
           } catch(std::exception e) {
-            ERROR("GEMSupervisorMonitor::updateApplicationStates caught std::exception: "
+            CMSGEMOS_ERROR("GEMSupervisorMonitor::updateApplicationStates caught std::exception: "
                   << e.what());
             state = e.what();
           } catch (...) {
-            ERROR("GEMSupervisorMonitor::updateApplicationStates caught exception");
+            CMSGEMOS_ERROR("GEMSupervisorMonitor::updateApplicationStates caught exception");
             state = "SOAP update failed";
           }
         }
       }
     }
-    DEBUG("GEMSupervisorMonitor::updateApplicationStates updating "
+    CMSGEMOS_DEBUG("GEMSupervisorMonitor::updateApplicationStates updating "
           << monitem->first << " with state " << state);
     (monitem->second.infoSpace)->setString(monitem->first, state);
-    DEBUG("GEMSupervisorMonitor::updateApplicationStates updating done!");
+    CMSGEMOS_DEBUG("GEMSupervisorMonitor::updateApplicationStates updating done!");
   }
 }
 
 void gem::supervisor::GEMSupervisorMonitor::buildStateTable(xgi::Output* out)
 {
-  DEBUG("GEMSupervisorMonitor::buildStateTable");
+  CMSGEMOS_DEBUG("GEMSupervisorMonitor::buildStateTable");
   *out << "<table class=\"xdaq-table\">" << std::endl
        << cgicc::thead() << std::endl
        << cgicc::tr()    << std::endl  // open
@@ -157,7 +157,7 @@ void gem::supervisor::GEMSupervisorMonitor::buildStateTable(xgi::Output* out)
   if (m_monitorableSetsMap.count("AppStates")) {
     for (auto monitem = m_monitorableSetsMap.find("AppStates")->second.begin();
          monitem != m_monitorableSetsMap.find("AppStates")->second.end(); ++monitem) {
-      DEBUG("GEMSupervisorMonitor::buildStateTable " << monitem->first);
+      CMSGEMOS_DEBUG("GEMSupervisorMonitor::buildStateTable " << monitem->first);
       *out << "<tr>"    << std::endl;
 
       *out << "<td>"    << std::endl
@@ -166,7 +166,7 @@ void gem::supervisor::GEMSupervisorMonitor::buildStateTable(xgi::Output* out)
            << cgicc::h3()
            << "</td>"   << std::endl;
 
-      DEBUG(monitem->first << " formatted to "
+      CMSGEMOS_DEBUG(monitem->first << " formatted to "
             << (monitem->second.infoSpace)->getFormattedItem(monitem->first, monitem->second.format));
       *out << "<td id=\"" << monitem->second.infoSpace->name() << "-" << monitem->first << "\">" << std::endl
            << cgicc::h3()

--- a/gemsupervisor/src/common/GEMSupervisorWeb.cc
+++ b/gemsupervisor/src/common/GEMSupervisorWeb.cc
@@ -30,7 +30,7 @@ void gem::supervisor::GEMSupervisorWeb::webDefault(xgi::Input * in, xgi::Output 
   throw (xgi::exception::Exception)
 {
   if (p_gemFSMApp)
-    DEBUG("GEMSupervisorWeb::current supervisor state is"
+    CMSGEMOS_DEBUG("GEMSupervisorWeb::current supervisor state is"
           << dynamic_cast<gem::supervisor::GEMSupervisor*>(p_gemFSMApp)->getCurrentState());
   *out << cgicc::script().set("type", "text/javascript")
     .set("src", "/gemdaq/gemsupervisor/html/scripts/gemsupervisor.js")
@@ -42,7 +42,7 @@ void gem::supervisor::GEMSupervisorWeb::webDefault(xgi::Input * in, xgi::Output 
 void gem::supervisor::GEMSupervisorWeb::controlPanel(xgi::Input * in, xgi::Output * out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMSupervisor::controlPanel");
+  CMSGEMOS_DEBUG("GEMSupervisor::controlPanel");
   GEMWebApplication::controlPanel(in, out);
 
   *out << cgicc::br();
@@ -58,14 +58,14 @@ void gem::supervisor::GEMSupervisorWeb::controlPanel(xgi::Input * in, xgi::Outpu
 void gem::supervisor::GEMSupervisorWeb::monitorPage(xgi::Input * in, xgi::Output * out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMSupervisorWeb::Rendering GEMSupervisorWeb monitorPage");
-  DEBUG("GEMSupervisorWeb::in: " << std::hex << in << " out: " << std::hex << out << std::dec);
-  DEBUG("GEMSupervisorWeb::current level is "      << level);
+  CMSGEMOS_DEBUG("GEMSupervisorWeb::Rendering GEMSupervisorWeb monitorPage");
+  CMSGEMOS_DEBUG("GEMSupervisorWeb::in: " << std::hex << in << " out: " << std::hex << out << std::dec);
+  CMSGEMOS_DEBUG("GEMSupervisorWeb::current level is "      << level);
   if (level != 5) {
   } else  {
     level = 2;
   }
-  DEBUG("GEMSupervisorWeb::current level is "      << level);
+  CMSGEMOS_DEBUG("GEMSupervisorWeb::current level is "      << level);
 
 
   *out << cgicc::section().set("style", "display:inline-block;float:left") << std::endl
@@ -87,7 +87,7 @@ void gem::supervisor::GEMSupervisorWeb::monitorPage(xgi::Input * in, xgi::Output
 void gem::supervisor::GEMSupervisorWeb::expertPage(xgi::Input * in, xgi::Output * out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMSupervisorWeb::rendering GEMSupervisorWeb expertPage");
+  CMSGEMOS_DEBUG("GEMSupervisorWeb::rendering GEMSupervisorWeb expertPage");
   // should put all this style information into a common CSS sheet
   *out << cgicc::section().set("style", "display:inline-block;float:left") << std::endl
        << cgicc::fieldset().set("style", "style=\"display:block\";padding:5px;margin:5px;list-style-type:none;margin-bottom:5px;line-height:18px;padding:2px 5px;-webkit-border-radius:5px;-moz-border-radius:5px;border-radius:5px;border:medium outset #CCC;")
@@ -102,7 +102,7 @@ void gem::supervisor::GEMSupervisorWeb::expertPage(xgi::Input * in, xgi::Output 
 void gem::supervisor::GEMSupervisorWeb::applicationPage(xgi::Input * in, xgi::Output * out)
   throw (xgi::exception::Exception)
 {
-  DEBUG("GEMSupervisorWeb::applicationPage");
+  CMSGEMOS_DEBUG("GEMSupervisorWeb::applicationPage");
   *out << "applicationPage</br>" << std::endl;
 }
 
@@ -128,11 +128,11 @@ void gem::supervisor::GEMSupervisorWeb::displayManagedStateTable(xgi::Input * in
            << cgicc::h3() ;
       // << dynamic_cast<gem::base::GEMFSMApplication*>(*managedApp)->getURN()
       std::string classname = (*managedApp)->getClassName();
-      DEBUG("GEMSupervisorWeb::managed class name is " << classname);
+      CMSGEMOS_DEBUG("GEMSupervisorWeb::managed class name is " << classname);
       *out << classname;
       *out << "(";
       unsigned int instance = (*managedApp)->getInstance();
-      DEBUG("GEMSupervisorWeb::managed class instance is " << instance);
+      CMSGEMOS_DEBUG("GEMSupervisorWeb::managed class instance is " << instance);
       *out << instance;
       *out << ")"
            << cgicc::h3() << std::endl
@@ -140,14 +140,14 @@ void gem::supervisor::GEMSupervisorWeb::displayManagedStateTable(xgi::Input * in
            << "<td>"      << std::endl
            << cgicc::h3();
 
-      INFO("GEMSupervisorWeb::trying to get the FSM class object for object " << std::hex << *managedApp << std::dec);
+      CMSGEMOS_INFO("GEMSupervisorWeb::trying to get the FSM class object for object " << std::hex << *managedApp << std::dec);
       std::string appStateURN = (*managedApp)->getURN();
       // appStateURN = appStateURN.substr(appStateURN.rfind("::")+2);
       // boost::replace_all(appStateURN, ":", "-");
       std::string classstate
         = gem::base::utils::GEMInfoSpaceToolBox::getString(xdata::getInfoSpaceFactory()->get(appStateURN), "StateName");
       *out << classstate;
-      INFO("GEMSupervisorWeb::managed class FSM state is " << classstate);
+      CMSGEMOS_INFO("GEMSupervisorWeb::managed class FSM state is " << classstate);
       *out << cgicc::h3() << std::endl
            << "</td>"     << std::endl
            << "</tr>"     << std::endl;
@@ -155,10 +155,10 @@ void gem::supervisor::GEMSupervisorWeb::displayManagedStateTable(xgi::Input * in
     *out << "</tbody>"  << std::endl
          << "</table>"  << std::endl;
   } catch (const xgi::exception::Exception& e) {
-    ERROR("GEMSupervisorWeb::Something went wrong displaying managed application state table(xgi): " << e.what());
+    CMSGEMOS_ERROR("GEMSupervisorWeb::Something went wrong displaying managed application state table(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("GEMSupervisorWeb::Something went wrong displaying managed application state table(std): " << e.what());
+    CMSGEMOS_ERROR("GEMSupervisorWeb::Something went wrong displaying managed application state table(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }

--- a/gemsupervisor/src/common/tbutils/GEMTBUtil.cc
+++ b/gemsupervisor/src/common/tbutils/GEMTBUtil.cc
@@ -132,10 +132,10 @@ gem::supervisor::tbutils::GEMTBUtil::GEMTBUtil(xdaq::ApplicationStub *s)
   resetSig_ = toolbox::task::bind(this, &GEMTBUtil::reset,      "reset"     );
 
   std::string className = getApplicationDescriptor()->getClassName();
-  DEBUG("className " << className);
+  CMSGEMOS_DEBUG("className " << className);
   className =
     className.substr(className.rfind("gem::supervisor::"),std::string::npos);
-  DEBUG("className " << className);
+  CMSGEMOS_DEBUG("className " << className);
 
   fsmP_ = new
     toolbox::fsm::AsynchronousFiniteStateMachine("GEMTButilFSM:" + className);
@@ -195,7 +195,7 @@ void gem::supervisor::tbutils::GEMTBUtil::actionPerformed(xdata::Event& event)
     std::stringstream ss;
     ss << "ipAddr_=[" << ipAddr_.toString() << "]" << std::endl;
 
-    DEBUG(ss.str());
+    CMSGEMOS_DEBUG(ss.str());
     confParams_.bag.deviceIP = ipAddr_;
   }
 }
@@ -210,10 +210,10 @@ void gem::supervisor::tbutils::GEMTBUtil::stateChanged(toolbox::fsm::FiniteState
 {
   //keep_refresh_ = false;
 
-  DEBUG("Current state is: [" << fsm.getStateName (fsm.getCurrentState()) << "]");
+  CMSGEMOS_DEBUG("Current state is: [" << fsm.getStateName (fsm.getCurrentState()) << "]");
   std::string state_=fsm.getStateName (fsm.getCurrentState());
 
-  DEBUG( "StateChanged: " << (std::string)state_);
+  CMSGEMOS_DEBUG( "StateChanged: " << (std::string)state_);
 
 }
 
@@ -232,7 +232,7 @@ void gem::supervisor::tbutils::GEMTBUtil::transitionFailed(toolbox::Event::Refer
          << std::endl
          << "]]>";
 
-  ERROR(reason.str());
+  CMSGEMOS_ERROR(reason.str());
 }
 
 //Actions (defined in the base class, not in the derived class)
@@ -536,10 +536,10 @@ void gem::supervisor::tbutils::GEMTBUtil::showCounterLayout(xgi::Output *out)
 
     }
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying showCounterLayout(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying showCounterLayout(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying showCounterLayout(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying showCounterLayout(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 } //end showCounterLayout
@@ -566,10 +566,10 @@ void gem::supervisor::tbutils::GEMTBUtil::showBufferLayout(xgi::Output *out)
 	   << cgicc::br()   << std::endl;
     }
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying showBufferLayout(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying showBufferLayout(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying showBufferLayout(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying showBufferLayout(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 } //end showBufferLayout
@@ -686,10 +686,10 @@ void gem::supervisor::tbutils::GEMTBUtil::fastCommandLayout(xgi::Output *out)
 	   << cgicc::form()  << std::endl;
     }
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying fastCommandLayout(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying fastCommandLayout(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying fastCommandLayout(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying fastCommandLayout(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -922,10 +922,10 @@ void gem::supervisor::tbutils::GEMTBUtil::webDefault(xgi::Input *in, xgi::Output
       .set("src","http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js")
 	 << cgicc::script() << std::endl;
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying GEMTBUtil control panel(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying GEMTBUtil control panel(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying GEMTBUtil control panel(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying GEMTBUtil control panel(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -937,20 +937,20 @@ void gem::supervisor::tbutils::GEMTBUtil::webInitialize(xgi::Input *in, xgi::Out
   try {
     cgicc::Cgicc cgi(in);
     std::vector<cgicc::FormEntry> vfat2FormEntries = cgi.getElements();
-    TRACE( "debugging form entries");
+    CMSGEMOS_TRACE( "debugging form entries");
     std::vector<cgicc::FormEntry>::const_iterator myiter = vfat2FormEntries.begin();
 
     //OH Devices
     cgicc::form_iterator oh = cgi.getElement("SetOH");
     if (strcmp((**oh).c_str(),"OH_0") == 0) {
       confParams_.bag.ohGTXLink.value_= 0;
-      INFO("OH_0 has been selected " << confParams_.bag.ohGTXLink);
+      CMSGEMOS_INFO("OH_0 has been selected " << confParams_.bag.ohGTXLink);
     } else if (strcmp((**oh).c_str(),"OH_1") == 0) {
       confParams_.bag.ohGTXLink.value_= 1;
-      INFO("OH_1 has been selected " << confParams_.bag.ohGTXLink);
+      CMSGEMOS_INFO("OH_1 has been selected " << confParams_.bag.ohGTXLink);
     } else if (strcmp((**oh).c_str(),"OH_2") == 0) {
       confParams_.bag.ohGTXLink.value_= 2;
-      INFO("OH_2 has been selected " << confParams_.bag.ohGTXLink);
+      CMSGEMOS_INFO("OH_2 has been selected " << confParams_.bag.ohGTXLink);
     }//if OH_1
 
     m_vfatMask = 0x0;
@@ -964,11 +964,11 @@ void gem::supervisor::tbutils::GEMTBUtil::webInitialize(xgi::Input *in, xgi::Out
       std::string tmpDeviceName = confParams_.bag.deviceName[i].toString();
       cgicc::const_form_iterator name = cgi.getElement(form.str());
       if (name != cgi.getElements().end()) {
-        DEBUG( "found form element::" << form.str());
-        DEBUG( "has value::" << name->getValue());
+        CMSGEMOS_DEBUG( "found form element::" << form.str());
+        CMSGEMOS_DEBUG( "has value::" << name->getValue());
 	tmpDeviceName = name->getValue();
 	confParams_.bag.deviceName[i] = tmpDeviceName;
-	DEBUG( "Web_deviceName::"             << confParams_.bag.deviceName[i].toString());
+        CMSGEMOS_DEBUG( "Web_deviceName::"             << confParams_.bag.deviceName[i].toString());
         m_vfatMask |= (0x1<<i);
       }
 
@@ -983,10 +983,10 @@ void gem::supervisor::tbutils::GEMTBUtil::webInitialize(xgi::Input *in, xgi::Out
     m_vfatMask = ~m_vfatMask;
     //change the status to initializing and make sure the page displays this information
   } catch (const xgi::exception::Exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 
@@ -1052,11 +1052,11 @@ void gem::supervisor::tbutils::GEMTBUtil::webResetCounters(xgi::Input *in, xgi::
   try {
     cgicc::Cgicc cgi(in);
     std::vector<cgicc::FormEntry> resetCounters = cgi.getElements();
-    DEBUG( "resetting counters entries");
+    CMSGEMOS_DEBUG( "resetting counters entries");
 
     hw_semaphore_.take();
 
-    DEBUG("GEMTBUtil::webResetCounters Reseting counters");
+    CMSGEMOS_DEBUG("GEMTBUtil::webResetCounters Reseting counters");
 
     if (cgi.queryCheckbox("RstL1ATTC") )
       optohybridDevice_->resetL1ACount(0x0);
@@ -1097,10 +1097,10 @@ void gem::supervisor::tbutils::GEMTBUtil::webResetCounters(xgi::Input *in, xgi::
     hw_semaphore_.give();
 
   } catch (const xgi::exception::Exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 
@@ -1115,12 +1115,12 @@ void gem::supervisor::tbutils::GEMTBUtil::webSendFastCommands(xgi::Input *in, xg
   try {
     cgicc::Cgicc cgi(in);
     std::vector<cgicc::FormEntry> resetCounters = cgi.getElements();
-    DEBUG( "resetting counters entries");
+    CMSGEMOS_DEBUG( "resetting counters entries");
 
     std::string fastCommand = cgi["SendFastCommand"]->getValue();
 
     if (strcmp(fastCommand.c_str(),"FlushFIFO") == 0) {
-      DEBUG("FlushFIFO button pressed");
+      CMSGEMOS_DEBUG("FlushFIFO button pressed");
       hw_semaphore_.take();
       for (int i = 0; i < 2; ++i){
 	glibDevice_->flushFIFO(i);
@@ -1129,7 +1129,7 @@ void gem::supervisor::tbutils::GEMTBUtil::webSendFastCommands(xgi::Input *in, xg
     }
 
     if (strcmp(fastCommand.c_str(),"SendTestPackets") == 0) {
-      DEBUG("SendTestPackets button pressed");
+      CMSGEMOS_DEBUG("SendTestPackets button pressed");
       hw_semaphore_.take();
       if (!is_running_) {
 	for (auto chip = vfatDevice_.begin(); chip != vfatDevice_.end(); ++chip){
@@ -1148,7 +1148,7 @@ void gem::supervisor::tbutils::GEMTBUtil::webSendFastCommands(xgi::Input *in, xg
     }
 
     else if (strcmp(fastCommand.c_str(),"Send L1A+CalPulse") == 0) {
-      DEBUG("Send L1A+CalPulse button pressed");
+      CMSGEMOS_DEBUG("Send L1A+CalPulse button pressed");
       cgicc::const_form_iterator element = cgi.getElement("CalPulseDelay");
       uint8_t delay = 4;
       if (element != cgi.getElements().end())
@@ -1161,35 +1161,35 @@ void gem::supervisor::tbutils::GEMTBUtil::webSendFastCommands(xgi::Input *in, xg
     }
 
     else if (strcmp(fastCommand.c_str(),"Send L1A") == 0) {
-      DEBUG("Send L1A button pressed");
+      CMSGEMOS_DEBUG("Send L1A button pressed");
       hw_semaphore_.take();
       optohybridDevice_->sendL1A(10,1);
       hw_semaphore_.give();
     }
 
     else if (strcmp(fastCommand.c_str(),"Send CalPulse") == 0) {
-      DEBUG("Send CalPulse button pressed");
+      CMSGEMOS_DEBUG("Send CalPulse button pressed");
       hw_semaphore_.take();
       optohybridDevice_->sendCalPulse(0x1,1);
       hw_semaphore_.give();
     }
 
     else if (strcmp(fastCommand.c_str(),"Send Resync") == 0) {
-      DEBUG("Send Resync button pressed");
+      CMSGEMOS_DEBUG("Send Resync button pressed");
       hw_semaphore_.take();
       optohybridDevice_->sendResync();
       hw_semaphore_.give();
     }
 
     else if (strcmp(fastCommand.c_str(),"Send BC0") == 0) {
-      DEBUG("Send BC0 button pressed");
+      CMSGEMOS_DEBUG("Send BC0 button pressed");
       hw_semaphore_.take();
       optohybridDevice_->sendBC0();
       hw_semaphore_.give();
     }
     /*
     else if (strcmp(fastCommand.c_str(),"SetTriggerSource") == 0) {
-      DEBUG("SetTriggerSource button pressed");
+      CMSGEMOS_DEBUG("SetTriggerSource button pressed");
       hw_semaphore_.take();
       cgicc::form_iterator fi = cgi.getElement("trgSrc");
       if( !fi->isEmpty() && fi != (*cgi).end()) {
@@ -1214,10 +1214,10 @@ void gem::supervisor::tbutils::GEMTBUtil::webSendFastCommands(xgi::Input *in, xg
     }*/
 
   } catch (const xgi::exception::Exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 
@@ -1263,12 +1263,12 @@ void gem::supervisor::tbutils::GEMTBUtil::initializeAction(toolbox::Event::Refer
   //optohybridDevice_ = optohybrid_shared_ptr(new gem::hw::optohybrid::HwOptoHybrid(ohDeviceName, "connections_ch.xml"));
 
   if (glibDevice_->isHwConnected()) {
-    INFO("GLIB device connected");
+    CMSGEMOS_INFO("GLIB device connected");
 
     glibDevice_->writeReg("GLIB.TTC.CONTROL.INHIBIT_L1A",0x1);
     disableTriggers();
     if (optohybridDevice_->isHwConnected()) {
-      DEBUG("OptoHybrid device connected");
+      CMSGEMOS_DEBUG("OptoHybrid device connected");
 
       optohybridDevice_->setVFATMask(m_vfatMask);
 
@@ -1297,11 +1297,11 @@ void gem::supervisor::tbutils::GEMTBUtil::initializeAction(toolbox::Event::Refer
 	  if (VfatName != "") {
 	    readout_mask = confParams_.bag.ohGTXLink;
 
-	    DEBUG(" webInitialize : DeviceName " << VfatName );
-	    DEBUG(" webInitialize : readout_mask 0x"  << std::hex << (int)readout_mask << std::dec );
+	    CMSGEMOS_DEBUG(" webInitialize : DeviceName " << VfatName );
+	    CMSGEMOS_DEBUG(" webInitialize : readout_mask 0x"  << std::hex << (int)readout_mask << std::dec );
 
 	    confParams_.bag.deviceChipID = tmpVFATDevice->getChipID();
-	    DEBUG(" CHIPID   :: " << confParams_.bag.deviceChipID);
+	    CMSGEMOS_DEBUG(" CHIPID   :: " << confParams_.bag.deviceChipID);
 	    // need to put all chips in sleep mode to start off
 	    vfatDevice_.push_back(tmpVFATDevice);
 	  }//end if VfatName
@@ -1310,17 +1310,17 @@ void gem::supervisor::tbutils::GEMTBUtil::initializeAction(toolbox::Event::Refer
 	for (auto chip = VFATdeviceConnected.begin(); chip != VFATdeviceConnected.end(); ++chip) {
 	  if ((*chip)->isHwConnected()) {
 	    (*chip)->setRunMode(0);
-	    DEBUG( "vfatDevice Conected::" << (*chip)->getSlot());
+	    CMSGEMOS_DEBUG( "vfatDevice Conected::" << (*chip)->getSlot());
 	  }
 	}// end for
 
 	for (auto chip = vfatDevice_.begin(); chip != vfatDevice_.end(); ++chip) {
-	  DEBUG( "vfatDevice selected::" << (*chip)->getSlot());
+	  CMSGEMOS_DEBUG( "vfatDevice selected::" << (*chip)->getSlot());
 	}
       }// end for
    }//end if OH connected
     else {
-      INFO("OptoHybrid device not connected, breaking out");
+      CMSGEMOS_INFO("OptoHybrid device not connected, breaking out");
       is_configured_  = false;
       is_working_     = false;
       hw_semaphore_.give();
@@ -1329,7 +1329,7 @@ void gem::supervisor::tbutils::GEMTBUtil::initializeAction(toolbox::Event::Refer
 
   }// end if glib connected
   else {
-    DEBUG("GLIB device not connected, breaking out");
+    CMSGEMOS_DEBUG("GLIB device not connected, breaking out");
     is_configured_  = false;
     is_working_     = false;
     hw_semaphore_.give();
@@ -1359,7 +1359,7 @@ void gem::supervisor::tbutils::GEMTBUtil::configureAction(toolbox::Event::Refere
        chip != confParams_.bag.deviceName.end(); ++chip, ++num) {
     ss << "Device name: " << chip->toString() << std::endl;
   }
-  DEBUG(ss.str());
+  CMSGEMOS_DEBUG(ss.str());
 
   hw_semaphore_.give();
 
@@ -1570,10 +1570,10 @@ void gem::supervisor::tbutils::GEMTBUtil::selectMultipleVFAT(xgi::Output *out)
     *out << cgicc::tr()    << std::endl;
     *out << cgicc::table() << std::endl;
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying VFATS(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying VFATS(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying VFATS(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying VFATS(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -1617,10 +1617,10 @@ void gem::supervisor::tbutils::GEMTBUtil::selectOptohybridDevice(xgi::Output *ou
 	    << "<td class=\"form\">"*/
 
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong setting the trigger source): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong setting the trigger source): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong setting the trigger source): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong setting the trigger source): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }// end void selectoptohybrid
@@ -1628,7 +1628,7 @@ void gem::supervisor::tbutils::GEMTBUtil::selectOptohybridDevice(xgi::Output *ou
 void gem::supervisor::tbutils::GEMTBUtil::NTriggersAMC13()
   throw (xgi::exception::Exception)
 {
-  DEBUG("-----------start SOAP message modify paramteres AMC13------ ");
+  CMSGEMOS_DEBUG("-----------start SOAP message modify paramteres AMC13------ ");
 
   xdaq::ApplicationDescriptor *d = getApplicationContext()->getDefaultZone()->getApplicationDescriptor("gem::hw::amc13::AMC13Manager", 0);  // this should not be hard coded
   xdaq::ApplicationDescriptor *o = this->getApplicationDescriptor();
@@ -1659,28 +1659,28 @@ void gem::supervisor::tbutils::GEMTBUtil::NTriggersAMC13()
 
   std::string tool;
   xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
-  DEBUG("msg: " << tool);
+  CMSGEMOS_DEBUG("msg: " << tool);
 
   try {
-    DEBUG("trying to send parameters");
+    CMSGEMOS_DEBUG("trying to send parameters");
     xoap::MessageReference reply = getApplicationContext()->postSOAP(msg, *o,  *d);
     std::string tool;
     xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
-    DEBUG("reply: " << tool);
+    CMSGEMOS_DEBUG("reply: " << tool);
   } catch (xoap::exception::Exception& e) {
-    ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
     XCEPT_RETHROW (xoap::exception::Exception, "Cannot send message", e);
   } catch (xdaq::exception::Exception& e) {
-    ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
     XCEPT_RETHROW (xoap::exception::Exception, "Cannot send message", e);
   } catch (std::exception& e) {
-    ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
     //XCEPT_RETHROW (xoap::exception::Exception, "Cannot send message", e);
   } catch (...) {
-    ERROR("------------------Fail  AMC13 configuring parameters message ");
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message ");
     XCEPT_RAISE (xoap::exception::Exception, "Cannot send message");
   }
-  DEBUG("-----------The message to AMC13 configuring parameters has been sent------------");
+  CMSGEMOS_DEBUG("-----------The message to AMC13 configuring parameters has been sent------------");
 }
 
 void gem::supervisor::tbutils::GEMTBUtil::enableTriggers()
@@ -1713,7 +1713,7 @@ void gem::supervisor::tbutils::GEMTBUtil::sendTriggers()
 void gem::supervisor::tbutils::GEMTBUtil::AMC13TriggerSetup()
   throw (xgi::exception::Exception)
 {
-  DEBUG("-----------start SOAP message modify paramteres AMC13------ ");
+  CMSGEMOS_DEBUG("-----------start SOAP message modify paramteres AMC13------ ");
 
   xdaq::ApplicationDescriptor *d = getApplicationContext()->getDefaultZone()->getApplicationDescriptor("gem::hw::amc13::AMC13Manager", 0);  // this should not be hard coded
   xdaq::ApplicationDescriptor *o = this->getApplicationDescriptor();
@@ -1818,26 +1818,26 @@ void gem::supervisor::tbutils::GEMTBUtil::AMC13TriggerSetup()
 
   std::string tool;
   xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
-  DEBUG("msg: " << tool);
+  CMSGEMOS_DEBUG("msg: " << tool);
 
   try {
-    DEBUG("trying to send parameters");
+    CMSGEMOS_DEBUG("trying to send parameters");
     xoap::MessageReference reply = getApplicationContext()->postSOAP(msg, *o,  *d);
     std::string tool;
     xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
-    DEBUG("reply: " << tool);
+    CMSGEMOS_DEBUG("reply: " << tool);
   } catch (xoap::exception::Exception& e) {
-    ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
     XCEPT_RETHROW (xoap::exception::Exception, "Cannot send message", e);
   } catch (xdaq::exception::Exception& e) {
-    ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
     XCEPT_RETHROW (xoap::exception::Exception, "Cannot send message", e);
   } catch (std::exception& e) {
-    ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message " << e.what());
     //XCEPT_RETHROW (xoap::exception::Exception, "Cannot send message", e);
   } catch (...) {
-    ERROR("------------------Fail  AMC13 configuring parameters message ");
+    CMSGEMOS_ERROR("------------------Fail  AMC13 configuring parameters message ");
     XCEPT_RAISE (xoap::exception::Exception, "Cannot send message");
   }
-  DEBUG("-----------The message to AMC13 configuring parameters has been sent------------");
+  CMSGEMOS_DEBUG("-----------The message to AMC13 configuring parameters has been sent------------");
 }

--- a/gemsupervisor/src/common/tbutils/LatencyScan.cc
+++ b/gemsupervisor/src/common/tbutils/LatencyScan.cc
@@ -126,7 +126,7 @@ bool gem::supervisor::tbutils::LatencyScan::run(toolbox::task::WorkLoop* wl)
     hw_semaphore_.take();
     //bufferDepth = glibDevice_->getFIFOVFATBlockOccupancy(readout_mask);
     hw_semaphore_.give();
-    TRACE(" ******IT IS NOT RUNNIG ***** ");
+    CMSGEMOS_TRACE(" ******IT IS NOT RUNNIG ***** ");
     wl_semaphore_.give(); // give work loop if it is not running
     return false;
   }
@@ -144,7 +144,7 @@ bool gem::supervisor::tbutils::LatencyScan::run(toolbox::task::WorkLoop* wl)
   confParams_.bag.triggersSeen =  optohybridDevice_->getL1ACount(0x0);
   CalPulseCount_[0] = optohybridDevice_->getCalPulseCount(0x0);
 
-  TRACE("ABC TriggersSeen " << confParams_.bag.triggersSeen << " Calpulse " << optohybridDevice_->getCalPulseCount(0x0));
+  CMSGEMOS_TRACE("ABC TriggersSeen " << confParams_.bag.triggersSeen << " Calpulse " << optohybridDevice_->getCalPulseCount(0x0));
 
   hw_semaphore_.give();//give hw to set the trigger source, send L1A+Cal pulses,
 
@@ -163,7 +163,7 @@ bool gem::supervisor::tbutils::LatencyScan::run(toolbox::task::WorkLoop* wl)
     glibDevice_->writeReg("GLIB.TTC.CONTROL.INHIBIT_L1A",0x1);
 
     confParams_.bag.triggersSeen = optohybridDevice_->getL1ACount(0x0);
-    TRACE("ABC Scan point TriggersSeen "
+    CMSGEMOS_TRACE("ABC Scan point TriggersSeen "
          << confParams_.bag.triggersSeen << " Calpulse " << optohybridDevice_->getCalPulseCount(0x0));
 
     hw_semaphore_.take(); //take hw to set Runmode 0 on VFATs
@@ -180,7 +180,7 @@ bool gem::supervisor::tbutils::LatencyScan::run(toolbox::task::WorkLoop* wl)
     /*    int counter = 3;
     while (counter > 0) {
       confParams_.bag.triggersSeen = optohybridDevice_->getL1ACount(0x0);
-      TRACE(" ABC Scan point TriggersSeen "
+      CMSGEMOS_TRACE(" ABC Scan point TriggersSeen "
            << confParams_.bag.triggersSeen
            << " Calpulse " << optohybridDevice_->getCalPulseCount(0x0)
            << " counter = " << counter);
@@ -191,8 +191,8 @@ bool gem::supervisor::tbutils::LatencyScan::run(toolbox::task::WorkLoop* wl)
       while ((glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
 				   toolbox::toString("DAQ.GTX%d.STATUS.EVENT_FIFO_IS_EMPTY",
 						     confParams_.bag.ohGTXLink.value_))))
-	TRACE("waiting for FIFO is empty: "
-	      << glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
+        CMSGEMOS_TRACE("waiting for FIFO is empty: "
+              << glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
                                       toolbox::toString("DAQ.GTX%d.STATUS.EVENT_FIFO_IS_EMPTY",
                                                         confParams_.bag.ohGTXLink.value_));
 	      sleep(0.005);
@@ -214,7 +214,7 @@ bool gem::supervisor::tbutils::LatencyScan::run(toolbox::task::WorkLoop* wl)
 
       hw_semaphore_.take();// vfat set latency
 
-      TRACE("ABC run: Latency= "
+      CMSGEMOS_TRACE("ABC run: Latency= "
            << (int)currentLatency_ << " VT1= "
            << scanParams_.bag.deviceVT1 << " VT2= "
            << scanParams_.bag.deviceVT2
@@ -240,8 +240,8 @@ bool gem::supervisor::tbutils::LatencyScan::run(toolbox::task::WorkLoop* wl)
       while ((glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
                                     toolbox::toString("DAQ.GTX%d.STATUS.EVENT_FIFO_IS_EMPTY",
                                                       confParams_.bag.ohGTXLink.value_))))
-	TRACE("waiting for FIFO is empty: "
-	      << glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
+        CMSGEMOS_TRACE("waiting for FIFO is empty: "
+              << glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
                                       toolbox::toString("DAQ.GTX%d.STATUS.EVENT_FIFO_IS_EMPTY",
                                                         confParams_.bag.ohGTXLink.value_))
 	      );
@@ -356,10 +356,10 @@ void gem::supervisor::tbutils::LatencyScan::scanParameters(xgi::Output *out)
 	 << cgicc::br()
 	 << cgicc::span() << std::endl; //end span
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying VFATS(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying VFATS(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying VFATS(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying VFATS(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -593,10 +593,10 @@ void gem::supervisor::tbutils::LatencyScan::webDefault(xgi::Input *in, xgi::Outp
 	 << cgicc::script() << std::endl;
 
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying LatencyScan control panel(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying LatencyScan control panel(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying LatencyScan control panel(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying LatencyScan control panel(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -645,10 +645,10 @@ void gem::supervisor::tbutils::LatencyScan::webConfigure(xgi::Input *in, xgi::Ou
 
 
   } catch (const xgi::exception::Exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception & e) {
-    ERROR("Something went wrong: " << e.what());
+    CMSGEMOS_ERROR("Something went wrong: " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 
@@ -695,7 +695,7 @@ void gem::supervisor::tbutils::LatencyScan::configureAction(toolbox::Event::Refe
   confParams_.bag.triggercount = 0;
 
   hw_semaphore_.take();
-  DEBUG( "attempting to configure device");
+  CMSGEMOS_DEBUG( "attempting to configure device");
 
   //make sure device is not running
   for (auto chip = vfatDevice_.begin(); chip != vfatDevice_.end(); ++chip) {
@@ -704,7 +704,7 @@ void gem::supervisor::tbutils::LatencyScan::configureAction(toolbox::Event::Refe
     (*chip)->setDeviceIPAddress(confParams_.bag.deviceIP);
     (*chip)->setRunMode(0);
 
-    TRACE("loading default settings");
+    CMSGEMOS_TRACE("loading default settings");
     //default settings for the frontend
     (*chip)->setTriggerMode(    0x3); //set to S1 to S8
     (*chip)->setCalibrationMode(0x0); //set to normal
@@ -739,26 +739,26 @@ void gem::supervisor::tbutils::LatencyScan::configureAction(toolbox::Event::Refe
     (*chip)->setVThreshold1(scanParams_.bag.deviceVT1);
     (*chip)->setVThreshold2(scanParams_.bag.deviceVT2);
 
-    TRACE( "setting DAC mode to normal");
+    CMSGEMOS_TRACE( "setting DAC mode to normal");
     (*chip)->setDACMode(gem::hw::vfat::StringToDACMode.at("OFF"));
 
-    TRACE( "setting starting latency value");
+    CMSGEMOS_TRACE( "setting starting latency value");
     (*chip)->setLatency(    scanParams_.bag.minLatency);
 
-    TRACE( "reading back current latency value");
+    CMSGEMOS_TRACE( "reading back current latency value");
     currentLatency_ = (*chip)->getLatency();
 
-    TRACE( "Threshold " << scanParams_.bag.deviceVT1);
+    CMSGEMOS_TRACE( "Threshold " << scanParams_.bag.deviceVT1);
 
-    TRACE( "VCal " << scanParams_.bag.VCal);
+    CMSGEMOS_TRACE( "VCal " << scanParams_.bag.VCal);
 
-    TRACE( "device configured");
+    CMSGEMOS_TRACE( "device configured");
     is_configured_ = true;
   }
 
   //flush fifo
-  TRACE("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
-  TRACE("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
+  CMSGEMOS_TRACE("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_TRACE("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
   glibDevice_->flushFIFO(readout_mask);
   while (glibDevice_->hasTrackingData(readout_mask)) {
     glibDevice_->flushFIFO(readout_mask);
@@ -781,7 +781,7 @@ void gem::supervisor::tbutils::LatencyScan::configureAction(toolbox::Event::Refe
 
   hw_semaphore_.give();
 
-  DEBUG( "configure routine completed");
+  CMSGEMOS_DEBUG( "configure routine completed");
 
   is_working_    = false;
 }
@@ -825,8 +825,8 @@ void gem::supervisor::tbutils::LatencyScan::startAction(toolbox::Event::Referenc
   hw_semaphore_.take();//oh reset counters
 
   //flush fifo
-  TRACE("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
-  TRACE("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
+  CMSGEMOS_TRACE("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_TRACE("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
   glibDevice_->flushFIFO(readout_mask);
   while (glibDevice_->hasTrackingData(readout_mask)) {
     glibDevice_->flushFIFO(readout_mask);

--- a/gemsupervisor/src/common/tbutils/ThresholdScan.cc
+++ b/gemsupervisor/src/common/tbutils/ThresholdScan.cc
@@ -97,14 +97,14 @@ bool gem::supervisor::tbutils::ThresholdScan::run(toolbox::task::WorkLoop* wl)
     wl_semaphore_.give(); // give work loop if it is not running
     //uint32_t bufferDepth = 0;
     //bufferDepth = glibDevice_->getFIFOVFATBlockOccupancy(readout_mask);
-    TRACE(" ******IT IS NOT RUNNIG ***** ");
+    CMSGEMOS_TRACE(" ******IT IS NOT RUNNIG ***** ");
     return false;
   }
 
   //send triggers
   hw_semaphore_.take(); //take hw to send the trigger
 
-  TRACE("scan point " << scanpoint_ );
+  CMSGEMOS_TRACE("scan point " << scanpoint_ );
 
   optohybridDevice_->setTrigSource(0x0);// trigger sources
 
@@ -114,7 +114,7 @@ bool gem::supervisor::tbutils::ThresholdScan::run(toolbox::task::WorkLoop* wl)
   }
   //count triggers
   confParams_.bag.triggersSeen = optohybridDevice_->getL1ACount(0x0);
-  TRACE("ABC TriggersSeen " << confParams_.bag.triggersSeen);
+  CMSGEMOS_TRACE("ABC TriggersSeen " << confParams_.bag.triggersSeen);
 
   confParams_.bag.triggersSeen = optohybridDevice_->getL1ACount(0x0);
 
@@ -135,7 +135,7 @@ bool gem::supervisor::tbutils::ThresholdScan::run(toolbox::task::WorkLoop* wl)
     glibDevice_->writeReg("GLIB.TTC.CONTROL.INHIBIT_L1A",0x1);
 
     confParams_.bag.triggersSeen = optohybridDevice_->getL1ACount(0x0);
-    TRACE("ABC Scan point TriggersSeen "
+    CMSGEMOS_TRACE("ABC Scan point TriggersSeen "
           << confParams_.bag.triggersSeen );
 
     hw_semaphore_.take(); //take hw to set Runmode 0 on VFATs
@@ -150,7 +150,7 @@ bool gem::supervisor::tbutils::ThresholdScan::run(toolbox::task::WorkLoop* wl)
     hw_semaphore_.give();  // give hw to reset counters
 
     confParams_.bag.triggersSeen = optohybridDevice_->getL1ACount(0x0);
-    TRACE("ABC Scan point TriggersSeen "
+    CMSGEMOS_TRACE("ABC Scan point TriggersSeen "
           << confParams_.bag.triggersSeen );
 
     if ( (unsigned)scanParams_.bag.deviceVT1 == (unsigned)0x0 ) {
@@ -164,7 +164,7 @@ bool gem::supervisor::tbutils::ThresholdScan::run(toolbox::task::WorkLoop* wl)
 
       hw_semaphore_.take(); // take hw to set threshold values
 
-      TRACE("ABC run: Latency= "
+      CMSGEMOS_TRACE("ABC run: Latency= "
             << scanParams_.bag.latency << " VT1= "
             << scanParams_.bag.deviceVT1 << " VT2= "
             << scanParams_.bag.deviceVT2 <<
@@ -199,8 +199,8 @@ bool gem::supervisor::tbutils::ThresholdScan::run(toolbox::task::WorkLoop* wl)
       while ((glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
                                     toolbox::toString("DAQ.GTX%d.STATUS.EVENT_FIFO_IS_EMPTY",
                                                       confParams_.bag.ohGTXLink.value_))))
-	TRACE("waiting for FIFO is empty: "
-	      << glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
+        CMSGEMOS_TRACE("waiting for FIFO is empty: "
+              << glibDevice_->readReg(glibDevice_->getDeviceBaseNode(),
                                       toolbox::toString("DAQ.GTX%d.STATUS.EVENT_FIFO_IS_EMPTY",
                                                         confParams_.bag.ohGTXLink.value_))
 	      );
@@ -304,10 +304,10 @@ void gem::supervisor::tbutils::ThresholdScan::scanParameters(xgi::Output *out)
 	 << cgicc::br() << std::endl
 	 << cgicc::span()   << std::endl;
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying VFATS(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying VFATS(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying VFATS(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying VFATS(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -541,10 +541,10 @@ void gem::supervisor::tbutils::ThresholdScan::webDefault(xgi::Input *in, xgi::Ou
 	 << cgicc::script() << std::endl;
 
   } catch (const xgi::exception::Exception& e) {
-    ERROR("Something went wrong displaying ThresholdScan control panel(xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying ThresholdScan control panel(xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception& e) {
-    ERROR("Something went wrong displaying ThresholdScan control panel(std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong displaying ThresholdScan control panel(std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 }
@@ -582,10 +582,10 @@ void gem::supervisor::tbutils::ThresholdScan::webConfigure(xgi::Input *in, xgi::
     if (element != cgi.getElements().end())
       confParams_.bag.nTriggers  = element->getIntegerValue();
   } catch (const xgi::exception::Exception & e) {
-    ERROR("Something went wrong (xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong (xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception & e) {
-    ERROR("Something went wrong (std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong (std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 
@@ -621,10 +621,10 @@ void gem::supervisor::tbutils::ThresholdScan::webStart(xgi::Input *in, xgi::Outp
     if (element != cgi.getElements().end())
       confParams_.bag.nTriggers  = element->getIntegerValue();
   } catch (const xgi::exception::Exception & e) {
-    ERROR("Something went wrong (xgi): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong (xgi): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   } catch (const std::exception & e) {
-    ERROR("Something went wrong (std): " << e.what());
+    CMSGEMOS_ERROR("Something went wrong (std): " << e.what());
     XCEPT_RAISE(xgi::exception::Exception, e.what());
   }
 
@@ -669,7 +669,7 @@ void gem::supervisor::tbutils::ThresholdScan::configureAction(toolbox::Event::Re
     (*chip)->setRunMode(0);
 
 
-    DEBUG("loading default settings");
+    CMSGEMOS_DEBUG("loading default settings");
     //default settings for the frontend
     (*chip)->setTriggerMode(    0x3); //set to S1 to S8
     (*chip)->setCalibrationMode(0x0); //set to normal
@@ -708,8 +708,8 @@ void gem::supervisor::tbutils::ThresholdScan::configureAction(toolbox::Event::Re
   }
 
   // flush FIFO, how to disable a specific, misbehaving, chip
-  DEBUG("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
-  DEBUG("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
+  CMSGEMOS_DEBUG("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_DEBUG("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
   glibDevice_->flushFIFO(readout_mask);
   while (glibDevice_->hasTrackingData(readout_mask)) {
     glibDevice_->flushFIFO(readout_mask);
@@ -779,8 +779,8 @@ void gem::supervisor::tbutils::ThresholdScan::startAction(toolbox::Event::Refere
   //start readout
 
   //flush fifo
-  DEBUG("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
-  DEBUG("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
+  CMSGEMOS_DEBUG("Flushing the FIFOs, readout_mask 0x" <<std::hex << (int)readout_mask << std::dec);
+  CMSGEMOS_DEBUG("Flushing FIFO" << readout_mask << " (depth " << glibDevice_->getFIFOOccupancy(readout_mask));
   glibDevice_->flushFIFO(readout_mask);
   while (glibDevice_->hasTrackingData(readout_mask)) {
     glibDevice_->flushFIFO(readout_mask);

--- a/gemutils/include/gem/utils/GEMLogging.h
+++ b/gemutils/include/gem/utils/GEMLogging.h
@@ -8,12 +8,12 @@
 #include "log4cplus/loggingmacros.h"
 
 namespace gem {
-#define TRACE(MSG) LOG4CPLUS_TRACE(m_gemLogger, MSG)
-#define DEBUG(MSG) LOG4CPLUS_DEBUG(m_gemLogger, MSG)
-#define INFO( MSG) LOG4CPLUS_INFO( m_gemLogger, MSG)
-#define WARN( MSG) LOG4CPLUS_WARN( m_gemLogger, MSG)
-#define ERROR(MSG) LOG4CPLUS_ERROR(m_gemLogger, MSG)
-#define FATAL(MSG) LOG4CPLUS_FATAL(m_gemLogger, MSG)
+#define CMSGEMOS_TRACE(MSG) LOG4CPLUS_TRACE(m_gemLogger, MSG)
+#define CMSGEMOS_DEBUG(MSG) LOG4CPLUS_DEBUG(m_gemLogger, MSG)
+#define CMSGEMOS_INFO( MSG) LOG4CPLUS_INFO( m_gemLogger, MSG)
+#define CMSGEMOS_WARN( MSG) LOG4CPLUS_WARN( m_gemLogger, MSG)
+#define CMSGEMOS_ERROR(MSG) LOG4CPLUS_ERROR(m_gemLogger, MSG)
+#define CMSGEMOS_FATAL(MSG) LOG4CPLUS_FATAL(m_gemLogger, MSG)
 
 #define TRACE_LOGGER(LOGGER, MSG) LOG4CPLUS_TRACE(LOGGER, MSG)
 #define DEBUG_LOGGER(LOGGER, MSG) LOG4CPLUS_DEBUG(LOGGER, MSG)

--- a/gemutils/include/gem/utils/soap/GEMSOAPToolBox.h
+++ b/gemutils/include/gem/utils/soap/GEMSOAPToolBox.h
@@ -194,7 +194,7 @@ namespace gem {
             }
             std::string tool;
             xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
-            DEBUG("GEMSOAPToolBox::sendApplicationParameterBag: " << tool);
+            CMSGEMOS_DEBUG("GEMSOAPToolBox::sendApplicationParameterBag: " << tool);
             answer = appCxt->postSOAP(msg, *srcDsc, *destDsc);
           } catch (gem::utils::exception::Exception& e) {
             std::string errMsg = toolbox::toString("Send application parameter bag %s failed [%s] (gem::utils::exception::Exception)",

--- a/gemutils/src/common/db/GEMDatabaseUtils.cc
+++ b/gemutils/src/common/db/GEMDatabaseUtils.cc
@@ -60,7 +60,7 @@ bool gem::utils::db::GEMDatabaseUtils::connect(std::string const& database)
     message += "' : ";
     message += mysql_error(p_db);
     p_db = 0;
-    ERROR(message);
+    CMSGEMOS_ERROR(message);
     XCEPT_RAISE(gem::utils::exception::DBConnectionError,message);
     // return false;
   }
@@ -79,9 +79,9 @@ void gem::utils::db::GEMDatabaseUtils::command(const std::string& command)
 {
   int rv = mysql_query(p_db,command.c_str());
   if (rv)
-    ERROR("MySQL comand error: " << std::string(mysql_error(p_db)));
+    CMSGEMOS_ERROR("MySQL comand error: " << std::string(mysql_error(p_db)));
   else
-    INFO("MySQL command success: " << command);
+    CMSGEMOS_INFO("MySQL command success: " << command);
   MYSQL_RES* res = mysql_use_result(p_db);
   mysql_free_result(res);
 }
@@ -90,14 +90,14 @@ unsigned int gem::utils::db::GEMDatabaseUtils::query(const std::string& query)
 {
   int rv = mysql_query(p_db,query.c_str());
   if (rv)
-    ERROR("MySQL query error: " << std::string(mysql_error(p_db)));
+    CMSGEMOS_ERROR("MySQL query error: " << std::string(mysql_error(p_db)));
   else
-    INFO("MySQL query success: " << query);
+    CMSGEMOS_INFO("MySQL query success: " << query);
   MYSQL_RES* res = mysql_use_result(p_db);
   MYSQL_ROW  row = mysql_fetch_row(res);
   if (row == 0) {
     std::string errMsg = "Query result " + query + " empty";
-    ERROR("GEMDatabaseUtils::query " << errMsg);
+    CMSGEMOS_ERROR("GEMDatabaseUtils::query " << errMsg);
     XCEPT_RAISE(gem::utils::exception::DBEmptyQueryResult, errMsg);
   }
 
@@ -123,12 +123,12 @@ void gem::utils::db::GEMDatabaseUtils::configure(const std::string& station,
 
   int retval = PyRun_SimpleString(cmd.str().c_str());
 
-  INFO("GEMDatabaseUtils::configure_db had return value " << retval);
+  CMSGEMOS_INFO("GEMDatabaseUtils::configure_db had return value " << retval);
 
   if (retval) {
     std::string errMsg = "configure_db call failed";
     PyErr_Print();
-    ERROR("GEMDatabaseUtils::configure " << errMsg);
+    CMSGEMOS_ERROR("GEMDatabaseUtils::configure " << errMsg);
     XCEPT_RAISE(gem::utils::exception::DBPythonError, errMsg);
   }
 

--- a/gemutils/src/common/gemXMLparser.cc
+++ b/gemutils/src/common/gemXMLparser.cc
@@ -22,15 +22,15 @@ gem::utils::gemXMLparser::~gemXMLparser()
 
 void gem::utils::gemXMLparser::parseXMLFile()
 {
-  INFO("Parsing XML file: " << m_xmlFile);
+  CMSGEMOS_INFO("Parsing XML file: " << m_xmlFile);
 
   //
   /// Initialize XML4C system
   try {
     xercesc::XMLPlatformUtils::Initialize();
-    INFO("Successfully initialized XML4C system");
+    CMSGEMOS_INFO("Successfully initialized XML4C system");
   } catch(const xercesc::XMLException& toCatch) {
-    ERROR("Error during Xerces-c Initialization." << std::endl
+    CMSGEMOS_ERROR("Error during Xerces-c Initialization." << std::endl
           << "  Exception message:"
           << xercesc::XMLString::transcode(toCatch.getMessage()));
     return;
@@ -41,7 +41,7 @@ void gem::utils::gemXMLparser::parseXMLFile()
   //  discovers errors during the course of parsing the XML document.
   //
   xercesc::XercesDOMParser* parser = new xercesc::XercesDOMParser;
-  DEBUG("Xerces parser created ");
+  CMSGEMOS_DEBUG("Xerces parser created ");
   parser->setValidationScheme(xercesc::XercesDOMParser::Val_Auto);
   parser->setDoNamespaces(false);
   parser->setCreateEntityReferenceNodes(false);
@@ -49,7 +49,7 @@ void gem::utils::gemXMLparser::parseXMLFile()
   // parser->setExpandEntityReferences(true);
   parser->setDoXInclude(true);
   // parser->setToCreateXMLDeclTypeNode(true);
-  DEBUG("Xerces parser tuned up ");
+  CMSGEMOS_DEBUG("Xerces parser tuned up ");
 
   //  Parse the XML file, catching any XML exceptions that might propogate
   //  out of it.
@@ -58,19 +58,19 @@ void gem::utils::gemXMLparser::parseXMLFile()
   try {
     parser->parse(m_xmlFile.c_str());
   } catch (const xercesc::XMLException& e) {
-    ERROR("An error occured during parsing" << std::endl
+    CMSGEMOS_ERROR("An error occured during parsing" << std::endl
           << "   Message: "
           << xercesc::XMLString::transcode(e.getMessage()));
     errorsOccured = true;
     // fileError = "An error occured during parsing of selected file. Please select another configuration file.";
   } catch (const xercesc::DOMException& e) {
-    ERROR("An error occured during parsing" << std::endl
+    CMSGEMOS_ERROR("An error occured during parsing" << std::endl
           << "   Message: "
           << xercesc::XMLString::transcode(e.msg));
     errorsOccured = true;
     // fileError = "An error occured during parsing of selected file. Please select another configuration file.";
   } catch (...) {
-    ERROR("An error occured during parsing");
+    CMSGEMOS_ERROR("An error occured during parsing");
     errorsOccured = true;
     // fileError = "An error occured during parsing of selected file. Please select another configuration file.";
   }
@@ -80,18 +80,18 @@ void gem::utils::gemXMLparser::parseXMLFile()
   // crateNodes.clear();
 
   if (!errorsOccured) {
-    DEBUG("DOM tree created succesfully");
+    CMSGEMOS_DEBUG("DOM tree created succesfully");
     this->outputXML(parser->getDocument(), "test.xml");
     xercesc::DOMNode* pDoc = parser->getDocument();
-    DEBUG("Base node (getDocument) obtained");
+    CMSGEMOS_DEBUG("Base node (getDocument) obtained");
     xercesc::DOMNode* n = pDoc->getFirstChild();
-    DEBUG("First child node obtained");
+    CMSGEMOS_DEBUG("First child node obtained");
     while (n) {
-      DEBUG("Loop on child nodes");
+      CMSGEMOS_DEBUG("Loop on child nodes");
       if (n->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) {
-        DEBUG("Element node found");
+        CMSGEMOS_DEBUG("Element node found");
         if (strcmp("GEMSystem", xercesc::XMLString::transcode(n->getNodeName())) == 0) {
-          DEBUG("GEM system found");
+          CMSGEMOS_DEBUG("GEM system found");
           parseGEMSystem(n);
         }
       }
@@ -99,30 +99,30 @@ void gem::utils::gemXMLparser::parseXMLFile()
     }
   }
 
-  DEBUG("Parser pointer " << parser);
+  CMSGEMOS_DEBUG("Parser pointer " << parser);
   delete parser;
-  DEBUG("Xerces parser deleted ");
+  CMSGEMOS_DEBUG("Xerces parser deleted ");
   xercesc::XMLPlatformUtils::Terminate();
 }
 
 void gem::utils::gemXMLparser::parseGEMSystem(xercesc::DOMNode* pNode)
 {
-  INFO("parseGEMSystem");
-  DEBUG("GEM system parsing");
+  CMSGEMOS_INFO("parseGEMSystem");
+  CMSGEMOS_DEBUG("GEM system parsing");
   xercesc::DOMNode* n = pNode->getFirstChild();
-  DEBUG("GEM system parsing: get first child");
+  CMSGEMOS_DEBUG("GEM system parsing: get first child");
   while (n) {
     if (n->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) {
       if (strcmp("uTCACrate", xercesc::XMLString::transcode(n->getNodeName())) == 0) {
-        DEBUG("GEM system parsing: uTCA crate found");
+        CMSGEMOS_DEBUG("GEM system parsing: uTCA crate found");
         if (countChildElementNodes(n)) {
-          DEBUG("GEM system parsing: uTCA crate is not empty");
+          CMSGEMOS_DEBUG("GEM system parsing: uTCA crate is not empty");
           gemCrateProperties* crate = new gemCrateProperties();
-          DEBUG("GEM system parsing: new crate properties object created");
+          CMSGEMOS_DEBUG("GEM system parsing: new crate properties object created");
           crate->setDeviceId(xercesc::XMLString::transcode(n->getAttributes()->getNamedItem(xercesc::XMLString::transcode("CrateId"))->getNodeValue()));
           p_gemSystem->addSubDeviceRef(crate);
           p_gemSystem->addSubDeviceId(crate->getDeviceId());
-          DEBUG("GEM system parsing: new crate properties object added to crateRefs");
+          CMSGEMOS_DEBUG("GEM system parsing: new crate properties object added to crateRefs");
           parseCrate(n);
         }
       }
@@ -133,29 +133,29 @@ void gem::utils::gemXMLparser::parseGEMSystem(xercesc::DOMNode* pNode)
 
 void gem::utils::gemXMLparser::parseCrate(xercesc::DOMNode* pNode)
 {
-  INFO("parseCrate");
-  DEBUG("GEM system parsing: starting parseCrate");
+  CMSGEMOS_INFO("parseCrate");
+  CMSGEMOS_DEBUG("GEM system parsing: starting parseCrate");
   xercesc::DOMNode* n = pNode->getFirstChild();
-  DEBUG("crate parsing: look for children");
+  CMSGEMOS_DEBUG("crate parsing: look for children");
   while (n) {
     if (n->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) {
       if (strcmp("MCH", xercesc::XMLString::transcode(n->getNodeName())) == 0) {
-        INFO("parseMCH");
+        CMSGEMOS_INFO("parseMCH");
       }
       if (strcmp("AMC", xercesc::XMLString::transcode(n->getNodeName())) == 0) {
-        INFO("parseAMC");
+        CMSGEMOS_INFO("parseAMC");
       }
       if (strcmp("GLIB", xercesc::XMLString::transcode(n->getNodeName())) == 0) {
-        INFO("parseGLIB");
-        DEBUG("crate parsing: GLIB found");
+        CMSGEMOS_INFO("parseGLIB");
+        CMSGEMOS_DEBUG("crate parsing: GLIB found");
         if (countChildElementNodes(n)) {
-          DEBUG("crate parsing: GLIB is not empty");
+          CMSGEMOS_DEBUG("crate parsing: GLIB is not empty");
           gemGLIBProperties* glib = new gemGLIBProperties();
-          DEBUG("crate parsing: create new GLIBproperties object");
+          CMSGEMOS_DEBUG("crate parsing: create new GLIBproperties object");
           glib->setDeviceId(xercesc::XMLString::transcode(n->getAttributes()->getNamedItem(xercesc::XMLString::transcode("GLIBId"))->getNodeValue()));
           p_gemSystem->getSubDevicesRefs().back()->addSubDeviceRef(glib);
           p_gemSystem->getSubDevicesRefs().back()->addSubDeviceId(glib->getDeviceId());
-          DEBUG("crate parsing: Add new GLIBproperties to the subdevices of parent crate");
+          CMSGEMOS_DEBUG("crate parsing: Add new GLIBproperties to the subdevices of parent crate");
           parseGLIB(n);
         }
       }
@@ -167,10 +167,10 @@ void gem::utils::gemXMLparser::parseCrate(xercesc::DOMNode* pNode)
 
 void gem::utils::gemXMLparser::parseGLIB(xercesc::DOMNode* pNode)
 {
-  DEBUG("crate parsing: start GLIB parsing");
+  CMSGEMOS_DEBUG("crate parsing: start GLIB parsing");
   xercesc::DOMNode* n = pNode->getFirstChild();
   gemGLIBProperties* glib_ = p_gemSystem->getSubDevicesRefs().back()->getSubDevicesRefs().back();
-  DEBUG("GLIB parsing: retrieve GLIB device from the devices parent tree");
+  CMSGEMOS_DEBUG("GLIB parsing: retrieve GLIB device from the devices parent tree");
   while (n) {
     if (n->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) {
       addProperty("Station",   n, glib_);
@@ -179,14 +179,14 @@ void gem::utils::gemXMLparser::parseGLIB(xercesc::DOMNode* pNode)
       addProperty("DEPTH",     n, glib_);
       addProperty("TDC_SBits", n, glib_);
       if (strcmp("OH", xercesc::XMLString::transcode(n->getNodeName())) == 0) {
-        DEBUG("GLIB parsing: OH found");
+        CMSGEMOS_DEBUG("GLIB parsing: OH found");
         if (countChildElementNodes(n)) {
           gemOHProperties* oh = new gemOHProperties();
-          DEBUG("GLIB parsing: create new OHproperties obect");
+          CMSGEMOS_DEBUG("GLIB parsing: create new OHproperties obect");
           oh->setDeviceId(xercesc::XMLString::transcode(n->getAttributes()->getNamedItem(xercesc::XMLString::transcode("OHId"))->getNodeValue()));
           p_gemSystem->getSubDevicesRefs().back()->getSubDevicesRefs().back()->addSubDeviceRef(oh);
           p_gemSystem->getSubDevicesRefs().back()->getSubDevicesRefs().back()->addSubDeviceId(oh->getDeviceId());
-          DEBUG("GLIB parsing: Add new OHproperties to the subdevices of parent device");
+          CMSGEMOS_DEBUG("GLIB parsing: Add new OHproperties to the subdevices of parent device");
           parseOH(n);
         }
       }
@@ -197,10 +197,10 @@ void gem::utils::gemXMLparser::parseGLIB(xercesc::DOMNode* pNode)
 
 void gem::utils::gemXMLparser::parseOH(xercesc::DOMNode* pNode)
 {
-  DEBUG("GLIB parsing: start OH parsing");
+  CMSGEMOS_DEBUG("GLIB parsing: start OH parsing");
   xercesc::DOMNode* n = pNode->getFirstChild();
   gemOHProperties* oh_ = p_gemSystem->getSubDevicesRefs().back()->getSubDevicesRefs().back()->getSubDevicesRefs().back();
-  DEBUG("OH parsing: retrieve OH device from the devices parent tree");
+  CMSGEMOS_DEBUG("OH parsing: retrieve OH device from the devices parent tree");
   while (n) {
     if (n->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) {
       addProperty("TrigSource",   n, oh_);
@@ -214,16 +214,16 @@ void gem::utils::gemXMLparser::parseOH(xercesc::DOMNode* pNode)
       addProperty("GTPLock",      n, oh_);
       addProperty("FW",           n, oh_);
       if (strcmp("VFATSettings", xercesc::XMLString::transcode(n->getNodeName())) == 0) {
-        DEBUG("OH parsing: VFATSettings tag found");
+        CMSGEMOS_DEBUG("OH parsing: VFATSettings tag found");
         if (countChildElementNodes(n)) {
           gemVFATProperties* vfat = new gemVFATProperties();
-          DEBUG("OH parsing: create new VFATproperties object");
+          CMSGEMOS_DEBUG("OH parsing: create new VFATproperties object");
           vfat->setDeviceId(xercesc::XMLString::transcode(n->getAttributes()->getNamedItem(xercesc::XMLString::transcode("VFATId"))->getNodeValue()));
-          DEBUG("OH parsing: retrieve VFAT device ID");
+          CMSGEMOS_DEBUG("OH parsing: retrieve VFAT device ID");
           p_gemSystem->getSubDevicesRefs().back()->getSubDevicesRefs().back()->getSubDevicesRefs().back()->addSubDeviceRef(vfat);
-          DEBUG("OH parsing: add new VFATproperties to the subdevices of the parent device");
+          CMSGEMOS_DEBUG("OH parsing: add new VFATproperties to the subdevices of the parent device");
           p_gemSystem->getSubDevicesRefs().back()->getSubDevicesRefs().back()->getSubDevicesRefs().back()->addSubDeviceId(vfat->getDeviceId());
-          DEBUG("OH parsing: add VFAT device ID to the subdevices of the parent device");
+          CMSGEMOS_DEBUG("OH parsing: add VFAT device ID to the subdevices of the parent device");
           parseVFAT2Settings(n);
         }
       }
@@ -234,10 +234,10 @@ void gem::utils::gemXMLparser::parseOH(xercesc::DOMNode* pNode)
 
 void gem::utils::gemXMLparser::parseVFAT2Settings(xercesc::DOMNode* pNode)
 {
-  DEBUG("OH parsing: start VFAT parsing");
+  CMSGEMOS_DEBUG("OH parsing: start VFAT parsing");
   xercesc::DOMNode* n = pNode->getFirstChild();
   gemVFATProperties* vfat_ = p_gemSystem->getSubDevicesRefs().back()->getSubDevicesRefs().back()->getSubDevicesRefs().back()->getSubDevicesRefs().back();
-  DEBUG("VFAT parsing: retrieve VFAT device from the devices parent tree");
+  CMSGEMOS_DEBUG("VFAT parsing: retrieve VFAT device from the devices parent tree");
   while (n) {
     if (n->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) {
       addProperty("CalMode",       n, vfat_);

--- a/gemutils/src/common/soap/GEMSOAPToolBox.cc
+++ b/gemutils/src/common/soap/GEMSOAPToolBox.cc
@@ -55,28 +55,28 @@ xoap::MessageReference gem::utils::soap::GEMSOAPToolBox::makeFSMSOAPReply(std::s
   xoap::SOAPEnvelope     envelope        = reply->getSOAPPart().getEnvelope();
   xoap::SOAPBody         body            = envelope.getBody();
   std::string            responseString  = event + "Response";
-  TRACE("GEMSOAPToolBox::makeFSMSOAPReply responseString "
+  CMSGEMOS_TRACE("GEMSOAPToolBox::makeFSMSOAPReply responseString "
             << responseString);
   xoap::SOAPName         responseName    = envelope.createName(responseString, "xdaq", XDAQ_NS_URI);
-  TRACE("GEMSOAPToolBox::makeFSMSOAPReply responseName "
+  CMSGEMOS_TRACE("GEMSOAPToolBox::makeFSMSOAPReply responseName "
             << responseName.getLocalName());
   xoap::SOAPBodyElement  responseElement = body.addBodyElement(responseName);
-  TRACE("GEMSOAPToolBox::makeFSMSOAPReply responseElement "
+  CMSGEMOS_TRACE("GEMSOAPToolBox::makeFSMSOAPReply responseElement "
             << responseElement.getTextContent());
   xoap::SOAPName         stateName       = envelope.createName("state", "xdaq", XDAQ_NS_URI);
-  TRACE("GEMSOAPToolBox::makeFSMSOAPReply stateName "
+  CMSGEMOS_TRACE("GEMSOAPToolBox::makeFSMSOAPReply stateName "
             << stateName.getLocalName());
   xoap::SOAPElement      stateElement    = responseElement.addChildElement(stateName);
-  TRACE("GEMSOAPToolBox::makeFSMSOAPReply stateElement"
+  CMSGEMOS_TRACE("GEMSOAPToolBox::makeFSMSOAPReply stateElement"
             << stateElement.getTextContent());
   xoap::SOAPName         attributeName   = envelope.createName("stateName", "xdaq", XDAQ_NS_URI);
-  TRACE("GEMSOAPToolBox::makeFSMSOAPReplyattributeName "
+  CMSGEMOS_TRACE("GEMSOAPToolBox::makeFSMSOAPReplyattributeName "
             << attributeName.getLocalName());
   stateElement.addAttribute(attributeName, state);
-  DEBUG("GEMSOAPToolBox::makeFSMSOAPReply reply ");
+  CMSGEMOS_DEBUG("GEMSOAPToolBox::makeFSMSOAPReply reply ");
   std::string tool;
   reply->writeTo(tool);
-  DEBUG(tool);
+  CMSGEMOS_DEBUG(tool);
   return reply;
 }
 
@@ -119,7 +119,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommand(std::string const& cmd,
     xoap::SOAPName soapcmd = env.createName(cmd, "xdaq", XDAQ_NS_URI);
     xoap::SOAPElement cont = env.getBody().addBodyElement(soapcmd);
 
-    DEBUG("GEMSOAPToolBox::sendCommand '" << cmd << "'"
+    CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommand '" << cmd << "'"
           << " in '"   << appCxt->getContextDescriptor()->getURL() << "'"
           << " from '" << srcDsc->getClassName() << "'"
           << " to '"   << destDsc->getClassName() << "'");
@@ -129,21 +129,21 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommand(std::string const& cmd,
       std::stringstream tcdscmd;
       tcdscmd << cmd << " xdaq:actionRequestorId=\""
               << srcDsc->getClassName() << "\"";
-      DEBUG("GEMSOAPToolBox::sendTCDSCommand '" << tcdscmd.str() << "'" << " to '" << destDsc->getClassName() << "'");
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendTCDSCommand '" << tcdscmd.str() << "'" << " to '" << destDsc->getClassName() << "'");
       cont.addAttribute(cmdtype,srcDsc->getClassName());
     }
 
     std::string tool;
     // xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
     msg->writeTo(tool);
-    DEBUG("GEMSOAPToolBox::sendCommand '" << cmd << "': SOAP msg " << tool);
+    CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommand '" << cmd << "': SOAP msg " << tool);
     // BUG FIXME: if this throws, we get a terminate, why???
     tool.clear();
 
     xoap::MessageReference reply = appCxt->postSOAP(msg, *srcDsc, *destDsc);
     // xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
     reply->writeTo(tool);
-    DEBUG("GEMSOAPToolBox::sendCommand '" << cmd << "': SOAP reply " << tool);
+    CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommand '" << cmd << "': SOAP reply " << tool);
   } catch (xdaq::exception::Exception& e) {
     std::string errMsg = toolbox::toString("Command %s failed [%s]", cmd.c_str(), e.what());
     XCEPT_RETHROW(gem::utils::exception::SOAPException, errMsg, e);
@@ -177,7 +177,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendTCDSCommand(std::string const& cmd,
     xoap::SOAPName soapcmd = env.createName(cmd, "xdaq", XDAQ_NS_URI);
     xoap::SOAPElement cont = env.getBody().addBodyElement(soapcmd);
 
-    DEBUG("GEMSOAPToolBox::sendTCDSCommand '" << cmd << "'"
+    CMSGEMOS_DEBUG("GEMSOAPToolBox::sendTCDSCommand '" << cmd << "'"
           << " in '"   << appCxt->getContextDescriptor()->getURL() << "'"
           << " from '" << srcDsc->getClassName() << "'"
           << " to '"   << destDsc->getClassName() << "'");
@@ -187,20 +187,20 @@ bool gem::utils::soap::GEMSOAPToolBox::sendTCDSCommand(std::string const& cmd,
       std::stringstream tcdscmd;
       tcdscmd << cmd << " xdaq:actionRequestorId=\""
               << srcDsc->getClassName() << "\"";
-      DEBUG("GEMSOAPToolBox::sendTCDSCommand '" << tcdscmd.str() << "'" << " to '" << destDsc->getClassName() << "'");
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendTCDSCommand '" << tcdscmd.str() << "'" << " to '" << destDsc->getClassName() << "'");
       cont.addAttribute(cmdtype,"");
     }
 
     std::string tool;
     // xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
     msg->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendTCDSCommand '" << cmd << "': SOAP msg " << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendTCDSCommand '" << cmd << "': SOAP msg " << tool);
     tool.clear();
 
     xoap::MessageReference reply = appCxt->postSOAP(msg, *srcDsc, *destDsc);
     // xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
     reply->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendTCDSCommand '" << cmd << "': SOAP reply " << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendTCDSCommand '" << cmd << "': SOAP reply " << tool);
   } catch (xdaq::exception::Exception& e) {
     std::string errMsg = toolbox::toString("Command %s failed [%s]", cmd.c_str(), e.what());
     XCEPT_RETHROW(gem::utils::exception::SOAPException, errMsg, e);
@@ -254,13 +254,13 @@ bool gem::utils::soap::GEMSOAPToolBox::sendParameter(std::vector<std::string> co
     std::string tool;
     // xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
     msg->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendParameter SOAP msg " << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendParameter SOAP msg " << tool);
     tool.clear();
 
     xoap::MessageReference reply = appCxt->postSOAP(msg, *srcDsc, *destDsc);
     // xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
     reply->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendParameter SOAP msg " << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendParameter SOAP msg " << tool);
   } catch (xdaq::exception::Exception& e) {
     std::string errMsg = toolbox::toString("Send Parameter %s failed [%s]", parameter.at(0).c_str(), e.what());
     XCEPT_RETHROW(gem::utils::exception::SOAPException, errMsg, e);
@@ -318,13 +318,13 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameter(std::string cons
     std::string tool;
     // xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
     msg->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendCommandWithParameter SOAP msg " << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendCommandWithParameter SOAP msg " << tool);
     tool.clear();
 
     xoap::MessageReference reply = appCxt->postSOAP(msg, *srcDsc, *destDsc);
     // xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
     reply->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendCommandWithParameter SOAP msg " << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendCommandWithParameter SOAP msg " << tool);
   } catch (xdaq::exception::Exception& e) {
     std::string errMsg = toolbox::toString("Sending parameter %s (value %d) failed [%s]", cmd.c_str(), parameter, e.what());
     XCEPT_RETHROW(gem::utils::exception::SOAPException,errMsg, e);
@@ -366,7 +366,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(std::string c
       xoap::SOAPName cmdtype = env.createName("actionRequestorId", "xdaq", srcDsc->getClassName());
       container.addAttribute(cmdtype,srcDsc->getClassName());
 
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag: '" << cmd << "' adding attribute " << cmdtype.getQualifiedName());
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag: '" << cmd << "' adding attribute " << cmdtype.getQualifiedName());
     }
 
     for (auto b = bag.begin(); b != bag.end(); ++b) {
@@ -378,7 +378,7 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(std::string c
       cs.addTextNode(s->toString());
     }
     // std::vector<xoap::SOAPElement> paramsFound = container.getChildElements();
-    DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag Inspecting command elements with qualified name "
+    CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag Inspecting command elements with qualified name "
           << container.getElementName().getQualifiedName() << " with memory address "
           << std::hex << &container << std::dec << " has value "
           << container.getValue() << " and has "
@@ -387,33 +387,33 @@ bool gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(std::string c
     std::vector<xoap::SOAPElement> elems = container.getChildElements();
     // for (auto elem = elems.begin(); elem != elems.end(); ++elem) {
     for (std::vector<xoap::SOAPElement>::iterator elem = elems.begin(); elem != elems.end(); ++elem) {
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag found element elem != elems.end() ? " << (elem != elems.end()));
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  qualifiedName: "
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag found element elem != elems.end() ? " << (elem != elems.end()));
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  qualifiedName: "
             << elem->getElementName().getQualifiedName());
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  prefix: "
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  prefix: "
             << elem->getElementName().getPrefix());
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  localName: "
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  localName: "
             << elem->getElementName().getLocalName());
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  URI: "
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  URI: "
             << elem->getElementName().getURI());
-      // // DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag memory address: "
+      // // CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag memory address: "
       // //       << std::hex << elem << std::dec);
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  has value: "
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag  has value: "
             << elem->getValue());
-      DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag and has "
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::sendCommandWithParameterBag and has "
             << elem->getChildElements().size() << " subchildren");
     }
 
     std::string tool;
     xoap::dumpTree(msg->getSOAPPart().getEnvelope().getDOMNode(),tool);
     // msg->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendCommandWithParameterBag: SOAP message is: " << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendCommandWithParameterBag: SOAP message is: " << tool);
     tool.clear();
 
     reply = appCxt->postSOAP(msg, *srcDsc, *destDsc);
     xoap::dumpTree(reply->getSOAPPart().getEnvelope().getDOMNode(),tool);
     // reply->writeTo(tool);
-    INFO("GEMSOAPToolBox::sendCommandWithParameterBag: SOAP reply is" << tool);
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendCommandWithParameterBag: SOAP reply is" << tool);
   } catch (gem::utils::exception::Exception& e) {
     std::string errMsg = toolbox::toString("Send command with parameter bag failed [%s]", e.what());
     XCEPT_RETHROW(gem::utils::exception::SOAPException, errMsg, e);
@@ -464,15 +464,15 @@ bool gem::utils::soap::GEMSOAPToolBox::sendApplicationParameter(std::string cons
     cs.addTextNode(parValue);
 
     std::string tool;
-    INFO("GEMSOAPToolBox::sendApplicationParameter message:");
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendApplicationParameter message:");
     msg->writeTo(tool);
-    INFO(tool);
+    CMSGEMOS_INFO(tool);
     tool.clear();
 
     reply = appCxt->postSOAP(msg, *srcDsc, *destDsc);
-    INFO("GEMSOAPToolBox::sendApplicationParameter reply:");
+    CMSGEMOS_INFO("GEMSOAPToolBox::sendApplicationParameter reply:");
     reply->writeTo(tool);
-    INFO(tool);
+    CMSGEMOS_INFO(tool);
   } catch (gem::utils::exception::Exception& e) {
     std::string errMsg = toolbox::toString("Send application parameter %s[%s,%s] failed [%s]",
                                            parName.c_str(), parType.c_str(), parValue.c_str(), e.what());
@@ -620,7 +620,7 @@ std::string gem::utils::soap::GEMSOAPToolBox::getApplicationState(xdaq::Applicat
 
     if (basic.size() == 1) {
       std::string stateString = basic[0].getValue();
-      DEBUG("GEMSOAPToolBox::createStateRequestMessage application " << destDsc->getClassName()
+      CMSGEMOS_DEBUG("GEMSOAPToolBox::createStateRequestMessage application " << destDsc->getClassName()
             << " returned state " << stateString);
       return stateString;
     } else {


### PR DESCRIPTION
## Description
Rename logging macros to not possibly clutter the global namespace

### Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Removes possibly duplicated names from the global namespace
