### PR TITLE
Update Makefile for building docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ dbgprofile: $(SUBPACKAGES)
 
 doc:  $(SUBPACKAGES)
 	@echo "Generating doxygen"
-	@rm -fr ./doc/html 2> /dev/null
+	@mkdir ./doc/build
+	@rm -fr ./doc/build/* 2> /dev/null
 	@doxygen -s ./doc/cmsgemos.cfg
 	#@git checkout gh-pages  > /dev/null 2>&1
 	#@git add -f ./doc/html  > /dev/null 2>&1

--- a/doc/cmsgemos.cfg
+++ b/doc/cmsgemos.cfg
@@ -42,7 +42,7 @@ PROJECT_NUMBER         = $(shell git describe --abbrev=4 --dirty --always --tags
 # If a relative path is entered, it will be relative to the location 
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = $(BUILD_HOME)/$(GEM_OS_PROJECT)/docs/build/$(PROJECT_NUMBER)
+OUTPUT_DIRECTORY       = $(BUILD_HOME)/$(GEM_OS_PROJECT)/doc/build/$(PROJECT_NUMBER)
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 
 # 4096 sub-directories (in 2 levels) under the output directory of each output 


### PR DESCRIPTION
Create `doc/build`, required by `doc` `make` target
As per #224 