### PR TITLE
Fix #240

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ SUBPACKAGES.INSTALL  := $(patsubst %,%.install,  ${SUBPACKAGES})
 SUBPACKAGES.RPM      := $(patsubst %,%.rpm,      ${SUBPACKAGES})
 SUBPACKAGES.CLEANRPM := $(patsubst %,%.cleanrpm, ${SUBPACKAGES})
 SUBPACKAGES.CLEAN    := $(patsubst %,%.clean,    ${SUBPACKAGES})
+SUBPACKAGES.TESTS    := $(patsubst %,%.tests,    ${SUBPACKAGES})
 
 #OS:=linux
 #ARCH:=x86_64
@@ -81,6 +82,8 @@ cleanrpm: $(SUBPACKAGES.CLEANRPM)
 
 clean: $(SUBPACKAGES.CLEAN)
 
+tests: $(SUBPACKAGES) $(SUBPACKAGES.TESTS)
+
 $(LIBDIR):
 	mkdir -p $(LIBDIR)
 
@@ -98,6 +101,9 @@ $(SUBPACKAGES.INSTALL):
 
 $(SUBPACKAGES.CLEAN):
 	$(MAKE) -C $(patsubst %.clean,%, $@) clean
+
+$(SUBPACKAGES.TESTS):
+	$(MAKE) -C $(patsubst %.tests,%, $@) tests
 
 .PHONY: $(SUBPACKAGES) $(SUBPACKAGES.INSTALL) $(SUBPACKAGES.CLEAN)
 

--- a/gemonlinedb/Makefile
+++ b/gemonlinedb/Makefile
@@ -17,8 +17,6 @@ GEMONLINEDB_VER_PATCH=0
 include $(BUILD_HOME)/$(Project)/config/mfDefsGEM.mk
 include $(BUILD_HOME)/$(Project)/config/mfPythonDefsGEM.mk
 
-DependentLibraries += boost_filesystem
-
 Sources = \
     AMC13Configuration.cc \
     AMCConfiguration.cc \
@@ -41,8 +39,6 @@ Sources = \
 
 DynamicLibrary=gemonlinedb
 
-TestLibraries = $(DependentLibraries) xoap boost_unit_test_framework tstoreapi xdata mimetic wsaddressing tstoreutils
-
 TestExecutables = \
     test/testAMC13Configuration.cc \
     test/testConfigurationLinker.cc \
@@ -61,8 +57,13 @@ IncludeDirs+=$(BUILD_HOME)/$(Project)/gemutils/include
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gembase/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 
-DependentLibraries=gembase gemutils xdaq xdata mimetic xoap xerces-c xcept toolbox log4cplus
+DependentLibraries=gembase gemutils xdaq cgicc xgi peer xdata mimetic xoap xerces-c xcept toolbox logudpappender logxmlappender log4cplus config cgicc
+DependentLibraries += boost_filesystem boost_regex boost_system
+
 # DependentLibraries+=$(StandardLibraries)
+
+TestLibraries= $(DependentLibraries) boost_unit_test_framework tstoreapi wsaddressing tstoreutils
+TestLibraryDirs= $(DependentLibraryDirs)
 
 # Targets with additional dependencies. Keep "default" first
 .PHONY: default clean tests


### PR DESCRIPTION
## Description
Makes minimal changes to `Makefile`s to allow building of `tests` target

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Motivation and Context
#240 

Does not optimally handle the dependent libraries, as fixes along these lines are being done in a separate development.
When these are merged together, that will get cleaned up

## How Has This Been Tested?
Builds locally
