### PR TITLE
Hot Fix: Updated VFAT_MASK Register Node Name in FPGA

### DIFF
--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -522,7 +522,7 @@ class HwOptoHybrid(object):
             print("Only implemented for v3 electronics, exiting")
             sys.exit(os.EX_USAGE)
 
-        return self.parentAMC.writeRegister("GEM_AMC.OH.OH%i.TRIG.CTRL.VFAT_MASK"%(self.link),sbitMask)
+        return self.parentAMC.writeRegister("GEM_AMC.OH.OH{0}.FPGA.TRIG.CTRL.VFAT_MASK".format(self.link),sbitMask)
 
     def setTriggerSource(self,source):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
At some point (don't remember when) the OH address table changed from using `GEM_AMC.OH.OHX.TRIG.` to `GEM_AMC.OH.OHX.FPGA.` for the parent node.

It seems some places did not have this change propagated through.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.  But here's an example of the correct node name:

```
eagle60 > write GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT_MASK 0xf00000
Initial value to write: 15728640, register GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT_MASK
0x00f00000(15728640)    written to GEM_AMC.OH.OH0.FPGA.TRIG.CTRL.VFAT_MASK
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
