### PR TITLE
Update XHAL path

### DIFF
--- a/gemdaqmonitor/Makefile
+++ b/gemdaqmonitor/Makefile
@@ -26,12 +26,12 @@ IncludeDirs+=$(BUILD_HOME)/$(Project)/$(Package)/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gembase/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemutils/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemhardware/include
-IncludeDirs+=$(XHALROOT)/include
+IncludeDirs+=$(XHAL_ROOT)/include
 
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gembase/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemhardware/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
-DependentLibraryDirs+=$(XHALROOT)/lib
+DependentLibraryDirs+=$(XHAL_ROOT)/lib
 
 UserCFlags  +=$(PYTHONCFLAGS)
 UserCCFlags +=$(PYTHONCFLAGS)

--- a/gemhardware/Makefile.devices
+++ b/gemhardware/Makefile.devices
@@ -25,15 +25,15 @@ IncludeDirs =$(XDAQ_ROOT)/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/$(Package)/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemutils/include
 IncludeDirs+=$(uHALROOT)/include
-IncludeDirs+=$(XHALROOT)/include
+IncludeDirs+=$(XHAL_ROOT)/include
 
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(uHALROOT)/lib
-DependentLibraryDirs+=$(XHALROOT)/lib
+DependentLibraryDirs+=$(XHAL_ROOT)/lib
 
 LibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 LibraryDirs+=$(uHALROOT)/lib
-LibraryDirs+=$(XHALROOT)/lib
+LibraryDirs+=$(XHAL_ROOT)/lib
 
 DependentLibraries =cactus_uhal_uhal xhal
 DependentLibraries+=gemutils

--- a/gemhardware/Makefile.managers
+++ b/gemhardware/Makefile.managers
@@ -27,14 +27,14 @@ IncludeDirs+=$(BUILD_HOME)/$(Project)/gemutils/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gembase/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemreadout/include
 IncludeDirs+=$(uHALROOT)/include
-IncludeDirs+=$(XHALROOT)/include
+IncludeDirs+=$(XHAL_ROOT)/include
 
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/$(Package)/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gembase/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemreadout/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(uHALROOT)/lib
-DependentLibraryDirs+=$(XHALROOT)/lib
+DependentLibraryDirs+=$(XHAL_ROOT)/lib
 
 UserCFlags  +=$(PYTHONCFLAGS)
 UserCCFlags +=$(PYTHONCFLAGS)

--- a/gempython/Makefile
+++ b/gempython/Makefile
@@ -47,17 +47,17 @@ IncludeDirs+=$(BUILD_HOME)/$(Project)/$(Package)/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemutils/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemhardware/include
 IncludeDirs+=$(uHALROOT)/include
-IncludeDirs+=$(XHALROOT)/include
+IncludeDirs+=$(XHAL_ROOT)/include
 
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemhardware/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(uHALROOT)/lib
-DependentLibraryDirs+=$(XHALROOT)/lib
+DependentLibraryDirs+=$(XHAL_ROOT)/lib
 
 LibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 LibraryDirs+=$(BUILD_HOME)/$(Project)/gemhardware/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 LibraryDirs+=$(uHALROOT)/lib
-LibraryDirs+=$(XHALROOT)/lib
+LibraryDirs+=$(XHAL_ROOT)/lib
 
 DependentLibraries =gemhardware_devices
 DependentLibraries+=boost_python

--- a/gemsupervisor/Makefile
+++ b/gemsupervisor/Makefile
@@ -31,14 +31,14 @@ IncludeDirs+=$(BUILD_HOME)/$(Project)/gemutils/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemhardware/include
 IncludeDirs+=$(BUILD_HOME)/$(Project)/gemreadout/include
 IncludeDirs+=$(uHALROOT)/include
-IncludeDirs+=$(XHALROOT)/include
+IncludeDirs+=$(XHAL_ROOT)/include
 
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemhardware/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gemreadout/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(BUILD_HOME)/$(Project)/gembase/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
 DependentLibraryDirs+=$(uHALROOT)/lib
-DependentLibraryDirs+=$(XHALROOT)/lib
+DependentLibraryDirs+=$(XHAL_ROOT)/lib
 
 UserCFlags  +=$(PYTHONCFLAGS)
 UserCCFlags +=$(PYTHONCFLAGS)


### PR DESCRIPTION
## Description
Change expected `xhal` path from `XHALROOT` to `XHAL_ROOT`,
to be consistent with other packages and `etc/profile.d/gemdaqenv.sh`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
