### PR TITLE
Bug Fix: attribute error in set_scanParams_latency.py due to a legacy keyword

### DIFF
--- a/gempython/tools/xdaq/set_scanParams_latency.py
+++ b/gempython/tools/xdaq/set_scanParams_latency.py
@@ -69,7 +69,7 @@ def setScanParamsLatency(args):
         msg = "%11s::  %s"%("After", '   '.join(map(str, regmap)))
         print(msg)
         if sum(badreg) > 0:
-            printRed("OH{} :: {} VFATs do not match expectation 0x{:02x}".format(args.link,sum(badreg),wval))
+            printRed("OH{} :: {} VFATs do not match expectation 0x{:02x}".format(ohN,sum(badreg),wval))
         
     amc.getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE").write(0x3)
     amc.getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS").write((wval<<16)|(rparm&0xffff))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The namespace object returned by the argument parser does not have the link attribute anymore.  It should be using the optohybrid index.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Crashes if called.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `gem904qc8daq`.  Works.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
