### PR TITLE
New Feature: Program OH FW and automatic ohMask determination

### DIFF
--- a/gempython/tests/writeGBTPhase.py
+++ b/gempython/tests/writeGBTPhase.py
@@ -1,0 +1,24 @@
+#!/bin/env python
+
+if __name__ == '__main__':
+    # create the parser
+    import argparse
+    parser = argparse.ArgumentParser(description="Tool for writing GBT phase for a single elink")
+
+    parser.add_argument("shelf",type=int,help="uTCA shelf number")
+    parser.add_argument("slot",type=int,help="AMC slot number in the uTCA shelf")
+    parser.add_argument("link",type=int,help="OH number on the AMC")
+    parser.add_argument("vfat",type=int,help="VFAT number on the OH")
+    parser.add_argument("phase",type=int,help="GBT Phase Value to Write")
+    args = parser.parse_args()
+
+    cardName = "gem-shelf%02d-amc%02d"%(args.shelf,args.slot)
+
+    from xhal.reg_interface_gem.core.gbt_utils_extended import setPhase
+    setPhase(cardName,args.link,args.vfat,args.phase)
+
+    from gempython.tools.vfat_user_functions_xhal import HwVFAT
+    vfatBoard = HwVFAT(cardName,args.link)
+    vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET",0x1)
+    
+    print("Goodbye")

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -772,6 +772,7 @@ class HwAMC(object):
         initJtagRegAddrs()
         for trial in range(0,maxIter):
             self.writeRegister("GEM_AMC.TTC.GENERATOR.SINGLE_HARD_RESET",0x1)
+            self.writeRegister("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET",0x1)
             isDead = True
             listOfDeadFPGAs = []
             ohMaskNeedSCAReset = 0x0

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -94,6 +94,13 @@ class VFATLinkMonitorParams(Structure):
             ]
 VFATLinkMonitorArrayType = VFATLinkMonitorParams * 12
 
+class NoUnmaskedOHException(Exception):
+    def __init__(self, message, errors):
+        super(NoUnmaskedOHException, self).__init__(message)
+
+        self.errors = errors
+        return
+
 class HwAMC(object):
     def __init__(self, cardName, debug=False):
         """
@@ -247,7 +254,7 @@ class HwAMC(object):
 
         return self.ttcGenConf(ohN, mode, t1type, pulseDelay, L1Ainterval, nPulses, enable)
 
-    def configureVFAT3DacMonitorMulti(self, dacSelect, ohMask=0xFFF):
+    def configureVFAT3DacMonitorMulti(self, dacSelect, ohMask=None):
         """
         Configure the DAC Monitoring to monitor the register defined by dacSelect
         on all unmasked VFATs for optohybrids given by ohMask.
@@ -257,8 +264,17 @@ class HwAMC(object):
         dacSelect - An integer defining the monitored register.
                     See VFAT3 Manual GLB_CFG_CTR_4 for details.
         ohMask - Mask which defines which OH's to query; 12 bit number where
-                 having a 1 in the N^th bit means to query the N^th optohybrid
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         """
+        
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::configureVFAT3DacMonitorMulti(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         ohVFATMaskArray = self.getMultiLinkVFATMask(ohMask)
         return self.confDacMonitorMulti(ohMask, ohVFATMaskArray, dacSelect)
@@ -271,7 +287,7 @@ class HwAMC(object):
         self.writeRegister("GEM_AMC.TTC.CTRL.L1A_ENABLE", 0x1)
         return
 
-    def getGBTLinkStatus(self,doReset=False,printSummary=False, ohMask=0xfff):
+    def getGBTLinkStatus(self,doReset=False,printSummary=False, ohMask=None):
         """
         Get's the GBT Status and can print a table of the status for each unmasked OH.
         Returns True if all unmasked OH's have all GBT's with:
@@ -283,8 +299,17 @@ class HwAMC(object):
         doReset - Issues a link reset if True
         printSummary - prints a table summarizing the status of the GBT's for each unmasked OH
         ohMask - Mask which defines which OH's to query; 12 bit number where
-                 having a 1 in the N^th bit means to query the N^th optohybrid
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         """
+        
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::getGBTLinkStatus(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         gbtMonData = OHLinkMonitorArrayType()
         self.getmonGBTLink(gbtMonData, self.nOHs, ohMask, doReset)
@@ -355,7 +380,7 @@ class HwAMC(object):
         else:
             return mask
 
-    def getMultiLinkVFATMask(self,ohMask=0xfff):
+    def getMultiLinkVFATMask(self,ohMask=None):
         """
         v3 electronics only
 
@@ -363,14 +388,23 @@ class HwAMC(object):
         array is the vfat mask for the ohN defined by the array index
 
         ohMask - Mask which defines which OH's to query; 12 bit number where
-                 having a 1 in the N^th bit means to query the N^th optohybrid
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         """
-
+        
         if self.fwVersion < 3:
             printRed("HwAMC::getLinkVFATMask() - No support in v2b FW")
             return os.EX_USAGE
 
-        vfatMaskArray = (c_uint32 * 12)()
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::getMultiLinkVFATMask(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
+
+        vfatMaskArray = (c_uint32 * self.nOHs)()
         rpcResp = self.getOHVFATMaskMultiLink(ohMask, vfatMaskArray)
 
         if rpcResp != 0:
@@ -378,10 +412,18 @@ class HwAMC(object):
         else:
             return vfatMaskArray
 
-    def getOHLinkStatus(self,doReset=False,printSummary=False, ohMask=0xfff):
+    def getOHLinkStatus(self,doReset=False,printSummary=False, ohMask=None):
         #place holder
         printYellow("HwAMC::getOHLinkStatus() not yet implemented")
         return
+
+    def getOHMask(self):
+        """
+        Gets the OH Mask to use with this AMC
+        """
+        scaReady = self.readRegister("GEM_AMC.SLOW_CONTROL.SCA.STATUS.READY")
+        scaError = self.readRegister("GEM_AMC.SLOW_CONTROL.SCA.STATUS.CRITICAL_ERROR")
+        return (scaReady & (~scaError & 0xfff))
 
     def getShelf(self):
         return self.shelf
@@ -412,7 +454,7 @@ class HwAMC(object):
                 print("\tENABLE: \t\t\t%i"%(running))
         return running
 
-    def getTriggerLinkStatus(self,printSummary=False, checkCSCTrigLink=False, ohMask=0xfff):
+    def getTriggerLinkStatus(self,printSummary=False, checkCSCTrigLink=False, ohMask=None):
         """
         Gets the trigger link status for each unmasked OH and returns a dictionary where with keys of ohN and 
         values as the sum of all trigger link status counters.  Only unmasked OH's will exist in this dictionary
@@ -422,9 +464,18 @@ class HwAMC(object):
         If checkCSCTrigLink is False the ohMask will define which OH's to query, a 1 in the N^th bit means to query the N^th optohybrid.
         If checkCSCTrigLink is True, the ohMask is expected to have all odd bits set to 0. Only even bits may be nonzero.
          If the N^th even bit is nonzero the trigger link status for that OHN and OHN+1 will be queried.
+         In all cases if ohMask is None it will be determined automatically from HwAMC::getOHMask().
          It is expected that the GEM trigger link from the physical optohybrid is going to the OHN fiber slot on this AMC and the
          CSC Trigger Link from the physical optohybrid is going to the OHN+1 fiber slot on this AMC.
         """
+        
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::getTriggerLinkStatus(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         ohMask2Query=ohMask
         # Are we checking CSC Trigger links?
@@ -502,7 +553,7 @@ class HwAMC(object):
 
         return ohSumLinkStatus
 
-    def getVFATLinkStatus(self,doReset=False,printSummary=False, ohMask=0xfff):
+    def getVFATLinkStatus(self,doReset=False,printSummary=False, ohMask=None):
         """
         Get's the VFAT link status and can print a table of the status for each unmasked OH.
         Returns True if all unmasked OH's have all VFAT's with:
@@ -511,8 +562,17 @@ class HwAMC(object):
         doReset - Issues a link reset if True
         printSummary - prints a table summarizing the status of the GBT's for each unmasked OH
         ohMask - Mask which defines which OH's to query; 12 bit number where
-                 having a 1 in the N^th bit means to query the N^th optohybrid
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         """
+        
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::getVFATLinkStatus(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         vfatMonData = VFATLinkMonitorArrayType()
         self.getmonVFATLink(vfatMonData, self.nOHs, ohMask, doReset)
@@ -547,7 +607,7 @@ class HwAMC(object):
 
         return (totalSyncErrors == 0)
 
-    def performDacScanMultiLink(self, dacDataAll, dacSelect, dacStep=1, ohMask=0xfff, useExtRefADC=False):
+    def performDacScanMultiLink(self, dacDataAll, dacSelect, dacStep=1, ohMask=None, useExtRefADC=False):
         """
         Scans the DAC defined by dacSelect for all links on this AMC.  See VFAT3 manual for more details
         on the available DAC selection.
@@ -558,9 +618,19 @@ class HwAMC(object):
         dacSelect - Integer which specifies the DAC to scan against the ADC.  See VFAT3 Manual
         dacStep - Step size to scan the DAC with
         ohMask - Mask which defines which OH's to query; 12 bit number where
-                 having a 1 in the N^th bit means to query the N^th optohybrid
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         useExtRefADC - If true the DAC scan will be made using the externally referenced ADC on the VFAT3s
         """
+        
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        nUnmaskedOHs = bin(ohMask).count("1")
+        if (not (nUnmaskedOHs > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::performDacScanMultiLink(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         # Check we are v3 electronics
         if self.fwVersion < 3:
@@ -574,7 +644,6 @@ class HwAMC(object):
             exit(os.EX_USAGE)
 
         # Check number of nonzero bits doesn't exceed NOH's
-        nUnmaskedOHs = bin(ohMask).count("1")
         if nUnmaskedOHs > self.nOHs:
             printRed("HwAMC::performDacScanMultiLink(): Number of unmasked OH's {0} exceeds max number of OH's {1}".format(nUnmaskedOHs,self.nOHs))
             exit(os.EX_USAGE)
@@ -587,7 +656,7 @@ class HwAMC(object):
 
         return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll)
 
-    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=0xfff, scanReg="THR_ARM_DAC"):
+    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=None, scanReg="THR_ARM_DAC"):
         """
         Measures the rate of sbits sent by all unmasked optobybrids on this AMC
 
@@ -607,9 +676,19 @@ class HwAMC(object):
         dacMax                  - Ending dac value of the scan
         dacStep                 - Step size for moving from dacMin to dacMax
         ohMask - Mask which defines which OH's to query; 12 bit number where
-                 having a 1 in the N^th bit means to query the N^th optohybrid
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         scanReg                 - Name of register to be scanned.
         """
+        
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        nUnmaskedOHs = bin(ohMask).count("1")
+        if (not (nUnmaskedOHs > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::performSBITRateScanMultiLink(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         # Check we are v3 electronics
         if self.fwVersion < 3:
@@ -617,7 +696,6 @@ class HwAMC(object):
             exit(os.EX_USAGE)
 
         # Check number of nonzero bits doesn't exceed NOH's
-        nUnmaskedOHs = bin(ohMask).count("1")
         if nUnmaskedOHs > self.nOHs:
             printRed("HwAMC::performSBITRateScanMultiLink(): Number of unmasked OH's {0} exceeds max number of OH's {1}".format(nUnmaskedOHs,self.nOHs))
             exit(os.EX_USAGE)
@@ -642,8 +720,21 @@ class HwAMC(object):
     
     def programAllOptohybridFPGAs(self, maxIter=5, ohMask=None):
         """
-        Will program the FPGA of all unmasked optohybrids. If ohMask is None it will 
-        determine which 
+        Will make up to maxIter attempts to program the FPGA of all unmasked optohybrids.
+        Before the first attempt the function will check on the AMC that the PROMLESS programming
+        is enabled, if it isn't this will call gemloader_configure.sh.sh on the AMC. Then
+        for each attempt a TTC Hard Reset will be sent from the TTC Generator and then it will
+        check if slow control with the unmasked OH FPGA's is possible.  If it is not, an SCA reset
+        will be sent and then the next attempt will be tried.
+
+        It will return a list of OH's, out of ohMask, who after maxIter is performed are still
+        unprogrammed. If all OH's in ohMask are programmed before maxIter is reached the proceedure will exit
+        and return an empty list.
+
+        maxIter- Maximum number of attempts to program all OH's in ohMask
+        ohMask - Mask which defines which OH's to query; 12 bit number where
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         """
 
         # Determine if PROM-Less programming is enabled, if not enable it
@@ -653,7 +744,13 @@ class HwAMC(object):
                 'gemuser@{0}'.format(self.name),
                 'sh -c "{0}"'.format(mpeekCmd)
                 ]
-        promlessEnabled = int(runCommandWithOutput(shellCmd).strip('\n'))
+        promlessEnabled = runCommandWithOutput(shellCmd).strip('\n')
+        if "0x" in promlessEnabled:
+            promlessEnabled = int(promlessEnabled,16)
+        else:
+            promlessEnabled = int(promlessEnabled)
+            pass
+
         if promlessEnabled != 0x1:
             shellCmd = [
                     'ssh',
@@ -664,14 +761,11 @@ class HwAMC(object):
 
         # Automatically determine ohMask if not provided
         if ohMask is None:
-            scaReady = self.readRegister("GEM_AMC.SLOW_CONTROL.SCA.STATUS.READY")
-            scaError = self.readRegister("GEM_AMC.SLOW_CONTROL.SCA.STATUS.CRITICAL_ERROR")
-            ohMask = (scaReady & (~scaError & 0xfff))
+            ohMask = self.getOHMask()
 
         # Are any optohybrids available?
         if (not (bin(ohMask).count("1") > 0) ):
-            printRed("HwAMC::programAllOptohybridFPGAs(): there are no unmasked optohybrids to program")
-            return [x for x in range(0,12) ]
+            raise NoUnmaskedOHException("{0}HwAMC::programAllOptohybridFPGAs(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         # Program FPGA's
         self.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x1)
@@ -702,15 +796,24 @@ class HwAMC(object):
 
         return listOfDeadFPGAs
 
-    def readADCsMultiLink(self, adcDataAll, useExtRefADC=False, ohMask=0xFFF, debug=False):
+    def readADCsMultiLink(self, adcDataAll, useExtRefADC=False, ohMask=None, debug=False):
         """
         Reads the ADC value from all unmasked VFATs
 
         adcDataAll - Array of type c_uint32 of size 24*12=288
         useExtRefADC - True (False) use the externally (internally) referenced ADC
         ohMask - Mask which defines which OH's to query; 12 bit number where
-                 having a 1 in the N^th bit means to query the N^th optohybrid
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         """
+
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::readADCsMultiLink(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         if debug:
             print("getting vfatmasks for each OH")
@@ -720,8 +823,7 @@ class HwAMC(object):
             print("| ohN | vfatmask |")
             print("| :-: | :------: |")
             for ohN in range(0,12):
-                mask = str(hex(ohVFATMaskArray[ohN])).strip('L')
-                print("| {0} | {1} |".format(ohN, mask))
+                print("| {0} | 0x{1:x} |".format(ohN, ohVFATMaskArray[ohN]))
 
         return self.readADCsMulti(ohMask,ohVFATMaskArray, adcDataAll, useExtRefADC)
 
@@ -799,20 +901,30 @@ class HwAMC(object):
 
         self.writeRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",ohMask,debug)
 
-    def scaMonitorMultiLink(self, NOH=12, ohMask=0xfff):
+    def scaMonitorMultiLink(self, ohMask=None):
         """
         v3 electronics only.
         Reads SCA monitoring data for multiple links on the AMC
 
-        NOH - number of OH's on this AMC
-        ohMask - 12 bit number where N^th bit corresponds to N^th OH.  Setting a bit to 1 will cause the SCA data to be monitored for this OH.
+        NOH    - number of OH's on this AMC
+        ohMask - Mask which defines which OH's to query; 12 bit number where
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         """
+        
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::scaMonitorMultiLink(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         scaMonData = SCAMonitorArrayType()
-        rpcResp = self.getmonOHSCAmain(scaMonData, NOH, ohMask)
+        rpcResp = self.getmonOHSCAmain(scaMonData, self.nOHs, ohMask)
 
         if rpcResp != 0:
-            raise Exception("RPC response was non-zero, reading SCA Monitoring Data from OH's in ohMask = {0} failed".format(str(hex(ohMask)).strip('L')))
+            raise Exception("RPC response was non-zero, reading SCA Monitoring Data from OH's in ohMask = 0x{0:x} failed".format(ohMask))
 
         return scaMonData
 
@@ -824,21 +936,31 @@ class HwAMC(object):
         self.slot = slot
         return
 
-    def sysmonMonitorMultiLink(self, NOH=12, ohMask=0xfff, doReset=False):
+    def sysmonMonitorMultiLink(self, NOH=12, ohMask=None, doReset=False):
         """
         v3 eletronics only.
         Reads FPGA sysmon data for multiple links on the AMC
 
         NOH - number of OH's on this AMC
-        ohMask - 12 bit number where N^th bit corresponds to N^th OH.  Setting a bit to 1 will cause the SCA data to be monitored for this OH.
+        ohMask - Mask which defines which OH's to query; 12 bit number where
+                 having a 1 in the N^th bit means to query the N^th optohybrid.
+                 If None will be determined automatically using HwAMC::getOHMask()
         doReset - Resets the sysmon alarm counters (generally unwise)
         """
+
+        # Automatically determine ohMask if not provided
+        if ohMask is None:
+            ohMask = self.getOHMask()
+
+        # Are any optohybrids available?
+        if (not (bin(ohMask).count("1") > 0) ):
+            raise NoUnmaskedOHException("{0}HwAMC::sysmonMonitorMultiLink(): there are no unmasked optohybrids{1}".format(colors.RED,colors.ENDC),os.EX_SOFTWARE)
 
         sysmonData = SysmonMonitorArrayType()
         rpcResp = self.getmonOHSysmon(sysmonData, NOH, ohMask, doReset)
 
         if rpcResp != 0:
-            raise Exception("RPC response was non-zero, reading Sysmon Monitoring Data from OH's in ohMask = {0} failed".format(str(hex(ohMask)).strip('L')))
+            raise Exception("RPC response was non-zero, reading Sysmon Monitoring Data from OH's in ohMask = 0x{0:x} failed".format(ohMask))
 
         return sysmonData
 

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -729,7 +729,7 @@ class HwAMC(object):
                 # Skip masked OH's
                 if( not ((ohMask >> ohN) & 0x1)):
                     continue
-                fwVerMaj = self.readRegister("GEM_AMC.OH.OH{0}.FPGA.CONTROL.RELEASE.VERSION.MAJOR".format(ohN))
+                fwVerMaj = int(self.readRegister("GEM_AMC.OH.OH{0}.FPGA.CONTROL.RELEASE.VERSION.MAJOR".format(ohN)))
                 if fwVerMaj != 0xdeaddead:
                     isDead = False
                 else:
@@ -743,6 +743,8 @@ class HwAMC(object):
                 fpgaCommPassed = True
                 break
             else:
+                #FIXME note when @evka85 removes adc monitoring block from GEM_AMC FW this line will need to be removed
+                self.writeRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",0x0)
                 sca_reset(ohMaskNeedSCAReset)
             pass
         self.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x0)

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -745,7 +745,7 @@ class HwAMC(object):
                 break
             else:
                 #FIXME note when @evka85 removes adc monitoring block from GEM_AMC FW this line will need to be removed
-                self.writeRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",0x0)
+                self.writeRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",0xfff)
                 sca_reset(ohMaskNeedSCAReset)
             pass
         self.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x0)

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -446,7 +446,8 @@ class HwAMC(object):
         # Are we checking CSC Trigger links?
         if (checkCSCTrigLink):
             # If input mask is not even otherwise it quits
-            if (int(ohMask)%2!=0):
+            onlyOddBits = 0b101010101010
+            if ( (ohMask & onlyOddBits) !=0):
                 printRed("HwAMC::getTriggerLinkStatus(): checkCSCTrigLink=True and ohMask={0}. Checking the CSC trigger link on an odd bit is not allowed.".format(hex(ohMask)))
                 exit(os.EX_USAGE)
                 pass
@@ -461,7 +462,7 @@ class HwAMC(object):
         
         linkStatus=0
         arraySize=8*int(self.nOHs)
-        linkResult = (c_uint32 * arraySize)()
+        linkResult = (c_uint32 * arraySize)( * [0xffffffff for x in range(0,arraySize) ] )
         self.getmonTRIGGEROHmain(linkResult, self.nOHs, ohMask2Query)
 
         if(printSummary):

--- a/gempython/tools/hw_constants.py
+++ b/gempython/tools/hw_constants.py
@@ -1,7 +1,7 @@
 # Known detector types
 gemVariants = {
             "ge11":["short","long"],
-            "ge21":["M{0}".format(ge21Type) for ge21Type in range(1,9) ],
+            "ge21":["m{0}".format(ge21Type) for ge21Type in range(1,9) ],
             "me0":"null"}
 
 vfatsPerGemVariant = {
@@ -39,6 +39,8 @@ maxVfat3DACSize = {
         }
 
 # VFAT3 Phase Settings
+GBT_PHASE_RANGE = 16
+
 # Best Guess of what default good phase "should be"
 from gempython.utils.nesteddict import nesteddict as ndict
 vfat3GBTPhaseLookupTable = ndict() #keys follow from gemVariants, values are a list with length = N_VFATs; each element is a phase value for that VFAT

--- a/gempython/tools/hw_constants.py
+++ b/gempython/tools/hw_constants.py
@@ -1,0 +1,78 @@
+# Known detector types
+gemVariants = {
+            "ge11":["short","long"],
+            "ge21":["M{0}".format(ge21Type) for ge21Type in range(1,9) ],
+            "me0":"null"}
+
+vfatsPerGemVariant = {
+            "ge11":24,
+            "ge21":12,
+            "me0":24}
+
+# Size of VFAT3 DAC's
+maxVfat3DACSize = {
+        #ADC Measures Current
+        #0:(0x3f, "CFG_IREF"), # This should never be scanned per VFAT3 Team's Instructions
+        1:(0xff,"CFG_CAL_DAC"), # as current
+        2:(0xff,"CFG_BIAS_PRE_I_BIT"),
+        3:(0x3f,"CFG_BIAS_PRE_I_BLCC"),
+        4:(0x3f,"CFG_BIAS_PRE_I_BSF"),
+        5:(0xff,"CFG_BIAS_SH_I_BFCAS"),
+        6:(0xff,"CFG_BIAS_SH_I_BDIFF"),
+        7:(0xff,"CFG_BIAS_SD_I_BDIFF"),
+        8:(0xff,"CFG_BIAS_SD_I_BFCAS"),
+        9:(0x3f,"CFG_BIAS_SD_I_BSF"),
+        10:(0x3f,"CFG_BIAS_CFD_DAC_1"),
+        11:(0x3f,"CFG_BIAS_CFD_DAC_2"),
+        12:(0x3f,"CFG_HYST"),
+        14:(0xff,"CFG_THR_ARM_DAC"),
+        15:(0xff,"CFG_THR_ZCC_DAC"),
+        #16:(0xff,""),Don't know reg in CTP7 address space
+
+        #ADC Measures Voltage
+        #33:(0xff,"CFG_CAL_DAC"), # as voltage; removing, harder to convert to charge
+        34:(0xff,"CFG_BIAS_PRE_VREF"),
+        35:(0xff,"CFG_THR_ARM_DAC"),
+        36:(0xff,"CFG_THR_ZCC_DAC"),
+        39:(0x3,"CFG_VREF_ADC")
+        #41:(0x3f,""))Don't know reg in CTP7 address space
+        }
+
+# VFAT3 Phase Settings
+# Best Guess of what default good phase "should be"
+from gempython.utils.nesteddict import nesteddict as ndict
+vfat3GBTPhaseLookupTable = ndict() #keys follow from gemVariants, values are a list with length = N_VFATs; each element is a phase value for that VFAT
+
+# Provide Place holders
+for ge11Type in gemVariants["ge11"]:
+    vfat3GBTPhaseLookupTable["ge11"][ge11Type] = [ 0 for x in range(0,vfatsPerGemVariant["ge11"]) ]
+for ge21Type in gemVariants["ge21"]:
+    vfat3GBTPhaseLookupTable["ge21"][ge21Type] = [ 0 for x in range(0,vfatsPerGemVariant["ge21"]) ]
+vfat3GBTPhaseLookupTable["me0"]["null"] = [ 0 for x in range(0,vfatsPerGemVariant["me0"]) ]
+
+# Fill Info for GE11 - Short
+# FIXME It would be great if this was in the DB and I could just load it from there...
+vfat3GBTPhaseLookupTable["ge11"]["short"][0]  = 6  #VFAT0
+vfat3GBTPhaseLookupTable["ge11"]["short"][1]  = 9  #VFAT1
+vfat3GBTPhaseLookupTable["ge11"]["short"][2]  = 13 #VFAT2
+vfat3GBTPhaseLookupTable["ge11"]["short"][3]  = 5  #VFAT3
+vfat3GBTPhaseLookupTable["ge11"]["short"][4]  = 5  #VFAT4
+vfat3GBTPhaseLookupTable["ge11"]["short"][5]  = 4  #VFAT5
+vfat3GBTPhaseLookupTable["ge11"]["short"][6]  = 7  #VFAT6
+vfat3GBTPhaseLookupTable["ge11"]["short"][7]  = 8  #VFAT7
+vfat3GBTPhaseLookupTable["ge11"]["short"][8]  = 7  #VFAT8
+vfat3GBTPhaseLookupTable["ge11"]["short"][9]  = 9  #VFAT9
+vfat3GBTPhaseLookupTable["ge11"]["short"][10] = 12 #VFAT10
+vfat3GBTPhaseLookupTable["ge11"]["short"][11] = 12 #VFAT11
+vfat3GBTPhaseLookupTable["ge11"]["short"][12] = 6  #VFAT12
+vfat3GBTPhaseLookupTable["ge11"]["short"][13] = 3  #VFAT13
+vfat3GBTPhaseLookupTable["ge11"]["short"][14] = 2  #VFAT14
+vfat3GBTPhaseLookupTable["ge11"]["short"][15] = 6  #VFAT15
+vfat3GBTPhaseLookupTable["ge11"]["short"][16] = 9  #VFAT16
+vfat3GBTPhaseLookupTable["ge11"]["short"][17] = 10 #VFAT17
+vfat3GBTPhaseLookupTable["ge11"]["short"][18] = 8  #VFAT18
+vfat3GBTPhaseLookupTable["ge11"]["short"][19] = 6  #VFAT19
+vfat3GBTPhaseLookupTable["ge11"]["short"][20] = 10 #VFAT20
+vfat3GBTPhaseLookupTable["ge11"]["short"][21] = 9  #VFAT21
+vfat3GBTPhaseLookupTable["ge11"]["short"][22] = 12 #VFAT22
+vfat3GBTPhaseLookupTable["ge11"]["short"][23] = 7  #VFAT23

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -547,7 +547,7 @@ class HwOptoHybrid(object):
         """
         # Check if input type is understood
         if gemType not in gemVariants.keys():
-            raise OHTypeException("gemType {0} not in the list of known gemVariants: {1}".format(gemType,gemVariants),os.EX_USAGE)
+            raise OHTypeException("gemType {0} not in the list of known gemVariants: {1}".format(gemType,gemVariants.keys()),os.EX_USAGE)
 
         if detType not in gemVariants[gemType]:
             raise OHTypeException("detType {0} not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -37,10 +37,10 @@ class HwOptoHybrid(object):
 
         # Check if input type is understood
         if gemType not in gemVariants.keys():
-            raise OHTypeException("gemType {0} not in the list of known gemVariants: {1}".format(gemType,gemVariants),os.EX_USAGE)
+            raise OHTypeException("HwOptoHybrid: gemType '{0}' not in the list of known gemVariants: {1}".format(gemType,gemVariants.keys()),os.EX_USAGE)
 
         if detType not in gemVariants[gemType]:
-            raise OHTypeException("detType {0} not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)
+            raise OHTypeException("HwOptoHybrid: detType '{0}' not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)
 
         # Store HW info
         self.link = link
@@ -335,6 +335,9 @@ class HwOptoHybrid(object):
             print("HwOptoHybrid.getTriggerSource() - No support for v3 electronics, exiting")
             sys.exit(os.EX_USAGE)
     
+    def getType(self):
+        return (self.typeGEM,self.typeDet)
+
     def getVFATMask(self):
         """
         V3 electronics only
@@ -533,6 +536,28 @@ class HwOptoHybrid(object):
         else:
             print("HwOptoHybrid.setTriggerThrottle() - There is no way to presecale the L1As being sent in v3 electronics, exiting")
             sys.exit(os.EX_USAGE)
+
+    def setType(self, gemType, detType):
+        """
+        Sets the GEM type and detector type, updates the number of VFATs expected 
+        and changes the VFAT GBT Phase lookup table
+
+        gemType - string specifying gemType, expexted to be a key in gemVariants dictionary
+        detType - string specifyng detector type within gemType, expected to be a value in gemVariants[gemType]
+        """
+        # Check if input type is understood
+        if gemType not in gemVariants.keys():
+            raise OHTypeException("gemType {0} not in the list of known gemVariants: {1}".format(gemType,gemVariants),os.EX_USAGE)
+
+        if detType not in gemVariants[gemType]:
+            raise OHTypeException("detType {0} not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)
+
+        self.nVFATs = vfatsPerGemVariant[gemType]
+        self.typeDet = detType
+        self.typeGEM = gemType
+        self.vfatGBTPhases = vfat3GBTPhaseLookupTable[gemType][detType]
+
+        return
 
     def setVFATMask(self, mask=None):
         if mask is None:

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -1,10 +1,11 @@
 from gempython.tools.optohybrid_user_functions_xhal import *
+from gempython.tools.hw_constants import gemVariants
 from gempython.utils.gemlogger import colormsg
 
 import logging
 
 class HwVFAT(object):
-    def __init__(self, cardName, link, debug=False):
+    def __init__(self, cardName, link, debug=False, gemVariants="ge11", detType="short"):
         """
         Initialize the HW board an open an RPC connection
         """
@@ -14,8 +15,15 @@ class HwVFAT(object):
         # Logger
         self.vfatlogger = logging.getLogger(__name__)
 
+        # Check if input type is understood
+        if gemType not in gemVariants.keys():
+            raise OHTypeException("gemType {0} not in the list of known gemVariants: {1}".format(gemType,gemVariants),os.EX_USAGE)
+
+        if detType not in gemVariants[gemType]:
+            raise OHTypeException("detType {0} not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)
+        
         # Optohybrid
-        self.parentOH = HwOptoHybrid(cardName, link, debug)
+        self.parentOH = HwOptoHybrid(cardName, link, debug, detType)
 
         # Define VFAT3 DAC Monitoring
         self.confDacMonitor = self.parentOH.parentAMC.lib.configureVFAT3DacMonitor
@@ -113,7 +121,7 @@ class HwVFAT(object):
         """
         Returns the chipIDs for all VFATs not in mask.
 
-        mask - vfatMask, 24 bit number, 1 in the N^th bit means skip this VFAT
+        mask - vfatMask, up to a 24 bit number, 1 in the N^th bit means skip this VFAT
         rawID - If true returns the rawID and does not apply the Reed-Muller decoding
         """
 

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -5,7 +5,7 @@ from gempython.utils.gemlogger import colormsg
 import logging
 
 class HwVFAT(object):
-    def __init__(self, cardName, link, debug=False, gemVariants="ge11", detType="short"):
+    def __init__(self, cardName, link, debug=False, gemType="ge11", detType="short"):
         """
         Initialize the HW board an open an RPC connection
         """
@@ -15,15 +15,14 @@ class HwVFAT(object):
         # Logger
         self.vfatlogger = logging.getLogger(__name__)
 
-        # Check if input type is understood
         if gemType not in gemVariants.keys():
-            raise OHTypeException("gemType {0} not in the list of known gemVariants: {1}".format(gemType,gemVariants),os.EX_USAGE)
+            raise OHTypeException("HwVFAT: gemType '{0}' not in the list of known gemVariants: {1}".format(gemType,gemVariants.keys()),os.EX_USAGE)
 
         if detType not in gemVariants[gemType]:
-            raise OHTypeException("detType {0} not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)
+            raise OHTypeException("HwVFAT: detType '{0}' not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)
         
         # Optohybrid
-        self.parentOH = HwOptoHybrid(cardName, link, debug, detType)
+        self.parentOH = HwOptoHybrid(cardName, link, debug, gemType, detType)
 
         # Define VFAT3 DAC Monitoring
         self.confDacMonitor = self.parentOH.parentAMC.lib.configureVFAT3DacMonitor

--- a/gempython/tools/xdaq/setDAQParamsPostConfigure.py
+++ b/gempython/tools/xdaq/setDAQParamsPostConfigure.py
@@ -7,18 +7,18 @@ def setDAQParams(args):
     from gempython.utils.gracefulKiller import GracefulKiller
     killer = GracefulKiller()
 
-    for slot in range(1,13):
+    for slot in range(0,12):
         # Skip unmasked slots
         if (not ((args.slotMask >> slot) & 0x1)):
             continue
 
         # Make the AMC Object w/uhal
         global amc
-        amc = getAMCObject(args.slot,args.shelf,args.d)
+        amc = getAMCObject(slot+1,args.shelf,args.d)
 
         # Get ohMask for this slot
         from gempython.tools.amc_user_functions_xhal import HwAMC
-        cardName = "gem-shelf%02d-amc%02d"%(args.shelf,args.slot)
+        cardName = "gem-shelf%02d-amc%02d"%(args.shelf,slot+1)
         amcRPC = HwAMC(cardName,debug=args.d)
         ohMask = amcRPC.getOHMask(raiseIfNoOHs=False)
 

--- a/gempython/tools/xdaq/setDAQParamsPostConfigure.py
+++ b/gempython/tools/xdaq/setDAQParamsPostConfigure.py
@@ -1,32 +1,41 @@
 #!/bin/env python
 
 from gempython.tools.amc_user_functions_uhal import *
+from gempython.utils.gemlogger import printGreen, printRed, printYellow
 
 def setDAQParams(args):
     from gempython.utils.gracefulKiller import GracefulKiller
     killer = GracefulKiller()
 
-    # Make the AMC Object w/uhal
-    global amc
-    amc = getAMCObject(args.slot,args.shelf,args.d)
+    for slot in range(1,13):
+        # Skip unmasked slots
+        if (not ((args.slotMask >> slot) & 0x1)):
+            continue
 
-    # Set the input enable mask
-    amc.getNode("GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK").write(args.ohMask)
-    amc.dispatch()
+        # Make the AMC Object w/uhal
+        global amc
+        amc = getAMCObject(args.slot,args.shelf,args.d)
 
-    # Ensure that L1A's are enabled to this AMC
-    enableL1A(amc)
+        # Get ohMask for this slot
+        from gempython.tools.amc_user_functions_xhal import HwAMC
+        cardName = "gem-shelf%02d-amc%02d"%(args.shelf,args.slot)
+        amcRPC = HwAMC(cardName,debug=args.d)
+        ohMask = amcRPC.getOHMask(raiseIfNoOHs=False)
 
-    # Ensure the TTC Generator is Disabled (not sure if this is in uhal addr table...)
-    from gempython.tools.amc_user_functions_xhal import HwAMC
-    cardName = "gem-shelf%02d-amc%02d"%(args.shelf,args.slot)
-    amcRPC = HwAMC(cardName,debug=args.d)
-    amcRPC.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x0,args.d)
+        # Set the input enable mask
+        amc.getNode("GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK").write(ohMask)
+        amc.dispatch()
+
+        # Ensure that L1A's are enabled to this AMC
+        enableL1A(amc)
+
+        # Ensure the TTC Generator is Disabled (not sure if this is in uhal addr table...)
+        amcRPC.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x0,args.d)
+        pass
 
     from time import sleep
-    from gempython.utils.gemlogger import printGreen, printRed
-    printRed("I will now wait 60 seconds; you must navigate to the RCMS Page and Press Start")
-    sleep(60)
+    printYellow("I will now wait 30 seconds; you must navigate to the RCMS Page and Press Start")
+    sleep(30)
     amc.getNode("GEM_AMC.DAQ.CONTROL.ZERO_SUPPRESSION_EN").write(0x0)
     amc.dispatch()
     printGreen("Zero Suppression has been correctly disabled; happy data taking!!")
@@ -39,10 +48,9 @@ if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("ohMask",       help="ohMask to apply, a 1 in the n^th bit indicates the n^th OH should be considered", type=parseInt)
-    parser.add_argument("-s","--slot", help="Slot number",         type=int)
-    parser.add_argument("--shelf",     help="uTCA shelf number",   type=int)
-    parser.add_argument("-d",          help="debug",    action='store_true')
+    parser.add_argument("-s","--slotMask", help="Slot mask to apply, a 1 in the n^th bit indicates the n^th slot should be considered", type=parseInt)
+    parser.add_argument("--shelf", help="uTCA shelf number", type=int)
+    parser.add_argument("-d", help="debug", action='store_true')
 
     args = parser.parse_args()
 
@@ -55,8 +63,8 @@ if __name__ == '__main__':
 
     if args.d:
         print("Running checks")
-    if args.slot < 0 or args.slot > 12:
-        print("Invalid slot specified {}".format(args.slot))
+    if args.slotMask < 0x0 or args.slotMask > 0xfff:
+        printRed("Invalid slotMask specified 0x{0:x}\nslotMask must be in [0x0,0xfff]".format(args.slotMask))
         exit(os.EX_USAGE)
 
     if args.d:

--- a/gempython/utils/wrappers.py
+++ b/gempython/utils/wrappers.py
@@ -53,7 +53,7 @@ def runCommandWithOutput(cmd,log=None):
             msg+=" %s"%(c)
         logger.info(colormsg(msg,logging.INFO))
         sys.stdout.flush()
-        returnVal = subprocess.check_output(cmd,stdout=log,stderr=log)
+        returnVal = subprocess.check_output(cmd,stderr=log)
     except CalledProcessError as e:
         msg =  "Caught exception"
         msg+=str(e)

--- a/gempython/utils/wrappers.py
+++ b/gempython/utils/wrappers.py
@@ -4,12 +4,13 @@ def runCommand(cmd,log=None):
     Provides a wrapper around the subprocess.call command
     cmd should be an array of the form: ["command","arg1",...]
     log should specify a logfile to write to
+    returns the returncode of the process call
     """
 
-    import datetime,os,sys
+    import sys
     import subprocess
     from subprocess import CalledProcessError
-    from gempython.utils.gemlogger import colors,colormsg
+    from gempython.utils.gemlogger import colormsg
     import logging
     logger = logging.getLogger(__name__)
 
@@ -30,6 +31,39 @@ def runCommand(cmd,log=None):
         sys.stdout.flush()
         pass
     return returncode
+
+def runCommandWithOutput(cmd,log=None):
+    """
+    Provides a wrapper around the subprocess.check_output command
+    cmd should be an array of the form: ["command","arg1",...]
+    log should specify a logfile to write to
+    returns the output of the process as a byte string
+    """
+
+    import sys
+    import subprocess
+    from subprocess import CalledProcessError
+    from gempython.utils.gemlogger import colormsg
+    import logging
+    logger = logging.getLogger(__name__)
+
+    try:
+        msg = "Executing command:"
+        for c in cmd:
+            msg+=" %s"%(c)
+        logger.info(colormsg(msg,logging.INFO))
+        sys.stdout.flush()
+        returnVal = subprocess.check_output(cmd,stdout=log,stderr=log)
+    except CalledProcessError as e:
+        msg =  "Caught exception"
+        msg+=str(e)
+        msg+=" running:"
+        for c in cmd:
+            msg+=" %s"%(c)
+        logger.error(colormsg(msg,logging.ERROR))
+        sys.stdout.flush()
+        pass
+    return returnVal
 
 def envCheck(envVar):
     import os


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Several changes described below, quick summary here:

- Added a tool for writing the GBT phase to a particular (OH,VFAT).
- Added a method `programAllOptohybridFPGAs` to `HwAMC` for programming all OH's using the promless method,
- Added a method `getOHMask` for automatically determining an `ohMask` on an AMC to `HwAMC`
- All functions will by default try to automatically determine `ohMask` but retain the ability to be provided an `ohMask` as an input argument
- Added an exception if `HwAMC` determines that the `ohMask` should be 0 (e.g. all optohybrids are masked)
- Added a new wrapper command around `subprocess.check_output` to return outputs of commands to python.
- Many hardware constants or containers including hardware constants have been placed in a dedicated `hw_constants.py` file.
- Classes `HwOptohybrid` and `HwVFAT` now take input arguments called `gemType` and `detType` which are expected to define the element in the `gemVariants` dictionary (defined in `hw_constants.py`).
- Added a new exception `OHTypeException` if the provided (`gemType`,`detType`) to the `HwOptohybrid` or `HwVFAT` class is not found in the `gemVariants` dictionary.
- Added a new method to `HwOptohybrid` called `setType` which allows you to set the `gemType` and `detType` after construction.  Will raise an `OHTypeException` if the input arguments are not found in `gemVariants`.
- The tool `setDAQParamsPostConfigure.py` can now handle multiple AMC slots in a single call.  Usage has changed.

### New Tool: `writeGBTPhase.py`

This allows you to manually set the e-link phase of given (OH,VFAT).  Following help menu:

```bash
$ writeGBTPhase.py -h
usage: writeGBTPhase.py [-h] shelf slot link vfat phase

Tool for writing GBT phase for a single elink

positional arguments:
  shelf       uTCA shelf number
  slot        AMC slot number in the uTCA shelf
  link        OH number on the AMC
  vfat        VFAT number on the OH
  phase       GBT Phase Value to Write

optional arguments:
  -h, --help  show this help message and exit
```

With a usage example:

```
writeGBTPhase.py 1 4 2 17 3
```

Note that after the phase is written this tool will issue a link reset (`GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET`) to ensure the VFAT receives a sync command after the phase is written.

### HwAMC::programAllOptohybridFPGAs

Will make up to `maxIter` attempts to program the FPGA of all unmasked optohybrids. Before the first attempt the function will check on the AMC that the PROMLESS programming is enabled by reading `mpeek 0x6a000000` this should be `0x1`; if it isn't this will call `gemloader_configure.sh` on the AMC in question to enable the PROMLESS programming.

Then for each attempt the following procedure will be used:

1. `TTC.Generator` is enabled,
2. TTC Hard Reset is sent from the `TTC.Generator`,
3. Link reset (`GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET`) is sent,
4. Check if slow control with the unmasked OH FPGA's is possible by reading `FPGA.CONTROL.RELEASE.VERSION.MAJOR` and ensuring this is not `0xdeaddead`.

For all unmasked OH's that step 4 fails for the procedure will:

1. Turn of SCA Monitoring, 
2. Issue an SCA reset

Then steps 2-4 for the first part will be tried again.

Once the maximum number of iterations are reached or all OH's are programmed the `TTC.GENERATOR` will be disabled.

The method will return a list of OH's, out of `ohMask`, who after `maxIter` is performed are still unprogrammed. If all OH's in `ohMask` are programmed before `maxIter` is reached the procedure will exit and return an empty list.

```
maxIter- Maximum number of attempts to program all OH's in ohMask
ohMask - Mask which defines which OH's to query; 12 bit number where
         having a 1 in the N^th bit means to query the N^th optohybrid.
         If None will be determined automatically using HwAMC::getOHMask()
```

### Automatic Determination of `ohMask` with `HwAMC::getOHMask()`

All methods that take an `ohMask` argument (except `HwAMC::scaMonitorToggle()` since this is more like a link specific method) have had `ohMask` argument default changed to `None`.  If at runtime `ohMask` is None it will automatically determine the `ohMask` from bitwise operation on `SCA.READY` and `SCA.CRITICAL_ERROR`:

```python
(scaReady & (~scaError & 0xfff))
```

This will take those OH's whose `SCA.READY` ready bit as 0x1 and whose `SCA.CRITICAL_ERROR` bit is 0x0 and generate an `ohMask` from them.

This is not a breaking change since any calling function can just supply the `ohMask` argument with the mask desired.

### New wrapper function `runCommandWithOutput` around `subprocess.check_output`

Needed a new wrapper function to be able to store output from shell commands.

### Hardware Constants Moved to: `gempython/tools/hw_constants.py`

- The `maxVfat3DACSize` dictionary was moved from `amc_user_functions_xhal.py` to this file
- Added a `gemVariants` dictionary to map the type of GEM detector {`ge11`,`ge21`, `me0`} to the corresponding type of GEB/detector.
- Added a dictionary `vfatsPerGemVariant` to map the number of VFATs for each `gemVariant`.  Key values here match with key values of `gemVariants`.
- Added a constant that stores the GBT phase range `GBT_PHASE_RANGE`.
- Added a look-up table that stores the best guess of a "good" GBT e-link phase value for each `gemVariant` and GEB type.  This dictionary is used when a GBT phase scan determines all phases as good. 

### `setDAQParamsPostConfigure.py` Now Handles Multiple AMC's

New help menu with usage shown:

```bash
$ setDAQParamsPostConfigure.py -h
usage: setDAQParamsPostConfigure.py [-h] [-s SLOTMASK] [--shelf SHELF] [-d]

optional arguments:
  -h, --help            show this help message and exit
  -s SLOTMASK, --slotMask SLOTMASK
                        Slot mask to apply, a 1 in the n^th bit indicates the
                        n^th slot should be considered
  --shelf SHELF         uTCA shelf number
  -d                    debug

```

For each unmasked AMC the OH's to use for the `INPUT_ENABLE_MASK` on this AMC are determined automatically with the `HwAMC::getOHMask()` method.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Quality of life features and more robust programming of OH's on an AMC.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensively on QC7 setup.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
