### PR TITLE
Updates for legacy uhal info scripts

### DIFF
--- a/gempython/tests/amc_info_uhal.py
+++ b/gempython/tests/amc_info_uhal.py
@@ -75,7 +75,6 @@ print "BOARD_ID            0x%08x"%(readRegister(amc,"GEM_AMC.GEM_SYSTEM.BOARD_I
 print "BOARD_TYPE          0x%08x"%(readRegister(amc,"GEM_AMC.GEM_SYSTEM.BOARD_TYPE"))
 print "RELEASE             0x%08x"%(readRegister(amc,"GEM_AMC.GEM_SYSTEM.RELEASE"))
 print "NUM_OF_OH           0x%08x"%(readRegister(amc,"GEM_AMC.GEM_SYSTEM.CONFIG.NUM_OF_OH"))
-print "USE_GBT             0x%08x"%(readRegister(amc,"GEM_AMC.GEM_SYSTEM.CONFIG.USE_GBT"))
 print "USE_TRIG_LINKS      0x%08x"%(readRegister(amc,"GEM_AMC.GEM_SYSTEM.CONFIG.USE_TRIG_LINKS"))
 print
 print "--=======================================--"

--- a/gempython/tests/optohybrid_info_uhal.py
+++ b/gempython/tests/optohybrid_info_uhal.py
@@ -45,105 +45,20 @@ print "-> OH FW %10s  %10s"%("Version","Date")
 print "         %s%10s%s  %s%10s%s"%(colors.YELLOW,fwver,colors.ENDC,
                                      colors.YELLOW,date,colors.ENDC)
 print
-printSysmonInfo(ohboard,options.gtx)
-print
 print "Connected VFATs mask: 0x%08x"%(getConnectedVFATsMask(ohboard,options.gtx,options.debug))
-# print "VFATs s-bit mask:     0x%08x"%(getVFATsBitMask(ohboard,options.gtx,options.debug))
 setVFATsBitMask(ohboard,options.gtx,options.sbitmask,options.debug)
 print "VFATs s-bit mask:     0x%08x"%(getVFATsBitMask(ohboard,options.gtx,options.debug))
 print
 
-if options.clkSrc in [0,1,2]:
-    setReferenceClock(ohboard,options.gtx,options.clkSrc)
-    pass
-#print "-> OH VFATs accessible: 0x%x"%(readRegister(ohboard,"VFATs_TEST"))
-if options.trgSrc in [0,1,2,3,4]:
-    setTriggerSource(ohboard,options.gtx,options.trgSrc)
-    pass
-
-if options.localT1:
-    #configureLocalT1(ohboard,options.gtx,0x0,0x0,0,25,100)
-    sendL1ACalPulse(ohboard,options.gtx,15)
-    pass
-
-if options.sbitSrc in [1,2,3,4,5,6]:
-    setTriggerSBits(False,amc,options.gtx,options.sbitSrc)
-    pass
-
 clocking = getClockingInfo(ohboard,options.gtx)
-#OH:  TrgSrc  SBitSrc  FPGA PLL    EXT PLL    CDCE     GTX  RefCLKSrc
-#->:     0x0      0x0       0x0       0x0      0x1     0x1        0x1
-if options.v2a:
-    print "Sources:  %6s  %7s  %9s"%("TrgSrc","SBitSrc","RefCLKSrc")
-    print "             0x%x      0x%x        0x%x"%(
-            readRegister(ohboard,"GEM_AMC.OH.OH%d.CONTROL.TRIGGER.SOURCE"%(options.gtx)),
-            readRegister(ohboard,"GEM_AMC.OH.OH%d.CONTROL.HDMI_OUTPUT.SBITS"%(options.gtx)),
-            clocking["refclock"])
-
-    print "Lock status:  %8s  %7s  %4s  %3s"%("FPGA PLL","EXT PLL","CDCE","GTX")
-    print "                   0x%x      0x%x   0x%x  0x%x"%(
-            clocking["fpgaplllock"],
-            clocking["extplllock"],
-            clocking["cdcelock"],
-            clocking["gtxreclock"])
-    pass
-else:
-    print "Sources:  %6s  %7s  %9s"%("TrgSrc","SBitSrc","RefCLKSrc")
-    print "             0x%x      0x%x        0x%x"%(
-            readRegister(ohboard,"GEM_AMC.OH.OH%d.CONTROL.TRIGGER.SOURCE"%(options.gtx)),
-            readRegister(ohboard,"GEM_AMC.OH.OH%d.CONTROL.HDMI_OUTPUT.SBITS"%(options.gtx)),
-            clocking["refclock"])
-
-    print "Lock status:  %10s  %13s"%("QPLL","QPLL FPGA PLL")
-    print "                     0x%x            0x%x"%(
-            clocking["qplllock"],
-            clocking["qpllfpgaplllock"])
-    errorCounts = nesteddict()
-    errorCounts["QPLL"] = []
-    errorCounts["FPGA"] = []
-    for trial in range(options.errorRate):
-        errorCounts["QPLL"].append(calculateLockErrors(ohboard,options.gtx,"QPLL",SAMPLE_TIME))
-        errorCounts["FPGA"].append(calculateLockErrors(ohboard,options.gtx,"QPLL_FPGA_PLL",SAMPLE_TIME))
-        pass
-    qrates = getErrorRate(errorCounts["QPLL"],SAMPLE_TIME)
-    frates = getErrorRate(errorCounts["FPGA"],SAMPLE_TIME)
-    print "Unlock count: 0x%08x     0x%08x"%(qrates[0],frates[0])
-    print "Unlock rate:%10sHz   %10sHz"%("%2.2f%s"%(qrates[1],qrates[2]),"%2.2f%s"%(frates[1],frates[2]))
-print
-#print "-> OH Clocking (src, bkp):     VFAT         CDCE"
-#print "-> %22s%d       (0x%x  0x%x)   (0x%x  0x%x)"%("link",links[link],
-#						     clocking["vfatsrc"],clocking["vfatbkp"],
-#						     clocking["cdcesrc"],clocking["cdcebkp"])
-#exit(1)
-
-if (options.resetCounters):
-    optohybridCounters(ohboard,options.gtx,True)
-    pass
-
-print "-> Counters    %8s     %8s     %8s     %8s"%("L1A","Cal","Resync","BC0")
-counters = optohybridCounters(ohboard,options.gtx)
-for key in counters["T1"]:
-    print "   %8s  0x%08x   0x%08x   0x%08x   0x%08x"%(key,
-                                                       counters["T1"][key]["L1A"],
-                                                       counters["T1"][key]["CalPulse"],
-                                                       counters["T1"][key]["Resync"],
-                                                       counters["T1"][key]["BC0"])
-    pass
-
-print
-print "--=======================================--"
-print "-> OH: %10s  %12s"%("ErrCnt","(rate)")
-errorCounts = []
-for trial in range(options.errorRate):
-    errorCounts.append(calculateLinkErrors(ohboard,options.gtx,SAMPLE_TIME))
-    pass
-sys.stdout.flush()
-
-rates = errorRate(errorCounts,SAMPLE_TIME)
-#counters = optohybridCounters(ohboard,options.gtx)
-print "-> LINK: %8d  (%6.2f%1sHz)"%(rates["LINK"][0],rates["LINK"][1],rates["LINK"][2])
-print "-> GTX:  %8d  (%6.2f%1sHz)"%(rates["GTX"][0],rates["GTX"][1],rates["GTX"][2])
-print "-> GBT:  %8d  (%6.2f%1sHz)"%(rates["GBT"][0],rates["GBT"][1],rates["GBT"][2])
+print "Lock status:  %10s  %13s"%("GBT MMCM","LOGIC MMCM")
+print "                     0x%x            0x%x"%(
+    clocking["gbtmmcmlock"],
+    clocking["logicmmcmlock"])
+errorCounts = nesteddict()
+print "Unlock count: 0x%08x     0x%08x"%(
+    clocking["gbtmmcmlockcnt"],
+    clocking["logicmmcmlockcnt"])
 
 print
 print "--=======================================--"

--- a/gempython/tests/vfat_info_uhal.py
+++ b/gempython/tests/vfat_info_uhal.py
@@ -11,23 +11,16 @@ from gempython.utils.gemlogger import colors,getGEMLogger
 from gempython.utils.nesteddict import nesteddict
 from gempython.utils.standardopts import parser
 
-parser.add_option("-z", "--sleep", action="store_true", dest="sleepAll",
-		  help="set all chips into sleep mode", metavar="sleepAll")
-parser.add_option("--bias", action="store_true", dest="biasAll",
-		  help="set all chips with default bias parameters", metavar="biasAll")
+parser.add_option("--verbose", action="store_true", dest="verbose")
 parser.add_option("--enable", type="string", dest="enabledChips",
 		  help="list of chips to enable, comma separated", metavar="enabledChips", default=[])
-parser.add_option("--testi2c", type="int", dest="testi2c", default=-1,
-		  help="Testing the I2C lines (select I2C line 0-5, or 6 for all", metavar="testi2c")
-parser.add_option("--testsingle", action="store_true", dest="testsingle",
-		  help="Testing single VFAT transactions (turn on every other VFAT)", metavar="testsingle")
 
 (options, args) = parser.parse_args()
 
 gemlogger = getGEMLogger(__name__)
 gemlogger.setLevel(logging.INFO)
 
-uhal.setLogLevelTo( uhal.LogLevel.FATAL )
+uhal.setLogLevelTo(uhal.LogLevel.FATAL)
 
 chips = []
 if options.enabledChips:
@@ -38,13 +31,11 @@ if options.enabledChips:
 
 amc     = getAMCObject(options.slot,options.shelf,options.debug)
 ohboard = getOHObject(options.slot,options.gtx,options.shelf,options.debug)
-setOHLogLevel(logging.INFO)
-setOHLogLevel(logging.INFO)
-setAMCLogLevel(logging.INFO)
-setVFATLogLevel(logging.INFO)
-########################################
-# IP address
-########################################
+setOHLogLevel(logging.FATAL)
+setAMCLogLevel(logging.FATAL)
+setVFATLogLevel(logging.FATAL)
+setRegisterLogLevel(logging.FATAL)
+
 if options.debug and False:
     print
     print "--=======================================--"
@@ -73,13 +64,6 @@ if options.debug and False:
         # In units of 32-bits. All single registers and FIFOs have default size of 1
         msg = "Size (in units of 32-bits):", node.getSize()
         gemlogger.debug(msg)
-        # User-definable string from address table - in principle a comma separated list of values
-        #msg = "Tags:", node.getTags()
-        #gemlogger.debug(msg)
-        ## Map of user-definable, semicolon-delimited parameter=value pairs specified in the "parameters"
-        ##  xml address file attribute.
-        #msg = "Parameters:", node.getParameters()
-        #gemlogger.debug(msg)
         pass
     pass
 
@@ -88,12 +72,10 @@ print "--=======================================--"
 print
 
 ebmask = 0x000000ff
-
 vfats = []
 for gebslot in range(24):
     vfats.append("slot%d"%(gebslot+1))
 
-##time.sleep(5)
 emptyMask = 0xFFFF
 thechipid = 0x0000
 
@@ -103,111 +85,22 @@ print "OH      :  %10s  %10s"%(getFirmwareVersion(ohboard,options.gtx),
                                getFirmwareDateString(ohboard,options.gtx))
 
 controls = []
-chipmask = 0xff000000
-if options.testi2c > -1:
-    chipmask = 0xff000000
-    line = options.testi2c
-    while (True):
-        if line < 6:
-            for idx in range((line/2)*8,((line/2)+1)*8):
-                if (line%2):
-                    # 0  0-3
-                    # 1  4-7
-                    # 2  8-11
-                    # 3 12-15
-                    # 4 16-19
-                    # 5 20-23
-                    if (idx%8) > 3:
-                        print "VFAT%02d: 0x%08x"%(idx,getChipID(ohboard,options.gtx,idx))
-                        pass
-                    pass
-                else:
-                    if (idx%8) < 4:
-                        print "VFAT%02d: 0x%08x"%(idx,getChipID(ohboard,options.gtx,idx))
-                    pass
-                pass
-            pass
-        else:
-            print getAllChipIDs(ohboard, options.gtx, chipmask)
-            for idx in range(24):
-                # if (idx%8) > 3:
-                print "VFAT%02d: 0x%08x"%(idx,getChipID(ohboard,options.gtx,idx))
-                # pass
-                pass
-            pass
-        time.sleep(1)
-        pass
-    pass
-msg = "Trying to do a block read on all VFATs chipID0"
+chipmask = getConnectedVFATsMask(ohboard,options.gtx)
+msg = "Trying to do a block read on all VFATs HW_CHIP_ID"
 gemlogger.debug(msg)
 
 chipids = getAllChipIDs(ohboard, options.gtx, chipmask,options.debug)
 msg = chipids
 gemlogger.debug(msg)
 
-if options.biasAll:
-    biasAllVFATs(ohboard, options.gtx, chipmask)
-    pass
-if options.sleepAll:
-    for chip in range(24):
-        msg = "sleeping chip %d"%(chip)
-        gemlogger.info(msg)
-        setRunMode(ohboard, options.gtx, chip, False)
-        pass
-    pass
 for chip in chips:
     msg = "enabling chip %d"%(chip)
     gemlogger.info(msg)
     setRunMode(ohboard, options.gtx, chip, True)
     pass
 
-if options.testsingle:
-    print "Testing single VFAT transactions"
-    for vfat in range(24):
-        # if (vfat%2 == 0):
-        setRunMode(ohboard, options.gtx, chip=vfat, enable=False,debug=True)
-        # setRunMode(ohboard, options.gtx, chip=vfat, enable=True,debug=True)
-        # else:
-        #     setRunMode(ohboard, options.gtx, chip=vfat, enable=False,debug=True)
-        #     pass
-        pass
-    pass
-
-controlRegs = nesteddict()
-for control in range(4):
-    controls.append(readAllVFATs(ohboard, options.gtx, "ContReg%d"%(control), 0xf0000000, options.debug))
-    controlRegs["ctrl%d"%control] = dict(map(lambda chip: (chip, controls[control][chip]&0xff), range(0,24)))
-    pass
-displayChipInfo(ohboard, options.gtx, chipids)
-
-print "%6s  %6s  %02s  %02s  %02s  %02s"%("chip", "ID", "ctrl0", "ctrl1", "ctrl2", "ctrl3")
-for chip in chipids.keys():
-    if (int(chip)%8==0):
-        print "-------------GEB Column %d-----------------"%(int(chip)/8)
-        pass
-    print "%s%6s%s  %s0x%04x%s   0x%02x   0x%02x   0x%02x   0x%02x"%(colors.GREEN,chip,colors.ENDC,
-                                                                     colors.CYAN,chipids[chip],colors.ENDC,
-                                                                     controlRegs["ctrl0"][chip],
-                                                                     controlRegs["ctrl1"][chip],
-                                                                     controlRegs["ctrl2"][chip],
-                                                                     controlRegs["ctrl3"][chip])
-    pass
+displayChipInfo(ohboard, options.gtx, chipids, verbose=options.verbose, debug=options.debug)
 
 print
 print "--=======================================--"
 print
-
-print "--===== Last BX Latency Counter =========--"
-print
-counts = []
-# writeAllVFATs(ohboard, options.gtx, "VThreshold1", 100)
-for i in range(24):
-    baseNode = "GEM_AMC.OH.OH%d.COUNTERS"%(options.gtx)
-    writeRegister(ohboard,"%s.VFAT%d_LAT_BX.RESET"%(baseNode,i),0x1)
-    # time.sleep(0.1*(test+1))
-for i in range(24):
-    baseNode = "GEM_AMC.OH.OH%d.COUNTERS"%(options.gtx)
-    counts.append(readRegister(ohboard,"%s.VFAT%d_LAT_BX"%(baseNode,i)))
-    # print ('  '.join(map(str,map(lambda vfat: (vfat, "%d"%counts[vfat]), range(0,24)))))
-for i in range(24):
-    print "VFAT%02d  %d"%(i,counts[i])

--- a/gempython/tools/amc_user_functions_uhal.py
+++ b/gempython/tools/amc_user_functions_uhal.py
@@ -69,7 +69,7 @@ def glibCounters(device,gtx,doReset=False):
         return
     else:
         counters = nesteddict()
-        
+
         for ipbcnt in ["Strobe","Ack"]:
             for ipb in ["OptoHybrid","TRK"]:
                 counters["IPBus"][ipbcnt][ipb] = readRegister(device,"%s.IPBus.%s.%s_%d"%(   baseNode, ipbcnt,ipb,gtx))
@@ -92,7 +92,7 @@ def readTrackingInfo(device,gtx,nBlocks=1):
     """
     baseNode = "GLIB.TRK_DATA.OptoHybrid_%d"%(gtx)
     data = readBlock(device,"%s.FIFO"%(baseNode),7*nBlocks)
-    
+
     #for word in data:
     #    msg = "%s: 0x%08x"%(word,data)
     #    amclogger.info(colormsg(msg,logging.INFO))
@@ -117,7 +117,7 @@ def readFIFODepth(device,gtx):
     data["isEMPTY"]   = readRegister(device,"%s.ISEMPTY"%(baseNode))
     data["Occupancy"] = readRegister(device,"%s.DEPTH"%(baseNode))
     return data
-        
+
 def setTriggerSBits(isGLIB,device,gtx,source):
     """
     Set the trigger sbit source
@@ -143,7 +143,7 @@ def resetDAQLink(device):
     """
     Reset the DAQ link
     """
-    
+
     writeRegister(device,"GEM_AMC.DAQ.CONTROL.DAQ_LINK_RESET",0x1)
     writeRegister(device,"GEM_AMC.DAQ.CONTROL.DAQ_LINK_RESET",0x0)
     pass
@@ -157,7 +157,7 @@ def enableDAQLink(device, linkEnableMask=0x1, doReset=False):
     amclogger.info(colormsg(msg,logging.INFO))
     if (doReset):
         resetDAQLink(device)
-        
+
     writeRegister(device, "GEM_AMC.DAQ.CONTROL.DAQ_ENABLE",        0x1)
     writeRegister(device, "GEM_AMC.DAQ.CONTROL.TTS_OVERRIDE",      0x8)
     writeRegister(device, "GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK", linkEnableMask)
@@ -181,26 +181,18 @@ def printSystemTTCInfo(amc,debug=False):
     print "-> GEM SYSTEM TTC INFORMATION"
     print "--=======================================--"
     print
-    mmcmLck      = readRegister(amc,"GEM_AMC.TTC.STATUS.CLK.MMCM_LOCKED")
-    mmcmULckCnt  = readRegister(amc,"GEM_AMC.TTC.STATUS.CLK.MMCM_UNLOCK_CNT")
-    phaseLck     = readRegister(amc,"GEM_AMC.TTC.STATUS.CLK.PHASE_LOCKED")
-    phaseULckCnt = readRegister(amc,"GEM_AMC.TTC.STATUS.CLK.PHASE_UNLOCK_CNT")
-    bc0Lck       = readRegister(amc,"GEM_AMC.TTC.STATUS.BC0.LOCKED")
-    bc0ULckCnt   = readRegister(amc,"GEM_AMC.TTC.STATUS.BC0.UNLOCK_CNT")
-    syncDone     = readRegister(amc,"GEM_AMC.TTC.STATUS.CLK.SYNC_DONE")
+    mmcmLck      = readRegister(amc,"GEM_AMC.TTC.STATUS.MMCM_LOCKED")
+    mmcmULckCnt  = readRegister(amc,"GEM_AMC.TTC.STATUS.MMCM_UNLOCK_CNT")
     ttcSglErrCnt = readRegister(amc,"GEM_AMC.TTC.STATUS.TTC_SINGLE_ERROR_CNT")
     ttcDblErrCnt = readRegister(amc,"GEM_AMC.TTC.STATUS.TTC_DOUBLE_ERROR_CNT")
+    bc0Lck       = readRegister(amc,"GEM_AMC.TTC.STATUS.BC0.LOCKED")
+    bc0ULckCnt   = readRegister(amc,"GEM_AMC.TTC.STATUS.BC0.UNLOCK_CNT")
     bc0OflwCnt   = readRegister(amc,"GEM_AMC.TTC.STATUS.BC0.OVERFLOW_CNT")
     bc0UflwCnt   = readRegister(amc,"GEM_AMC.TTC.STATUS.BC0.UNDERFLOW_CNT")
     print("BC0.LOCKED           %s0x%08x%s"%(colors.GREEN if bc0Lck           else colors.RED,bc0Lck,colors.ENDC))
     print("MMCM_LOCKED          %s0x%08x%s"%(colors.GREEN if mmcmLck          else colors.RED,mmcmLck,colors.ENDC))
-    print("PHASE_LOCKED         %s0x%08x%s"%(colors.GREEN if phaseLck         else colors.RED,phaseLck,colors.ENDC))
-    print("SYNC_DONE            %s0x%08x%s"%(colors.GREEN if syncDone         else colors.RED,syncDone,colors.ENDC))
-    print("MMCM_UNLOCK_CNT      %s0x%08x%s"%(colors.RED   if mmcmULckCnt > 0  else colors.GREEN,mmcmULckCnt,colors.ENDC))
     print("BC0.UNLOCK_CNT       %s0x%08x%s"%(colors.RED   if bc0ULckCnt > 0   else colors.GREEN,bc0ULckCnt,colors.ENDC))
-    print("PHASE_UNLOCK_CNT     %s0x%08x%s"%(colors.RED   if phaseULckCnt > 0 else colors.GREEN,phaseULckCnt,colors.ENDC))
-    print("PHASE_UNLOCK_TIME    %s0x%08x%s"%(colors.BLUE,readRegister(amc,"GEM_AMC.TTC.STATUS.CLK.PHASE_UNLOCK_TIME"),colors.ENDC))
-    print("SYNC_DONE_TIME       %s0x%08x%s"%(colors.BLUE,readRegister(amc,"GEM_AMC.TTC.STATUS.CLK.SYNC_DONE_TIME"   ),colors.ENDC))
+    print("MMCM_UNLOCK_CNT      %s0x%08x%s"%(colors.RED   if mmcmULckCnt > 0  else colors.GREEN,mmcmULckCnt,colors.ENDC))
     print("TTC_SINGLE_ERROR_CNT %s0x%08x%s"%(colors.GREEN if ttcSglErrCnt == 0  else colors.YELLOW if ttcSglErrCnt < 0xffff else colors.RED,ttcSglErrCnt,colors.ENDC))
     print("TTC_DOUBLE_ERROR_CNT %s0x%08x%s"%(colors.GREEN if ttcDblErrCnt == 0  else colors.YELLOW if ttcDblErrCnt < 0xffff else colors.RED,ttcDblErrCnt,colors.ENDC))
     print("BC0.OVERFLOW_CNT     %s0x%08x%s"%(colors.GREEN if bc0OflwCnt == 0  else colors.YELLOW if bc0OflwCnt < 0xffff else colors.RED,bc0OflwCnt,colors.ENDC))

--- a/gempython/tools/hw_constants.py
+++ b/gempython/tools/hw_constants.py
@@ -9,6 +9,11 @@ vfatsPerGemVariant = {
             "ge21":12,
             "me0":24}
 
+gbtsPerGemVariant = {
+            "ge11":3,
+            "ge21":1,
+            "me0":0}
+
 # Size of VFAT3 DAC's
 maxVfat3DACSize = {
         #ADC Measures Current

--- a/gempython/tools/vfat_user_functions_uhal.py
+++ b/gempython/tools/vfat_user_functions_uhal.py
@@ -12,29 +12,11 @@ def setVFATLogLevel(level):
     vfatlogger.setLevel(level)
     pass
 
-class parameters:
-    defaultValues = {
-        "ContReg1":    0x00,
-        "ContReg2":    0x30,
-        "ContReg3":    0x00,
-        "Latency":      169,
-        "IPreampIn":    144,
-        "IPreampFeed":   69,
-        "IPreampOut":   129,
-        "IShaper":      130,
-        "IShaperFeed":   87,
-        "IComp":        101,
-        "VCal":           0,
-        # ["VThreshold1":   25,
-        "VThreshold2": 0x00,
-        "CalPhase":    0x00
-        }
-
 class VFATException(Exception):
     pass
 
 def readVFAT(device, gtx, chip, reg, debug=False):
-    baseNode = "GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d"%(gtx,chip)
+    baseNode = "GEM_AMC.OH.OH%d.GEB.VFAT%d"%(gtx,chip)
     vfatVal = readRegister(device,"%s.%s"%(baseNode,reg),debug)
     # do check on status
     if ((vfatVal >> 26) & 0x1) :
@@ -79,11 +61,11 @@ def readAllVFATs(device, gtx, reg, mask=0x0, debug=False):
     return vfatVals
 
 def writeVFAT(device, gtx, chip, reg, value, debug=False):
-    baseNode = "GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d"%(gtx,chip)
+    baseNode = "GEM_AMC.OH.OH%d.GEB.VFAT%d"%(gtx,chip)
     writeRegister(device,"%s.%s"%(baseNode,reg), value, debug)
 
 def writeVFATRegisters(device, gtx, chip, regs_with_values, debug=False):
-    baseNode = "GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d"%(gtx,chip)
+    baseNode = "GEM_AMC.OH.OH%d.GEB.VFAT%d"%(gtx,chip)
     registers = nesteddict()
     for reg in regs_with_values.keys():
         registers["%s.%s"%(baseNode,reg)] = regs_with_values[reg]
@@ -91,7 +73,7 @@ def writeVFATRegisters(device, gtx, chip, regs_with_values, debug=False):
     writeRegisterList(device,registers)
 
 def readVFATRegisters(device, gtx, chip, regs, debug=False):
-    baseNode = "GEM_AMC.OH.OH%d.GEB.VFATS.VFAT%d"%(gtx,chip)
+    baseNode = "GEM_AMC.OH.OH%d.GEB.VFAT%d"%(gtx,chip)
     registers = []
     for reg in regs:
         registers.append("%s.%s"%(baseNode,reg))
@@ -101,240 +83,133 @@ def readVFATRegisters(device, gtx, chip, regs, debug=False):
 def writeAllVFATs(device, gtx, reg, value, mask=0x0, debug=False):
     broadcastWrite(device,gtx,reg,value,mask,debug)
 
-def setupDefaultCRs(device, gtx, chip, sleep=False, debug=False):
-    registers = {
-        "ContReg1": 0x00,
-        "ContReg2": 0x30,
-        "ContReg3": 0x00
-        }
-    if not sleep:
-        registers["ContReg0"]= 0x36
-    else:
-        registers["ContReg0"]= 0x37
-        pass
-    writeVFATRegisters(device, gtx, chip, registers)
-    return
-
 def setRunMode(device, gtx, chip, enable, debug=False):
-    regVal = readVFAT(device, gtx, chip, "ContReg0",debug)
+    regVal = readVFAT(device, gtx, chip, "CFG_RUN",debug)
     if (enable):
-        msg = "%s: Enabling VFAT%02d - Current CR0 value 0x%02x setting to 0x%02x"%(device,chip,regVal,((0xff&regVal)|0x1))
+        msg = "%s: Enabling VFAT%02d - Current CFG_RUN value 0x%02x setting to 0x%02x"%(device,chip,regVal,((0xff&regVal)|0x1))
         vfatlogger.debug(colormsg(msg,logging.DEBUG))
-        writeVFAT(device, gtx, chip, "ContReg0", ((0xff&regVal)|0x01),debug)
+        writeVFAT(device, gtx, chip, "CFG_RN", ((0xff&regVal)|0x01),debug)
     else:
-        msg = "%s: Disabling VFAT%02d - Current CR0 value 0x%02x setting to 0x%02x"%(device,chip,regVal,((0xff&regVal)&0xfe))
+        msg = "%s: Disabling VFAT%02d - Current CFG_RUN value 0x%02x setting to 0x%02x"%(device,chip,regVal,((0xff&regVal)&0xfe))
         vfatlogger.debug(colormsg(msg,logging.DEBUG))
-        writeVFAT(device, gtx, chip, "ContReg0", ((0xff&regVal)&0xfe),debug)
+        writeVFAT(device, gtx, chip, "CFG_RUN", ((0xff&regVal)&0xfe),debug)
         pass
 
-    msg = "%s: VFAT%02d CR0 is now 0x%02x"%(device,chip,readVFAT(device, gtx, chip, "ContReg0",debug))
+    msg = "%s: VFAT%02d CFG_RUN is now 0x%02x"%(device,chip,readVFAT(device, gtx, chip, "CFG_RUN",debug))
     vfatlogger.debug(colormsg(msg,logging.DEBUG))
     return
 
-def setChannelRegister(device, gtx, chip, chan,
-                       mask=0x0, pulse=0x0, trim=0x0, debug=False):
-    if (chan not in range(0,128)):
-        msg = "%s: Invalid VFAT channel specified %d"%(device,chan)
-        vfatlogger.warning(colormsg(msg,logging.WARNING))
-        raise VFATException(colormsg(msg,logging.FATAL))
-    chanReg = ((pulse&0x1) << 6)|((mask&0x1) << 5)|(trim&0x1f)
-    writeVFAT(device, gtx, chip, "VFATChannels.ChanReg%d"%(chan),chanReg)
-    return
-
-def setChannelRegister(device, gtx, chip, chan,
-                       chanreg, debug=False):
-    if (chan not in range(0,128)):
-        msg = "%s: Invalid VFAT channel specified %d"%(device,chan)
-        vfatlogger.warning(colormsg(msg,logging.WARNING))
-        raise VFATException(colormsg(msg,logging.FATAL))
-    writeVFAT(device, gtx, chip, "VFATChannels.ChanReg%d"%(chan),chanreg)
-    return
-
-def getChannelRegister(device, gtx, chip, chan, debug=False):
-    if (chan not in range(0,128)):
-        msg = "%s: Invalid VFAT channel specified %d"%(device,chan)
-        vfatlogger.warning(colormsg(msg,logging.WARNING))
-        raise VFATException(colormsg(msg,logging.FATAL))
-    return readVFAT(device, gtx, chip, "VFATChannels.ChanReg%d"%(chan))
-
-def setAllChannelRegisters(device, gtx, chan,
-                           mask=0x0, pulse=0x0, trim=0x0,
-                           chipmask=0x0, debug=False):
-    if (chan not in range(0,128)):
-        msg = "%s: Invalid VFAT channel specified %d"%(device,chan)
-        vfatlogger.warning(colormsg(msg,logging.WARNING))
-        raise VFATException(colormsg(msg,logging.FATAL))
-    chanReg = ((pulse&0x1) << 6)|((mask&0x1) << 5)|(trim&0x1f)
-    writeAllVFATs(device, gtx, "VFATChannels.ChanReg%d"%(chan), chanReg, mask, debug)
-    return
-
-def setAllChannelRegisters(device, gtx, chan, chanreg,
-                           chipmask=0x0, debug=False):
-    if (chan not in range(0,128)):
-        msg = "%s: Invalid VFAT channel specified %d"%(device,chan)
-        vfatlogger.warning(colormsg(msg,logging.WARNING))
-        raise VFATException(colormsg(msg,logging.FATAL))
-    writeAllVFATs(device, gtx, "VFATChannels.ChanReg%d"%(chan), chanreg, chipmask, debug)
-    return
-
-def getAllChannelRegisters(device, gtx, chan, mask=0x0, debug=False):
-    if (chan not in range(0,128)):
-        msg = "%s: Invalid VFAT channel specified %d"%(device,chan)
-        vfatlogger.warning(colormsg(msg,logging.WARNING))
-        raise VFATException(colormsg(msg,logging.FATAL))
-    return readAllVFATs(device, gtx, "VFATChannels.ChanReg%d"%(chan), mask, debug)
-
-def setVFATThreshold(device, gtx, chip, vt1, vt2=0, debug=False):
-    writeVFATRegisters(device, gtx, chip,
-                       {"VThreshold1": vt1,
-                        "VThreshold2": vt2
-                        })
-    return
-
-def getVFATThreshold(device, gtx, chip, vt1, vt2=0, debug=False):
-    thresholds = readVFATRegisters(device, gtx, chip, ["VThreshold1","VThreshold2"])
-    vt1 = 0
-    vt2 = 0
-    for reg in thresholds.keys():
-        if (reg.find("VThreshold1") > 0):
-            vt1 = thresholds[reg]
-        elif (reg.find("VThreshold2") > 0):
-            vt2 = thresholds[reg]
-            pass
-        pass
-    return vt2-v21
-
-def biasVFAT(device, gtx, chip, enable=True, zeroChannels=False, debug=False):
-    registers = parameters.defaultValues
-
-    if (enable):
-        registers["ContReg0"] = 0x37
-    else:
-        #what about leaving any other settings?
-        #not now, want a reproducible routine
-        registers["ContReg0"] = 0x36
-        pass
-
-    if zeroChannels:
-        # zeroAllChannels(device,gtx,chip,deubg)
-        for chan in range(128):
-            # mask no channels, as this seems to affect the output data packets, not just the triggers
-            # disable cal pulses to all channels
-            registers["VFATChannels.ChanReg%d"%(chan)] = 0x00
-            pass
-        pass
-    writeVFATRegisters(device,gtx,chip,registers)
-    return
-
-def biasAllVFATs(device, gtx, mask=0x0, enable=True, zeroChannels=False, debug=False):
-    if (enable):
-        writeAllVFATs(device, gtx, "ContReg0",    0x37, mask=mask)
-    else:
-        #what about leaving any other settings?
-        #not now, want a reproducible routine
-        writeAllVFATs(device, gtx, "ContReg0",    0x36, mask=mask)
-        pass
-    writeAllVFATs(device, gtx, "ContReg1",    parameters.defaultValues["ContReg1"   ], mask=mask)
-    writeAllVFATs(device, gtx, "ContReg2",    parameters.defaultValues["ContReg2"   ], mask=mask)
-    # ContReg3 contains the trimDAC range, so will be different from VFAT2 to VFAT2
-    # writeAllVFATs(device, gtx, "ContReg3",    parameters.defaultValues["ContReg3"   ], mask=mask)
-    writeAllVFATs(device, gtx, "Latency",     parameters.defaultValues["Latency"    ], mask=mask)
-    writeAllVFATs(device, gtx, "IPreampIn",   parameters.defaultValues["IPreampIn"  ], mask=mask)
-    writeAllVFATs(device, gtx, "IPreampFeed", parameters.defaultValues["IPreampFeed"], mask=mask)
-    writeAllVFATs(device, gtx, "IPreampOut",  parameters.defaultValues["IPreampOut" ], mask=mask)
-    writeAllVFATs(device, gtx, "IShaper",     parameters.defaultValues["IShaper"    ], mask=mask)
-    writeAllVFATs(device, gtx, "IShaperFeed", parameters.defaultValues["IShaperFeed"], mask=mask)
-    writeAllVFATs(device, gtx, "IComp",       parameters.defaultValues["IComp"      ], mask=mask)
-    writeAllVFATs(device, gtx, "VCal",        parameters.defaultValues["VCal"       ], mask=mask)
-    # writeAllVFATs(device, gtx, "VThreshold1", parameters.defaultValues["VThreshold1"], mask=mask)
-    writeAllVFATs(device, gtx, "VThreshold2", parameters.defaultValues["VThreshold2"], mask=mask)
-    writeAllVFATs(device, gtx, "CalPhase",    parameters.defaultValues["CalPhase"   ], mask=mask)
-
-    if zeroChannels:
-        zeroAllVFATChannels(device,gtx,mask=mask,debug=debug)
-        pass
-    return
-
-def zeroAllVFATChannels(device,gtx,mask=0x0,debug=False):
-    msg = "%s: Zeroing channel registers on all VFATs"%(device)
-    vfatlogger.debug(colormsg(msg,logging.DEBUG))
-    for chan in range(128):
-        setAllChannelRegisters(device,gtx,chan,chanreg=0x0,chipmask=mask,debug=debug)
-    return
-
-def zeroAllChannels(device,gtx,chip,debug=False):
-    msg = "%s: Zeroing channel registers on VFAT%02d"%(device,chip)
-    vfatlogger.debug(colormsg(msg,logging.DEBUG))
-    for chan in range(128):
-        setChannelRegister(device,gtx,chip,chan,chanreg=0x0,debug=debug)
-    return
+def decodeChipID(chipID):
+    from subprocess import check_output
+    dec = "0x{:08x}"
+    try:
+        retVal = check_output(["rmdecode","2","5",dec.format(chipID)])
+        return int(retVal,16)
+    except Exception as e:
+        print("Unable to decode 0x{:08x}".format(chipID),e)
+        return chipID
 
 def getChipID(device, gtx, chip, debug=False):
-    thechipid = 0x0000
-    emptyMask = 0xffff
-    ebmask = 0x000000ff
-    thechipid  = readVFAT(device, gtx, chip, "ChipID1")
-    if (thechipid < 0):
-        thechipid = 0xdead
-    elif (((thechipid>>16)&emptyMask) != ((0x050<<4)+(chip))):
-        thechipid  = (thechipid & ebmask)<<8
-        thechipid |= (readVFAT(device, gtx, chip, "ChipID0") & ebmask)
-    else:
-        thechipid = 0xdead
-        pass
-
-    return thechipid
+    return(decodeChipID(readVFAT(device, gtx, chip, "HW_CHIP_ID")))
 
 def getAllChipIDs(device, gtx, mask=0xff000000, debug=False):
     """Returns a map of slot number to chip ID, for chips enabled in the mask
     Currently does not only return the unmasked values, but all values
     To be fixed in a future version"""
-    chipID0s = readAllVFATs(device, gtx, "ChipID0", mask, debug)
-    chipID1s = readAllVFATs(device, gtx, "ChipID1", mask, debug)
-    ##make unknown chips report 0xdead
-    return dict(map(lambda slotID: (slotID, (((chipID1s[slotID])&0xff)<<8)|(chipID0s[slotID]&0xff)
-                                    #if (((chipID1s[slotID]>>16)&0xffff) != ((0x050<<4)+(slotID))) else 0xdead),
-                                    if (((chipID1s[slotID]>>16)&0xffff) == 0x0000) else 0xdead),
+    chipIDs = readAllVFATs(device, gtx, "HW_CHIP_ID", mask, debug)
+
+    return dict(map(lambda slotID: (slotID, decodeChipID(chipIDs[slotID])),
                     range(0,24)))
 
-def displayChipInfo(device, gtx, regkeys, mask=0xff000000, debug=False):
+def displayChipInfo(device, gtx, regkeys, mask=0xff000000, verbose=False, debug=False):
     """Takes as an argument a map of slot number to chip IDs and prints
     out all the information for the selected chips, would like for 0xdead
     chips to be red, but don't have time to really do this now """
-    slotbase = "GEB%d SlotID::"%(gtx)
-    base     = "     ChipID::"
-    perslot  = "%3d"
-    perchip  = "0x%04x"
-    perreg   = "0x%02x"
-    perset   = "%4d"
-    registerList = {perreg: ["ContReg0","ContReg1","ContReg2","ContReg3"],
-                    perset: [
-            "Latency",
-            "IPreampIn","IPreampFeed","IPreampOut",
-            "IShaper","IShaperFeed",
-            "IComp",
-            "VCal",
-            "VThreshold1",
-            "VThreshold2",
-            "CalPhase",
-            ]
-                    }
+    slotbase = "GEB{:d} SlotID".format(gtx)
+    base     =  "     ChipID"
+    perslot  = "{:6d}"
+    perchip  = "{:6d}"
+    perreg   = "0x{:04x}"
+    perset   = "{:6d}"
+    registerList = {
+        perset: [
+            #"CFG_{:d}".format(x) for x in range(17)
+            "CFG_PULSE_STRETCH",
+            "CFG_FP_FE",
+            "CFG_RES_PRE",
+            "CFG_CAP_PRE",
+            "CFG_PT",
+            "CFG_EN_HYST",
+            "CFG_SEL_POL",
+            "CFG_SEL_COMP_MODE",
+            "CFG_IREF",
+            "CFG_THR_ARM_DAC",
+            "CFG_HYST",
+            "CFG_LATENCY",
+            "CFG_CAL_SEL_POL",
+            "CFG_CAL_DAC",
+            "CFG_CAL_MODE",
+            "CFG_CAL_FS",
+            "CFG_CAL_DUR",
+            "CFG_BIAS_CFD_DAC_2",
+            "CFG_BIAS_CFD_DAC_1",
+            "CFG_BIAS_PRE_I_BSF",
+            "CFG_BIAS_PRE_I_BIT",
+            "CFG_BIAS_PRE_I_BLCC",
+            "CFG_BIAS_PRE_VREF",
+            "CFG_BIAS_SH_I_BFCAS",
+            "CFG_BIAS_SH_I_BDIFF",
+            "CFG_BIAS_SH_I_BFAMP",
+            "CFG_BIAS_SD_I_BDIFF",
+            "CFG_BIAS_SD_I_BSF",
+            "CFG_BIAS_SD_I_BFCAS",
+            "CFG_RUN",
+        ],
+        perreg: []
+    }
+    disabled = [
+        "CFG_SYNC_LEVEL_MODE",
+        "CFG_SELF_TRIGGER_MODE",
+        "CFG_DDR_TRIGGER_MODE",
+        "CFG_SPZS_SUMMARY_ONLY",
+        "CFG_SPZS_MAX_PARTITIONS",
+        "CFG_SPZS_ENABLE",
+        "CFG_SZP_ENABLE",
+        "CFG_SZD_ENABLE",
+        "CFG_TIME_TAG",
+        "CFG_EC_BYTES",
+        "CFG_BC_BYTES",
+        "CFG_FORCE_TH",
+        "CFG_CAL_EXT",
+    ]
+    verboseRegs = [
+        "CFG_FORCE_EN_ZCC",
+        "CFG_VREF_ADC",
+        "CFG_MON_GAIN",
+        "CFG_MONITOR_SELECT",
+        "CFG_THR_ZCC_DAC",
+        "CFG_CAL_PHI",
+    ]
 
-    slotmap = map(lambda slotID: perslot%(slotID), regkeys.keys())
-    msg = "%s   %s%s%s"%(slotbase,colors.GREEN,'    '.join(map(str, slotmap)),colors.ENDC)
-    # vfatlogger.info(colormsg(msg,logging.INFO))
+    if verbose:
+        registerList[perset] += verboseRegs
+
+    MAX_HEADER = len(max(registerList[perset]+registerList[perreg],key=len))
+    msghdr = "{{:{}s}}::".format(MAX_HEADER)
+
+    slotmap = map(lambda slotID: perslot.format(slotID), regkeys.keys())
+    msg = "{:s}{:s}{:s}{:s}".format(msghdr.format(slotbase),colors.GREEN,' '.join(map(str, slotmap)),colors.ENDC)
+
     print(msg)
-    chipmap = map(lambda chipID: perchip%(regkeys[chipID]), regkeys.keys())
-    msg = "%s%s%s%s"%(base,colors.CYAN,' '.join(map(str, chipmap)),colors.ENDC)
-    # vfatlogger.info(colormsg(msg,logging.INFO))
+    chipmap = map(lambda chipID: perchip.format(regkeys[chipID]), regkeys.keys())
+    msg = "{:s}{:s}{:s}{:s}".format(msghdr.format(base),colors.CYAN,' '.join(map(str, chipmap)),colors.ENDC)
+
     print(msg)
     for key in registerList:
         for reg in registerList[key]:
-            # regmap = map(lambda chip: perreg%(readVFAT(device, gtx, chip,reg)&0xff), regkeys.keys())
             regValues = readAllVFATs(device, gtx, reg, mask, debug)
-            regmap = map(lambda chip: key%(chip&0xff), regValues)
-            msg = "%11s::  %s"%(reg, '   '.join(map(str, regmap)))
-            # vfatlogger.info(colormsg(msg,logging.INFO))
+            regmap = map(lambda chip: key.format(chip&0xffff), regValues)
+            msg = "{:s}{:s}".format(msghdr.format(reg), ' '.join(map(str, regmap)))
             print(msg)
             pass
         pass

--- a/gempython/utils/registers_uhal.py
+++ b/gempython/utils/registers_uhal.py
@@ -46,12 +46,12 @@ address 0x%08x  mask 0x%08x  permission %s  mode 0x%08x  size 0x%08x
             controlChar = device.getNode(register).read()
             device.dispatch()
             return controlChar
-        except uhal.exception, e:
+        except uhal.exception as e:
             nRetries += 1
             gRetries += 1
             if ((nRetries % 10) == 1):
                 msg = "%s: read (%s) error encountered (%s), retrying operation (%d,%d)"%(device,register,str(e),nRetries,gRetries)
-                reglogger.warning(msg)
+                reglogger.debug(msg)
                 continue
         pass
 
@@ -78,8 +78,10 @@ def readRegisterList(device, registers, debug=False):
     while (nRetries < gMAX_RETRIES):
         try:
             results = nesteddict()
-            for reg in registers:
+            for i,reg in enumerate(registers):
                 results[reg] = device.getNode(reg).read()
+                if (i % 5 == 4):
+                    device.dispatch()
                 pass
             msg = "%s\n"%(device)
             if (debug):
@@ -102,9 +104,9 @@ def readRegisterList(device, registers, debug=False):
 
             return results
 
-        except uhal.exception, e:
+        except uhal.exception as e:
             msg ="%s: read error encountered (%s), retrying operation (%d,%d)"%(device,str(e),nRetries,gRetries),
-            reglogger.warning(msg)
+            reglogger.debug(msg)
             nRetries += 1
             gRetries += 1
             if ((nRetries % 10) == 1):
@@ -154,7 +156,7 @@ address 0x%08x  mask 0x%08x  permission %s  mode 0x%08x  size 0x%08x
 
             return words
         # want to be able to return nothing in the result of a failed transaction
-        except uhal.exception, e:
+        except uhal.exception as e:
             nRetries += 1
             gRetries += 1
             # if ('amount of data' in e):
@@ -167,12 +169,12 @@ address 0x%08x  mask 0x%08x  permission %s  mode 0x%08x  size 0x%08x
             #     print colors.MAGENTA, "other error",register, "-> Error : ", e, colors.ENDC
             if ((nRetries % 10) == 1):
                 msg = "%s: read (%s) error encountered (%s), retrying operation (%d,%d)"%(device,register,str(e),nRetries,gRetries)
-                reglogger.warning(msg)
+                reglogger.debug(msg)
             continue
         pass
     msg = "%s: error encountered, retried read operation (%d)"%(device,nRetries)
     reglogger.error(msg)
-    
+
     return []
 
 def writeRegister(device, register, value, debug=False):
@@ -201,7 +203,7 @@ address 0x%08x  mask 0x%08x  permission %s  mode 0x%08x  size 0x%08x
             device.dispatch()
             return
 
-        except uhal.exception, e:
+        except uhal.exception as e:
             # if ('amount of data' in e):
             #     print colors.BLUE, "bad header",register, "-> Error : ", e, colors.ENDC
             # elif ('INFO CODE = 0x4L' in e):
@@ -214,7 +216,7 @@ address 0x%08x  mask 0x%08x  permission %s  mode 0x%08x  size 0x%08x
             gRetries += 1
             if ((nRetries % 10) == 1) and debug:
                 msg = "%s: write (%s) error encountered (%s), retrying operation (%d,%d)"%(device,register,str(e),nRetries,gRetries)
-                reglogger.warning(msg)
+                reglogger.debug(msg)
                 pass
             continue
         pass
@@ -233,19 +235,20 @@ def writeRegisterList(device, regs_with_vals, debug=False):
     nRetries = 0
     while (nRetries < gMAX_RETRIES):
         try:
-            for reg in regs_with_vals.keys():
+            for i,reg in enumerate(regs_with_vals.keys()):
                 device.getNode(reg).write(0xffffffff&regs_with_vals[reg])
-                # device.dispatch()
+                if (i % 5 == 4):
+                    device.dispatch()
                 pass
             device.dispatch()
             return
 
-        except uhal.exception, e:
+        except uhal.exception as e:
             msg = "%s: write error encountered ["%(device)
             for reg in regs_with_vals:
                 msg+= "%s:0x%x,"%(reg,regs_with_vals[reg])
             msg+= "], (%s) retrying operation (%d,%d)"%(str(e),nRetries,gRetries)
-            reglogger.warning(msg)
+            reglogger.debug(msg)
             nRetries += 1
             gRetries += 1
             if ((nRetries % 10) == 1) and debug:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

### Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
#279 
##### Changes to `amc_user_functions_xhal.py`
When running `testConnectivity.py` one will now see:
```
--=======================================--
-> GEM SYSTEM TRIGGER LINK INFORMATION
--=======================================--

                        |  OH9
LINK0_MISSED_COMMA_CNT  | 0x0
LINK1_MISSED_COMMA_CNT  | 0x0
LINK0_OVERFLOW_CNT      | 0x0
LINK1_OVERFLOW_CNT      | 0x0
LINK0_UNDERFLOW_CNT     | 0x0
LINK1_UNDERFLOW_CNT     | 0x0
LINK0_SBIT_OVERFLOW_CNT | 0x0
LINK1_SBIT_OVERFLOW_CNT | 0x0
Trigger link to OHs in mask: 0x200 is good
Trigger Link Successfully Established
```
where each OH would be printed as its own column.
Likewise for:
```
====================
Step 4: Checking VFAT Communication
====================
Checking GBT Communication (After Programming FPGA)
--=======================================--
-> GEM SYSTEM GBT INFORMATION
--=======================================--

                      | OH9
GBT0.READY            |   1
GBT0.NOT_READY        |   0
GBT0.RX_HAD_OVERFLOW  |   0
GBT0.RX_HAD_UNDERFLOW |   0
GBT1.READY            |   1
GBT1.NOT_READY        |   0
GBT1.RX_HAD_OVERFLOW  |   0
GBT1.RX_HAD_UNDERFLOW |   0
GBT2.READY            |   1
GBT2.NOT_READY        |   0
GBT2.RX_HAD_OVERFLOW  |   0
GBT2.RX_HAD_UNDERFLOW |   0
GBT Communication Is Stil Good
```

### Updates to `<>_info_uhal.py` scripts:
#### `amc_info_uhal.py -s2`
```
--=======================================--
  Opening AMC with ID gem.shelf01.amc02
--=======================================--


--=======================================--
-> BOARD SYSTEM INFORMATION
--=======================================--

-> board type  : GLIB
-> system type : 20v1
-> version nbr : 3.7.1
-> sys fw date : 23/5/2017
-> ip_addr     : 66.73.76.71
-> hw_addr     : 49:42:47:4c:49:42
-> CPLD bus state : 0x34

-> amc slot #        : 4
-> mac address (ipb) : 42:49:4c:47:42:49
-> mac IP source     : 0x74c

--=======================================--
-> GEM SYSTEM INFORMATION
--=======================================--

TK_LINK_RX_POLARITY 0x00000000
TK_LINK_TX_POLARITY 0x00000000
BOARD_ID            0x0000beef
BOARD_TYPE          0x00000001
RELEASE             0x00030701
NUM_OF_OH           0x0000000c
USE_TRIG_LINKS      0x00000001

--=======================================--
-> DAQ INFORMATION
--=======================================--

--=======================================--
-> GEM SYSTEM TTC INFORMATION
--=======================================--

BC0.LOCKED           0x00000001
MMCM_LOCKED          0x00000001
BC0.UNLOCK_CNT       0x0000002b
MMCM_UNLOCK_CNT      0x00000000
TTC_SINGLE_ERROR_CNT 0x00000000
TTC_DOUBLE_ERROR_CNT 0x00000000
BC0.OVERFLOW_CNT     0x00000000
BC0.UNDERFLOW_CNT    0x0000002b

--=======================================--
-> GEM SYSTEM SCA INFORMATION
--=======================================--

READY             0x00000200
CRITICAL_ERROR    0x00000000
NOT_READY_CNT_OH00 0x00000001
NOT_READY_CNT_OH01 0x00000001
NOT_READY_CNT_OH02 0x00000001
NOT_READY_CNT_OH03 0x00000001
NOT_READY_CNT_OH04 0x00000001
NOT_READY_CNT_OH05 0x00000001
NOT_READY_CNT_OH06 0x00000001
NOT_READY_CNT_OH07 0x00000001
NOT_READY_CNT_OH08 0x00000001
NOT_READY_CNT_OH09 0x00000002
NOT_READY_CNT_OH10 0x00000001
NOT_READY_CNT_OH11 0x00000001

-> DAQ control reg    :0x00000100
-> DAQ status reg     :0x88000027
-> DAQ L1A ID         :0x00000001
-> DAQ sent events cnt:0x00000000

-> DAQ DAV_TIMEOUT  :0x00000500
-> DAQ RUN_TYPE     :0x00000000
-> DAQ RUN_PARAMS   :0x00000000

-> DAQ GTX NOT_IN_TABLE error counter:0x00000000
-> DAQ GTX dispersion error counter  :0x00000000

-> AMC MAX_DAV_TIMER :0x00000000
-> AMC LAST_DAV_TIMER:0x00000000

-> TTC Control :0x00000000

-> RX Link Control :0x00000000
-> TX Link Control :0x00000000
```

#### `optohybrid_info_uhal.py -s2 -g9`
```
-> --------------------------
->     OPTOHYBRID STATUS
-> --------------------------
-> OH FW    Version        Date
            3.1.5.c  12/09/2018

Connected VFATs mask: 0xffb32100
VFATs s-bit mask:     0x00000000

Lock status:    GBT MMCM     LOGIC MMCM
                     0x0            0x1
Unlock count: 0x00000000     0x00000000

-> Counters         L1A          Cal       Resync          BC0

--=======================================--

--=======================================--
```

#### `vfat_info_uhal.py -s2 -g9`
```
--=======================================--

Firmware:     Version        Date
AMC     :       3.7.1   23/5/2017
OH      :     3.1.5.c  12/09/2018
GEB9 SlotID        ::         0          1          2          3          4          5          6          7          8          9         10         11         12         13         14         15         16         17         18         19         20         21         22         23
     ChipID        ::0xee1e44b4 0x8e247ed4 0x36369c9c 0xeeb4eeb4 0xe0605c5c 0x5c060e5c 0xb82ee274 0x00103c3c 0x00000000 0x427ee8d4 0x0e20369c 0x30a66afc 0x00001066 0x00000000 0x0a36a09c 0xa6fca6fc 0x00000000 0x00000000 0xe2de4874 0x944e4e34 0x00000000 0x00000000 0x74dede74 0x00000000
CFG_PULSE_STRETCH  ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_FP_FE          ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_RES_PRE        ::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_CAP_PRE        ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_PT             ::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_EN_HYST        ::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_SEL_POL        ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_SEL_COMP_MODE  ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_IREF           ::0x0020     0x0020     0x0020     0x0020     0x0020     0x0020     0x0020     0x0020     0x0000     0x0020     0x0020     0x0020     0x0020     0x0000     0x0020     0x0020     0x0000     0x0000     0x0020     0x0020     0x0000     0x0000     0x0020     0x0000
CFG_THR_ARM_DAC    ::0x0020     0x0020     0x0020     0x0020     0x0020     0x0020     0x0020     0x0020     0x0000     0x0020     0x0020     0x0020     0x0020     0x0000     0x0020     0x0020     0x0000     0x0000     0x0020     0x0020     0x0000     0x0000     0x0020     0x0000
CFG_HYST           ::0x0005     0x0005     0x0005     0x0005     0x0005     0x0005     0x0005     0x0005     0x0000     0x0005     0x0005     0x0005     0x0005     0x0000     0x0005     0x0005     0x0000     0x0000     0x0005     0x0005     0x0000     0x0000     0x0005     0x0000
CFG_LATENCY        ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_CAL_SEL_POL    ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_CAL_DAC        ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_CAL_MODE       ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_CAL_FS         ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_CAL_DUR        ::0x01ff     0x01ff     0x01ff     0x01ff     0x01ff     0x01ff     0x01ff     0x01ff     0x0000     0x01ff     0x01ff     0x01ff     0x01ff     0x0000     0x01ff     0x01ff     0x0000     0x0000     0x01ff     0x01ff     0x0000     0x0000     0x01ff     0x0000
CFG_BIAS_CFD_DAC_2 ::0x0028     0x0028     0x0028     0x0028     0x0028     0x0028     0x0028     0x0028     0x0000     0x0028     0x0028     0x0028     0x0028     0x0000     0x0028     0x0028     0x0000     0x0000     0x0028     0x0028     0x0000     0x0000     0x0028     0x0000
CFG_BIAS_CFD_DAC_1 ::0x0028     0x0028     0x0028     0x0028     0x0028     0x0028     0x0028     0x0028     0x0000     0x0028     0x0028     0x0028     0x0028     0x0000     0x0028     0x0028     0x0000     0x0000     0x0028     0x0028     0x0000     0x0000     0x0028     0x0000
CFG_BIAS_PRE_I_BSF ::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_BIAS_PRE_I_BIT ::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_BIAS_PRE_I_BLCC::0x000f     0x000f     0x000f     0x000f     0x000f     0x000f     0x000f     0x000f     0x0000     0x000f     0x000f     0x000f     0x000f     0x0000     0x000f     0x000f     0x0000     0x0000     0x000f     0x000f     0x0000     0x0000     0x000f     0x0000
CFG_BIAS_PRE_VREF  ::0x0056     0x0056     0x0056     0x0056     0x0056     0x0056     0x0056     0x0056     0x0000     0x0056     0x0056     0x0056     0x0056     0x0000     0x0056     0x0056     0x0000     0x0000     0x0056     0x0056     0x0000     0x0000     0x0056     0x0000
CFG_BIAS_SH_I_BFCAS::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_BIAS_SH_I_BDIFF::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_BIAS_SH_I_BFAMP::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_BIAS_SD_I_BDIFF::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_BIAS_SD_I_BSF  ::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_BIAS_SD_I_BFCAS::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_RUN            ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000

--=======================================--
```
If adding the `--verbose` flag, additional registers are printed:
```
CFG_FORCE_EN_ZCC   ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_VREF_ADC       ::0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0001     0x0001     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0001     0x0000     0x0000     0x0001     0x0000
CFG_MON_GAIN       ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_MONITOR_SELECT ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
CFG_THR_ZCC_DAC    ::0x000b     0x000b     0x000b     0x000b     0x000b     0x000b     0x000b     0x000b     0x0000     0x000b     0x000b     0x000b     0x000b     0x0000     0x000b     0x000b     0x0000     0x0000     0x000b     0x000b     0x0000     0x0000     0x000b     0x0000
CFG_CAL_PHI        ::0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000     0x0000
```

## How Has This Been Tested?
Tested against `GEM_AMC:v3.7.1` and `OptoHybridv3:v3.5.1.C`