### PR TITLE
#280: Update writeGBTPhase.py for single/multiple links

### DIFF
--- a/gempython/tests/writeGBTPhase.py
+++ b/gempython/tests/writeGBTPhase.py
@@ -1,24 +1,78 @@
 #!/bin/env python
 
+def writeSinglePhase(args):
+    """
+    This function writes the phase for single elink
+    """
+    from xhal.reg_interface_gem.core.gbt_utils_extended import setPhase
+    setPhase(cardName, args.link, args.vfat, args.phase)
+
+    from gempython.tools.vfat_user_functions_xhal import HwVFAT
+    vfatBoard = HwVFAT(cardName, args.link)
+    vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1)
+
+def writeAllPhases(args):
+    """
+    This function writes the phase for all elink
+    """
+    listOflink_phases = dict() # define dict for holding link and phases from file
+    for line in open(args.gbtPhaseFile, "r"):
+        if line[0].isalpha() or line[0] == "#":
+            pass
+        else:
+            dict_key = str(line.split("\t")[0])
+            if dict_key not in listOflink_phases:
+                listOflink_phases[dict_key] = []
+            listOflink_phases[dict_key].append(int(line.split("\t")[2]))
+    for link, listOfPhases in listOflink_phases.items():
+        from xhal.reg_interface_gem.core.gbt_utils_extended import setPhaseAllVFATs
+        setPhaseAllVFATs(cardName, int(link), listOfPhases)
+
+    from gempython.tools.vfat_user_functions_xhal import HwVFAT
+    vfatBoard = HwVFAT(cardName, int(list(listOflink_phases)[0])) # get first key from dict
+    vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET", 0x1)
+
 if __name__ == '__main__':
     # create the parser
     import argparse
-    parser = argparse.ArgumentParser(description="Tool for writing GBT phase for a single elink")
+    parent_parser = argparse.ArgumentParser(add_help=False, formatter_class=argparse.RawTextHelpFormatter)
 
-    parser.add_argument("shelf",type=int,help="uTCA shelf number")
-    parser.add_argument("slot",type=int,help="AMC slot number in the uTCA shelf")
-    parser.add_argument("link",type=int,help="OH number on the AMC")
-    parser.add_argument("vfat",type=int,help="VFAT number on the OH")
-    parser.add_argument("phase",type=int,help="GBT Phase Value to Write")
+    parent_parser.add_argument("shelf", type=int, help="uTCA shelf number")
+    parent_parser.add_argument("slot", type=int, help="AMC slot number in the uTCA shelf")
+
+    parser = argparse.ArgumentParser(description="Tool for writing GBT phase for a single or all elink")
+    from gempython.utils.gemlogger import colors
+    subparsers = parser.add_subparsers(help="Available subcommands and their descriptions."
+                                       "To view the sub menu call {0}writeGBTPhase.py COMMAND -h{1}"
+                                       " e.g. {0}writeGBTPhase.py single -h{1}".format(colors.GREEN,colors.ENDC),
+                                       dest='command')
+
+    parser_single = subparsers.add_parser("single", help='write GBT phase for single VFAT', parents=[parent_parser])
+    parser_all = subparsers.add_parser("all", help='write GBT phase for all VFAT', parents=[parent_parser],
+                                       formatter_class=argparse.RawTextHelpFormatter)
+
+    # create the sub-parser for writing the GBT phase for "single" elink
+    parser_single.add_argument("vfat", type=int, help="VFAT number on the OH")
+    parser_single.add_argument("phase", type=int, help="GBT Phase Value to Write")
+    parser_single.add_argument("link", type=int, help="OH number on the AMC")
+    parser_single.set_defaults(func=writeSinglePhase)
+
+    # create the sub-parser for writing the GBT phase for "all" elink
+    parser_all.add_argument("gbtPhaseFile", type=str,
+                            help="File having link, vfat and phase info.\n"
+                            "The input file will look like:\n"
+                            "--------------------------\n"
+                            "link/i:vfatN/i:GBTPhase/i:\n"
+                            "4    0    7\n"
+                            "4    1    9\n"
+                            "4    2    13\n"
+                            "--------------------------\n"
+                           )
+    parser_all.set_defaults(func=writeAllPhases)
+
     args = parser.parse_args()
 
-    cardName = "gem-shelf%02d-amc%02d"%(args.shelf,args.slot)
+    cardName = "gem-shelf%02d-amc%02d"%(args.shelf, args.slot)
+    args.func(args)
 
-    from xhal.reg_interface_gem.core.gbt_utils_extended import setPhase
-    setPhase(cardName,args.link,args.vfat,args.phase)
-
-    from gempython.tools.vfat_user_functions_xhal import HwVFAT
-    vfatBoard = HwVFAT(cardName,args.link)
-    vfatBoard.parentOH.parentAMC.writeRegister("GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET",0x1)
-    
-    print("Goodbye")
+    print "Goodbye"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Earlier `writeGBTPhase.py` script was writing phase for single link and single VFAT. Now, its upgraded for writing single as well as for all VFATs on mulitple links.

## Description
<!--- Describe your changes in detail -->
Added two sub-commands `single` and `all`. So, user need to enter `single` or `multiple` option along with its other arguments.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Right now there's no easy way to write a set of known phases at once to the frontend. QC8 shifters generally end up having to relaunch testConnectivity.py to do a phase scan (slow, especially with many links) or need to call writeGBTPhase.py 24 times per OH to set known phases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This script was tested on `gem904qc8daq` machine on `GE11-X-S-INDIA-0015`. Using the commands below. 

```sh
[gemuser@gem904qc8daq ~]$ python writeGBTPhase.py single 1 6 23 7 3
Open pickled address table if available  /opt/cmsgemos/etc/maps//amc_address_table_top.pickle...
Initializing AMC gem-shelf01-amc06
Initial value to write: 1, register GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET
Goodbye
```

```sh
[gemuser@gem904qc8daq ~]$ python writeGBTPhase.py all 1 6 $DATA_PATH/GE11-X-S-INDIA-0015/gbtPhaseSetPoints_GE11-X-S-INDIA-0015_current.log
Open pickled address table if available  /opt/cmsgemos/etc/maps//amc_address_table_top.pickle...
Initializing AMC gem-shelf01-amc06
Initial value to write: 1, register GEM_AMC.GEM_SYSTEM.CTRL.LINK_RESET
Goodbye
```

### Help menue of script `writeGBTPhase.py`
[**updated**]

```bash
$ python writeGBTPhase.py -h
usage: writeGBTPhase.py [-h] {single,all} ...

Tool for writing GBT phase for a single or all elink

positional arguments:
  {single,all}  Available subcommands and their descriptions.To view the sub
                menu call writeGBTPhase.py COMMAND -h e.g.
                writeGBTPhase.py single -h
    single      write GBT phase for single VFAT
    all         write GBT phase for all VFAT

optional arguments:
  -h, --help    show this help message and exit
```
Above help menue shows the available sub-commands. They are `single` and `all`.  Details of these sub-commands can be checked using `python writeGBTPhase.py single -h` or `python writeGBTPhase.py all -h`. 

```bash
$ python writeGBTPhase.py single -h
usage: writeGBTPhase.py single [-h] shelf slot vfat phase link

positional arguments:
  shelf       uTCA shelf number
  slot        AMC slot number in the uTCA shelf
  vfat        VFAT number on the OH
  phase       GBT Phase Value to Write
  link        OH number on the AMC

optional arguments:
  -h, --help  show this help message and exit
```

```bash
$ python writeGBTPhase.py all -h
usage: writeGBTPhase.py all [-h] shelf slot gbtPhaseFile

positional arguments:
  shelf         uTCA shelf number
  slot          AMC slot number in the uTCA shelf
  gbtPhaseFile  File having link, vfat and phase info.
                The input file will look like:
                --------------------------
                link/i:vfatN/i:GBTPhase/i:
                4    0    7
                4    1    9
                4    2    13
                --------------------------

optional arguments:
  -h, --help    show this help message and exit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation ([here](https://github.com/cms-gem-daq-project/sw_utils/blob/develop/v3ElectronicsUserGuide.md#writegbtphasepy-manually-writing-the-gbt-e-link-phase-for-a-given-vfat)).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->