### PR TITLE
All bits of SCA MONITORING_OFF register are 1

### DIFF
--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -790,7 +790,7 @@ class HwAMC(object):
                 break
             else:
                 #FIXME note when @evka85 removes adc monitoring block from GEM_AMC FW this line will need to be removed
-                self.writeRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",0xfff)
+                self.writeRegister("GEM_AMC.SLOW_CONTROL.SCA.ADC_MONITORING.MONITORING_OFF",0xffffffff)
                 sca_reset(ohMaskNeedSCAReset)
             pass
         self.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Following email chain discussion; this patch is meant to see if writing all bits of the SCA MONITORING_OFF register to 1 improve issues with promless programming.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
This register is supposed to be a link mask; but there is some concern that having nonzero bits in the higher bits might impact the promless programming; this patch is meant to see if that will help.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial; hasn't been tested.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
