### PR TITLE
Bug Fix: HwAMC should be using self.NGBT not NGBT

### DIFF
--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -293,10 +293,10 @@ class HwAMC(object):
             gbtfmt.append("GBT{}.RX_HAD_OVERFLOW")
             gbtfmt.append("GBT{}.RX_HAD_UNDERFLOW")
 
-            lines = [[] for x in range(NGBT*4+1)]
+            lines = [[] for x in range(self.NGBT*4+1)]
             lines[0].append("{}".format(" "*(len(max(gbtfmt)))))
 
-            for gbt in range(NGBT):
+            for gbt in range(self.NGBT):
                 lines[4*gbt+1].append("{{:{}s}}".format(len(max(gbtfmt,key=len))).format(gbtfmt[0].format(gbt)))
                 lines[4*gbt+2].append("{{:{}s}}".format(len(max(gbtfmt,key=len))).format(gbtfmt[1].format(gbt)))
                 lines[4*gbt+3].append("{{:{}s}}".format(len(max(gbtfmt,key=len))).format(gbtfmt[2].format(gbt)))
@@ -316,7 +316,7 @@ class HwAMC(object):
             if printSummary:
                 lines[0].append(hfmt.format(("OH{:d}".format(ohN)).rjust(4)))
 
-            for gbtN in range(NGBT):
+            for gbtN in range(self.NGBT):
                 gbtRdy      = gbtMonData[ohN].gbtRdy[gbtN]
                 gbtNotRdy   = gbtMonData[ohN].gbtNotRdy[gbtN]
                 gbtRxOver   = gbtMonData[ohN].gbtRxOverflow[gbtN]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When https://github.com/cms-gem-daq-project/cmsgemos/pull/282/files was merged the `NGBT` was coming from `gbtsPerGemVariant` whenever it was used, but this was removed however `self.NGBT` was not updated.

This patch resolves this issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Without this fix a `NameError` is raised.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On QC7.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
