### PR TITLE
Feature/ge21compatibility

### DIFF
--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -125,11 +125,11 @@ class HwAMC(object):
         self.confDacMonitorMulti.restype = c_uint
 
         self.readADCsMulti = self.lib.readVFAT3ADCMultiLink
-        self.readADCsMulti.argTypes = [ c_uint, POINTER(c_uint32), POINTER(c_uint), c_bool ]
+        self.readADCsMulti.argTypes = [ c_uint, POINTER(c_uint32), POINTER(c_uint), c_bool, c_uint ]
         self.readADCsMulti.restype = c_uint
 
         self.dacScanMulti = self.lib.dacScanMultiLink
-        self.dacScanMulti.argTypes = [ c_uint, c_uint, c_uint, c_uint, c_bool, POINTER(c_uint) ]
+        self.dacScanMulti.argTypes = [ c_uint, c_uint, c_uint, c_uint, c_bool, POINTER(c_uint), c_uint ]
         self.dacScanMulti.restype = c_uint
 
         # Define SCA & Sysmon Monitoring
@@ -165,7 +165,7 @@ class HwAMC(object):
         self.readSBits.restype = c_uint
 
         self.sbitRateScanMulti = self.lib.sbitRateScan
-        self.sbitRateScanMulti.argTypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32)]
+        self.sbitRateScanMulti.argTypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), c_uint]
         self.sbitRateScanMulti.restype = c_uint
 
         # Parse XML
@@ -668,7 +668,7 @@ class HwAMC(object):
             printRed("HwAMC::performDacScanMultiLink(): I expected container of length {0} but provided 'dacDataAll' has length {1}",format(lenExpected, len(dacDataAll)))
             exit(os.EX_USAGE)
 
-        return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll)
+        return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll, self.NVFAT)
 
     def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=None, scanReg="THR_ARM_DAC"):
         """
@@ -724,7 +724,7 @@ class HwAMC(object):
             printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataTrigRatePerVFAT' has length {1}".format(self.NVFAT*lenExpected, len(outDataTrigRatePerVFAT)))
             exit(os.EX_USAGE)
 
-        return self.sbitRateScanMulti(ohMask, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT)
+        return self.sbitRateScanMulti(ohMask, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, self.NVFAT)
 
     def programAllOptohybridFPGAs(self, maxIter=5, ohMask=None):
         """
@@ -828,7 +828,7 @@ class HwAMC(object):
             for ohN in range(0,12):
                 print("| {0} | 0x{1:x} |".format(ohN, ohVFATMaskArray[ohN]))
 
-        return self.readADCsMulti(ohMask,ohVFATMaskArray, adcDataAll, useExtRefADC)
+        return self.readADCsMulti(ohMask,ohVFATMaskArray, adcDataAll, useExtRefADC, self.NVFAT)
 
     def readBlock(register, nwords, debug=False):
         """

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -1,5 +1,5 @@
 from ctypes import *
-from gempython.tools.hw_constants import maxVfat3DACSize,gbtsPerGemVariant
+from gempython.tools.hw_constants import maxVfat3DACSize, gbtsPerGemVariant, vfatsPerGemVariant
 from gempython.utils.gemlogger import colors, printRed, printYellow
 from gempython.utils.wrappers import runCommand, runCommandWithOutput
 
@@ -182,6 +182,12 @@ class HwAMC(object):
         #Determine the number of GBTs based on the gemType
         if gemType in gbtsPerGemVariant.keys():
             self.NGBT = gbtsPerGemVariant[gemType]
+        else:
+            raise KeyError("Unrecognized gemType {0}".format(gemType))
+
+        #Determine the number of VFATs per geb based on the gemType
+        if gemType in vfatsPerGemVariant.keys():
+            self.NVFAT = vfatsPerGemVariant[gemType]
         else:
             raise KeyError("Unrecognized gemType {0}".format(gemType))
 
@@ -604,7 +610,7 @@ class HwAMC(object):
                 # print("----------OH{0}----------".format(ohN))
                 pass
 
-            for vfatN in range(24):
+            for vfatN in range(self.NVFAT):
                 nSyncErrors = vfatMonData[ohN].syncErrCnt[vfatN]
                 totalSyncErrors += nSyncErrors
 

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -807,7 +807,7 @@ class HwAMC(object):
     def readADCsMultiLink(self, adcDataAll, useExtRefADC=False, ohMask=None, debug=False):
         """
         Reads the ADC value from all unmasked VFATs
-        adcDataAll - Array of type c_uint32 of size self.NVFAT*12=288
+        adcDataAll - Array of type c_uint32 of size self.NVFAT*12 (288 for GE1/1 or 144 for GE2/1)
         useExtRefADC - True (False) use the externally (internally) referenced ADC
         ohMask - Mask which defines which OH's to query; 12 bit number where
                  having a 1 in the N^th bit means to query the N^th optohybrid.

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -104,7 +104,7 @@ class HwAMC(object):
 
         # Define Link Monitoring
         self.getmonGBTLink = self.lib.getmonGBTLink
-        self.getmonGBTLink.argTypes = [ OHLinkMonitorArrayType, c_uint, c_uint, c_bool ]
+        self.getmonGBTLink.argTypes = [ OHLinkMonitorArrayType, c_uint, c_uint, c_bool, c_uint]
         self.getmonGBTLink.restype = c_uint
 
         self.getmonOHLink = self.lib.getmonOHLink
@@ -284,7 +284,7 @@ class HwAMC(object):
             ohMask = self.getOHMask(callingMthd="getGBTLinkStatus")
 
         gbtMonData = OHLinkMonitorArrayType()
-        self.getmonGBTLink(gbtMonData, self.nOHs, ohMask, doReset)
+        self.getmonGBTLink(gbtMonData, self.nOHs, ohMask, doReset, self.NGBT)
 
         if printSummary:
             print("--=======================================--")
@@ -592,7 +592,7 @@ class HwAMC(object):
             colw = len(max([colors.GREEN,colors.RED],key=len))+len(colors.ENDC)+4
             xfmt = "{}0x{:1x}{}"
 
-            vfatsyncfmt = ["VFAT{}.SYNC_ERR_CNT".format(vfat) for vfat in range(24) ]
+            vfatsyncfmt = ["VFAT{}.SYNC_ERR_CNT".format(vfat) for vfat in range(self.NVFAT) ]
 
             lines = [[] for x in range(len(vfatsyncfmt)+1)]
             lines[0].append("{}".format(" "*(len(max(vfatsyncfmt,key=len)))))

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -58,7 +58,7 @@ class SysmonMonitorParams(Structure):
             ]
 SysmonMonitorArrayType = SysmonMonitorParams * 12 # Sysmon Monitor Array
 
-vfatValueArray = c_uint32 * self.NVFAT
+vfatValueArray = c_uint32 * 24
 class VFATLinkMonitorParams(Structure):
     _fields_ = [
             ("daqCRCErrCnt",vfatValueArray),

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -187,7 +187,7 @@ class HwAMC(object):
 
         #Determine the number of VFATs per geb based on the gemType
         if gemType in vfatsPerGemVariant.keys():
-            self.NVFAT = vfatsPerGemVariant[gemType]
+            self.nVFATs = vfatsPerGemVariant[gemType]
         else:
             raise KeyError("Unrecognized gemType {0}".format(gemType))
 
@@ -353,7 +353,7 @@ class HwAMC(object):
     def getLinkVFATMask(self,ohN):
         """
         V3 electronics only
-        Returns a self.NVFAT bit number that can be used as the VFAT Mask
+        Returns a self.nVFATs bit number that can be used as the VFAT Mask
         for the Optohybrid ohN
         """
         if self.fwVersion < 3:
@@ -592,7 +592,7 @@ class HwAMC(object):
             colw = len(max([colors.GREEN,colors.RED],key=len))+len(colors.ENDC)+4
             xfmt = "{}0x{:1x}{}"
 
-            vfatsyncfmt = ["VFAT{}.SYNC_ERR_CNT".format(vfat) for vfat in range(self.NVFAT) ]
+            vfatsyncfmt = ["VFAT{}.SYNC_ERR_CNT".format(vfat) for vfat in range(self.nVFATs) ]
 
             lines = [[] for x in range(len(vfatsyncfmt)+1)]
             lines[0].append("{}".format(" "*(len(max(vfatsyncfmt,key=len)))))
@@ -610,7 +610,7 @@ class HwAMC(object):
                 # print("----------OH{0}----------".format(ohN))
                 pass
 
-            for vfatN in range(self.NVFAT):
+            for vfatN in range(self.nVFATs):
                 nSyncErrors = vfatMonData[ohN].syncErrCnt[vfatN]
                 totalSyncErrors += nSyncErrors
 
@@ -663,12 +663,12 @@ class HwAMC(object):
             exit(os.EX_USAGE)
 
         # Check length of results container
-        lenExpected = self.nOHs * (maxVfat3DACSize[dacSelect][0] - 0+1)*self.NVFAT / dacStep
+        lenExpected = self.nOHs * (maxVfat3DACSize[dacSelect][0] - 0+1)*self.nVFATs / dacStep
         if (len(dacDataAll) != lenExpected):
             printRed("HwAMC::performDacScanMultiLink(): I expected container of length {0} but provided 'dacDataAll' has length {1}",format(lenExpected, len(dacDataAll)))
             exit(os.EX_USAGE)
 
-        return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll, self.NVFAT)
+        return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll, self.nVFATs)
 
     def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=None, scanReg="THR_ARM_DAC"):
         """
@@ -681,7 +681,7 @@ class HwAMC(object):
         outDataTrigRate         - As outDataDacVal but for trigger rate
         outDataTrigRatePerVFAT  - As outDataTrigRate but for each VFAT, array size
                                   must be:
-                                  (self.NVFAT * (12 * (dacMax - dacMin + 1) / stepSize))
+                                  (self.nVFATs * (12 * (dacMax - dacMin + 1) / stepSize))
         chan                    - VFAT channel to be considered, for all channels
                                   set to 128
         dacMin                  - Starting dac value of the scan
@@ -720,11 +720,11 @@ class HwAMC(object):
             exit(os.EX_USAGE)
 
         # Check length of results container - outDataTrigRatePerVFAT
-        if (len(outDataTrigRatePerVFAT) != (self.NVFAT*lenExpected)):
-            printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataTrigRatePerVFAT' has length {1}".format(self.NVFAT*lenExpected, len(outDataTrigRatePerVFAT)))
+        if (len(outDataTrigRatePerVFAT) != (self.nVFATs*lenExpected)):
+            printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataTrigRatePerVFAT' has length {1}".format(self.nVFATs*lenExpected, len(outDataTrigRatePerVFAT)))
             exit(os.EX_USAGE)
 
-        return self.sbitRateScanMulti(ohMask, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, self.NVFAT)
+        return self.sbitRateScanMulti(ohMask, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, self.nVFATs)
 
     def programAllOptohybridFPGAs(self, maxIter=5, ohMask=None):
         """
@@ -807,7 +807,7 @@ class HwAMC(object):
     def readADCsMultiLink(self, adcDataAll, useExtRefADC=False, ohMask=None, debug=False):
         """
         Reads the ADC value from all unmasked VFATs
-        adcDataAll - Array of type c_uint32 of size self.NVFAT*12 (288 for GE1/1 or 144 for GE2/1)
+        adcDataAll - Array of type c_uint32 of size self.nVFATs*12 (288 for GE1/1 or 144 for GE2/1)
         useExtRefADC - True (False) use the externally (internally) referenced ADC
         ohMask - Mask which defines which OH's to query; 12 bit number where
                  having a 1 in the N^th bit means to query the N^th optohybrid.
@@ -828,7 +828,7 @@ class HwAMC(object):
             for ohN in range(0,12):
                 print("| {0} | 0x{1:x} |".format(ohN, ohVFATMaskArray[ohN]))
 
-        return self.readADCsMulti(ohMask,ohVFATMaskArray, adcDataAll, useExtRefADC, self.NVFAT)
+        return self.readADCsMulti(ohMask,ohVFATMaskArray, adcDataAll, useExtRefADC, self.nVFATs)
 
     def readBlock(register, nwords, debug=False):
         """

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -285,6 +285,7 @@ class HwAMC(object):
             print("-> GEM SYSTEM GBT INFORMATION")
             print("--=======================================--")
             print("")
+            print("Number of GBTs per optical link: %s" %(self.NGBT))
             hfmt   = "{:4s}"
             dfmt   = "{}{:4d}{}"
             gbtfmt = []

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -58,7 +58,7 @@ class SysmonMonitorParams(Structure):
             ]
 SysmonMonitorArrayType = SysmonMonitorParams * 12 # Sysmon Monitor Array
 
-vfatValueArray = c_uint32 * 24
+vfatValueArray = c_uint32 * self.NVFAT
 class VFATLinkMonitorParams(Structure):
     _fields_ = [
             ("daqCRCErrCnt",vfatValueArray),
@@ -353,7 +353,7 @@ class HwAMC(object):
     def getLinkVFATMask(self,ohN):
         """
         V3 electronics only
-        Returns a 24 bit number that can be used as the VFAT Mask
+        Returns a self.NVFAT bit number that can be used as the VFAT Mask
         for the Optohybrid ohN
         """
         if self.fwVersion < 3:
@@ -663,7 +663,7 @@ class HwAMC(object):
             exit(os.EX_USAGE)
 
         # Check length of results container
-        lenExpected = self.nOHs * (maxVfat3DACSize[dacSelect][0] - 0+1)*24 / dacStep
+        lenExpected = self.nOHs * (maxVfat3DACSize[dacSelect][0] - 0+1)*self.NVFAT / dacStep
         if (len(dacDataAll) != lenExpected):
             printRed("HwAMC::performDacScanMultiLink(): I expected container of length {0} but provided 'dacDataAll' has length {1}",format(lenExpected, len(dacDataAll)))
             exit(os.EX_USAGE)
@@ -681,7 +681,7 @@ class HwAMC(object):
         outDataTrigRate         - As outDataDacVal but for trigger rate
         outDataTrigRatePerVFAT  - As outDataTrigRate but for each VFAT, array size
                                   must be:
-                                  (24 * (12 * (dacMax - dacMin + 1) / stepSize))
+                                  (self.NVFAT * (12 * (dacMax - dacMin + 1) / stepSize))
         chan                    - VFAT channel to be considered, for all channels
                                   set to 128
         dacMin                  - Starting dac value of the scan
@@ -720,8 +720,8 @@ class HwAMC(object):
             exit(os.EX_USAGE)
 
         # Check length of results container - outDataTrigRatePerVFAT
-        if (len(outDataTrigRatePerVFAT) != (24*lenExpected)):
-            printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataTrigRatePerVFAT' has length {1}".format(24*lenExpected, len(outDataTrigRatePerVFAT)))
+        if (len(outDataTrigRatePerVFAT) != (self.NVFAT*lenExpected)):
+            printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataTrigRatePerVFAT' has length {1}".format(self.NVFAT*lenExpected, len(outDataTrigRatePerVFAT)))
             exit(os.EX_USAGE)
 
         return self.sbitRateScanMulti(ohMask, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT)
@@ -807,7 +807,7 @@ class HwAMC(object):
     def readADCsMultiLink(self, adcDataAll, useExtRefADC=False, ohMask=None, debug=False):
         """
         Reads the ADC value from all unmasked VFATs
-        adcDataAll - Array of type c_uint32 of size 24*12=288
+        adcDataAll - Array of type c_uint32 of size self.NVFAT*12=288
         useExtRefADC - True (False) use the externally (internally) referenced ADC
         ohMask - Mask which defines which OH's to query; 12 bit number where
                  having a 1 in the N^th bit means to query the N^th optohybrid.

--- a/gempython/tools/hw_constants.py
+++ b/gempython/tools/hw_constants.py
@@ -57,6 +57,8 @@ for ge21Type in gemVariants["ge21"]:
     vfat3GBTPhaseLookupTable["ge21"][ge21Type] = [ 0 for x in range(0,vfatsPerGemVariant["ge21"]) ]
 vfat3GBTPhaseLookupTable["me0"]["null"] = [ 0 for x in range(0,vfatsPerGemVariant["me0"]) ]
 
+# Fill Info for GE21 - m3
+vfat3GBTPhaseLookupTable["ge21"]["m3"][5]  = 4  #VFAT5
 # Fill Info for GE11 - Short
 # FIXME It would be great if this was in the DB and I could just load it from there...
 vfat3GBTPhaseLookupTable["ge11"]["short"][0]  = 6  #VFAT0

--- a/gempython/tools/hw_constants.py
+++ b/gempython/tools/hw_constants.py
@@ -58,7 +58,7 @@ for ge21Type in gemVariants["ge21"]:
 vfat3GBTPhaseLookupTable["me0"]["null"] = [ 0 for x in range(0,vfatsPerGemVariant["me0"]) ]
 
 # Fill Info for GE21 - m3
-vfat3GBTPhaseLookupTable["ge21"]["m3"][5]  = 4  #VFAT5
+vfat3GBTPhaseLookupTable["ge21"]["m3"][5]  = 8  #VFAT5
 # Fill Info for GE11 - Short
 # FIXME It would be great if this was in the DB and I could just load it from there...
 vfat3GBTPhaseLookupTable["ge11"]["short"][0]  = 6  #VFAT0

--- a/gempython/tools/hw_constants.py
+++ b/gempython/tools/hw_constants.py
@@ -57,8 +57,62 @@ for ge21Type in gemVariants["ge21"]:
     vfat3GBTPhaseLookupTable["ge21"][ge21Type] = [ 0 for x in range(0,vfatsPerGemVariant["ge21"]) ]
 vfat3GBTPhaseLookupTable["me0"]["null"] = [ 0 for x in range(0,vfatsPerGemVariant["me0"]) ]
 
+# Fill Info for GE21 - m1
+vfat3GBTPhaseLookupTable["ge21"]["m1"][0]  = 6  #VFAT0
+vfat3GBTPhaseLookupTable["ge21"]["m1"][1]  = 10 #VFAT1
+vfat3GBTPhaseLookupTable["ge21"]["m1"][2]  = 6  #VFAT2
+vfat3GBTPhaseLookupTable["ge21"]["m1"][3]  = 9  #VFAT3
+vfat3GBTPhaseLookupTable["ge21"]["m1"][4]  = 8  #VFAT4
+vfat3GBTPhaseLookupTable["ge21"]["m1"][5]  = 7  #VFAT5
+vfat3GBTPhaseLookupTable["ge21"]["m1"][6]  = 4  #VFAT6
+vfat3GBTPhaseLookupTable["ge21"]["m1"][7]  = 8  #VFAT7
+vfat3GBTPhaseLookupTable["ge21"]["m1"][8]  = 12 #VFAT8
+vfat3GBTPhaseLookupTable["ge21"]["m1"][9]  = 9  #VFAT9
+vfat3GBTPhaseLookupTable["ge21"]["m1"][10] = 9  #VFAT10
+vfat3GBTPhaseLookupTable["ge21"]["m1"][11] = 8  #VFAT11
+
+# Fill Info for GE21 - m2
+vfat3GBTPhaseLookupTable["ge21"]["m2"][0]  = 6  #VFAT0
+vfat3GBTPhaseLookupTable["ge21"]["m2"][1]  = 6  #VFAT1
+vfat3GBTPhaseLookupTable["ge21"]["m2"][2]  = 10 #VFAT2
+vfat3GBTPhaseLookupTable["ge21"]["m2"][3]  = 7  #VFAT3
+vfat3GBTPhaseLookupTable["ge21"]["m2"][4]  = 8  #VFAT4
+vfat3GBTPhaseLookupTable["ge21"]["m2"][5]  = 7  #VFAT5
+vfat3GBTPhaseLookupTable["ge21"]["m2"][6]  = 4  #VFAT6
+vfat3GBTPhaseLookupTable["ge21"]["m2"][7]  = 8  #VFAT7
+vfat3GBTPhaseLookupTable["ge21"]["m2"][8]  = 7  #VFAT8
+vfat3GBTPhaseLookupTable["ge21"]["m2"][9]  = 5  #VFAT9
+vfat3GBTPhaseLookupTable["ge21"]["m2"][10] = 8  #VFAT10
+vfat3GBTPhaseLookupTable["ge21"]["m2"][11] = 7  #VFAT11
+
 # Fill Info for GE21 - m3
-vfat3GBTPhaseLookupTable["ge21"]["m3"][5]  = 8  #VFAT5
+vfat3GBTPhaseLookupTable["ge21"]["m3"][0]  = 7  #VFAT0
+vfat3GBTPhaseLookupTable["ge21"]["m3"][1]  = 5  #VFAT1
+vfat3GBTPhaseLookupTable["ge21"]["m3"][2]  = 7  #VFAT2
+vfat3GBTPhaseLookupTable["ge21"]["m3"][3]  = 10 #VFAT3
+vfat3GBTPhaseLookupTable["ge21"]["m3"][4]  = 9  #VFAT4
+vfat3GBTPhaseLookupTable["ge21"]["m3"][5]  = 7  #VFAT5
+vfat3GBTPhaseLookupTable["ge21"]["m3"][6]  = 8  #VFAT6
+vfat3GBTPhaseLookupTable["ge21"]["m3"][7]  = 10 #VFAT7
+vfat3GBTPhaseLookupTable["ge21"]["m3"][8]  = 7  #VFAT8
+vfat3GBTPhaseLookupTable["ge21"]["m3"][9]  = 10 #VFAT9
+vfat3GBTPhaseLookupTable["ge21"]["m3"][10] = 6  #VFAT10
+vfat3GBTPhaseLookupTable["ge21"]["m3"][11] = 4  #VFAT11
+
+# Fill Info for GE21 - m4
+vfat3GBTPhaseLookupTable["ge21"]["m4"][0]  = 3  #VFAT0
+vfat3GBTPhaseLookupTable["ge21"]["m4"][1]  = 3  #VFAT1
+vfat3GBTPhaseLookupTable["ge21"]["m4"][2]  = 3  #VFAT2
+vfat3GBTPhaseLookupTable["ge21"]["m4"][3]  = 9  #VFAT3
+vfat3GBTPhaseLookupTable["ge21"]["m4"][4]  = 4  #VFAT4
+vfat3GBTPhaseLookupTable["ge21"]["m4"][5]  = 3  #VFAT5
+vfat3GBTPhaseLookupTable["ge21"]["m4"][6]  = 8  #VFAT6
+vfat3GBTPhaseLookupTable["ge21"]["m4"][7]  = 8  #VFAT7
+vfat3GBTPhaseLookupTable["ge21"]["m4"][8]  = 11 #VFAT8
+vfat3GBTPhaseLookupTable["ge21"]["m4"][9]  = 6  #VFAT9
+vfat3GBTPhaseLookupTable["ge21"]["m4"][10] = 6  #VFAT10
+vfat3GBTPhaseLookupTable["ge21"]["m4"][11] = 4  #VFAT11
+
 # Fill Info for GE11 - Short
 # FIXME It would be great if this was in the DB and I could just load it from there...
 vfat3GBTPhaseLookupTable["ge11"]["short"][0]  = 6  #VFAT0

--- a/gempython/tools/hw_constants.py
+++ b/gempython/tools/hw_constants.py
@@ -11,7 +11,7 @@ vfatsPerGemVariant = {
 
 gbtsPerGemVariant = {
             "ge11":3,
-            "ge21":1,
+            "ge21":2,
             "me0":0}
 
 # Size of VFAT3 DAC's

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -53,7 +53,7 @@ class HwOptoHybrid(object):
 
         # Define broadcast read
         self.bRead = self.parentAMC.lib.broadcastRead
-        self.bRead.argtypes = [c_uint, c_char_p, c_uint, POINTER(c_uint32)]
+        self.bRead.argtypes = [c_uint, c_char_p, c_uint, POINTER(c_uint32), c_uint]
         self.bRead.restype = c_uint
 
         # Define broadcast write
@@ -111,7 +111,7 @@ class HwOptoHybrid(object):
         outData = (c_uint32 * self.nVFATs)()
 
         try:
-            rpcResp = self.bRead(self.link, register, mask, outData)
+            rpcResp = self.bRead(self.link, register, mask, outData, self.nVFATs)
         except Exception as e:
             print e
             pass

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -31,7 +31,7 @@ class HwOptoHybrid(object):
         """
         # Debug flag
         self.debug = debug
-        
+
         # Logger
         self.ohlogger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class HwOptoHybrid(object):
         self.vfatGBTPhases = vfat3GBTPhaseLookupTable[gemType][detType]
         self.typeDet = detType
         self.typeGEM = gemType
-        self.parentAMC = HwAMC(cardName, debug)
+        self.parentAMC = HwAMC(cardName, debug, gemType)
 
         # Define broadcast read
         self.bRead = self.parentAMC.lib.broadcastRead
@@ -60,7 +60,7 @@ class HwOptoHybrid(object):
         self.bWrite = self.parentAMC.lib.broadcastWrite
         self.bWrite.argtypes = [c_uint, c_char_p, c_uint, c_uint]
         self.bWrite.restype = c_uint
-       
+
         # Define the sbit mapping scan modules
         self.sbitMappingWithCalPulse = self.parentAMC.lib.checkSbitMappingWithCalPulse
         self.sbitMappingWithCalPulse.restype = c_uint
@@ -120,13 +120,13 @@ class HwOptoHybrid(object):
             raise OHRPCException("broadcastRead failed for device %i; reg: %s; with mask %x"%(self.link,register,mask), os.EX_SOFTWARE)
 
         return outData
-    
+
     def broadcastWrite(self,register,value,mask=0xff000000):
         """
         Perform a broadcast RPC write on the VFATs specified by mask
         Will return when operation has completed
         """
-        
+
         rpcResp = 0
 
         try:
@@ -334,7 +334,7 @@ class HwOptoHybrid(object):
         else:
             print("HwOptoHybrid.getTriggerSource() - No support for v3 electronics, exiting")
             sys.exit(os.EX_USAGE)
-    
+
     def getType(self):
         return (self.typeGEM,self.typeDet)
 
@@ -500,7 +500,7 @@ class HwOptoHybrid(object):
 
         Sets the sbit mask in the OH FPGA
         """
-        
+
         if self.parentAMC.fwVersion < 3:
             print("Parent AMC Major FW Version: %i"%(self.parentAMC.fwVersion))
             print("Only implemented for v3 electronics, exiting")
@@ -530,7 +530,7 @@ class HwOptoHybrid(object):
         """
         Set the trigger throttle
         """
-       
+
         if self.parentAMC.fwVersion < 3:
             return self.parentAMC.writeRegister("GEM_AMC.OH.OH%d.CONTROL.TRIGGER.THROTTLE"%(self.link),throttle)
         else:
@@ -539,7 +539,7 @@ class HwOptoHybrid(object):
 
     def setType(self, gemType, detType):
         """
-        Sets the GEM type and detector type, updates the number of VFATs expected 
+        Sets the GEM type and detector type, updates the number of VFATs expected
         and changes the VFAT GBT Phase lookup table
 
         gemType - string specifying gemType, expexted to be a key in gemVariants dictionary

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -31,7 +31,7 @@ class HwOptoHybrid(object):
         """
         # Debug flag
         self.debug = debug
-
+        
         # Logger
         self.ohlogger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class HwOptoHybrid(object):
         self.vfatGBTPhases = vfat3GBTPhaseLookupTable[gemType][detType]
         self.typeDet = detType
         self.typeGEM = gemType
-        self.parentAMC = HwAMC(cardName, debug, gemType)
+        self.parentAMC = HwAMC(cardName, debug)
 
         # Define broadcast read
         self.bRead = self.parentAMC.lib.broadcastRead
@@ -60,7 +60,7 @@ class HwOptoHybrid(object):
         self.bWrite = self.parentAMC.lib.broadcastWrite
         self.bWrite.argtypes = [c_uint, c_char_p, c_uint, c_uint]
         self.bWrite.restype = c_uint
-
+       
         # Define the sbit mapping scan modules
         self.sbitMappingWithCalPulse = self.parentAMC.lib.checkSbitMappingWithCalPulse
         self.sbitMappingWithCalPulse.restype = c_uint
@@ -120,13 +120,13 @@ class HwOptoHybrid(object):
             raise OHRPCException("broadcastRead failed for device %i; reg: %s; with mask %x"%(self.link,register,mask), os.EX_SOFTWARE)
 
         return outData
-
+    
     def broadcastWrite(self,register,value,mask=0xff000000):
         """
         Perform a broadcast RPC write on the VFATs specified by mask
         Will return when operation has completed
         """
-
+        
         rpcResp = 0
 
         try:
@@ -334,7 +334,7 @@ class HwOptoHybrid(object):
         else:
             print("HwOptoHybrid.getTriggerSource() - No support for v3 electronics, exiting")
             sys.exit(os.EX_USAGE)
-
+    
     def getType(self):
         return (self.typeGEM,self.typeDet)
 
@@ -500,7 +500,7 @@ class HwOptoHybrid(object):
 
         Sets the sbit mask in the OH FPGA
         """
-
+        
         if self.parentAMC.fwVersion < 3:
             print("Parent AMC Major FW Version: %i"%(self.parentAMC.fwVersion))
             print("Only implemented for v3 electronics, exiting")
@@ -530,7 +530,7 @@ class HwOptoHybrid(object):
         """
         Set the trigger throttle
         """
-
+       
         if self.parentAMC.fwVersion < 3:
             return self.parentAMC.writeRegister("GEM_AMC.OH.OH%d.CONTROL.TRIGGER.THROTTLE"%(self.link),throttle)
         else:
@@ -539,7 +539,7 @@ class HwOptoHybrid(object):
 
     def setType(self, gemType, detType):
         """
-        Sets the GEM type and detector type, updates the number of VFATs expected
+        Sets the GEM type and detector type, updates the number of VFATs expected 
         and changes the VFAT GBT Phase lookup table
 
         gemType - string specifying gemType, expexted to be a key in gemVariants dictionary

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -163,7 +163,7 @@ class HwOptoHybrid(object):
         L1AInterval - Number of BX's inbetween L1A's
         mask        - VFAT mask to use for excluding vfats from the trigger
         nevts       - Number of events for each dac value in scan
-        outData     - Pointer to an array of size (24*128*8*nevts) which
+        outData     - Pointer to an array of size (self.parentAMC.nVFAT*128*8*nevts) which
                       stores the results of the scan:
                             bits [0,7] channel pulsed,
                             bits [8:15] sbit observed,
@@ -342,7 +342,7 @@ class HwOptoHybrid(object):
         """
         V3 electronics only
 
-        Returns a 24 bit number that should be used as the VFAT Mask
+        Returns a self.parentAMC.nVFAT bit number that should be used as the VFAT Mask
         """
 
         return self.parentAMC.getLinkVFATMask(self.link)
@@ -370,7 +370,7 @@ class HwOptoHybrid(object):
         mask        - VFAT mask to use
         nevts       - Number of events for each dac value in scan
         outData     - Array of type c_uint32, if chan >= 0 array size
-                      must be: ((dacMax - dacMin + 1) / stepSize) * 24.
+                      must be: ((dacMax - dacMin + 1) / stepSize) * self.parentAMC.nVFAT.
                       The first ((dacMax - dacMin + 1) / stepSize)
                       array positions are for VFAT0, the next
                       ((dacMax - dacMin + 1) / stepSize) are for VFAT1,
@@ -483,7 +483,7 @@ class HwOptoHybrid(object):
             exit(os.EX_USAGE)
 
         #Check length of results container
-        lenExpected = (maxVfat3DACSize[dacSelect][0] - 0+1)*24 / dacStep
+        lenExpected = (maxVfat3DACSize[dacSelect][0] - 0+1)*self.parentAMC.nVFAT / dacStep
         if (len(outData) != lenExpected):
             print("HwOptoHybrid::performDacScan(): I expected container of lenght {0} but provided 'outData' has length {1}",format(lenExpected, len(outData)))
             exit(os.EX_USAGE)

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -80,17 +80,17 @@ class HwOptoHybrid(object):
         self.genScan.restype = c_uint
         self.genScan.argtypes = [c_uint, c_uint, c_uint, c_uint,
                                  c_uint, c_uint, c_bool, c_bool, c_uint, c_uint,
-                                 c_char_p, c_bool, c_bool, POINTER(c_uint32)]
+                                 c_char_p, c_bool, c_bool, POINTER(c_uint32), c_uint]
         self.genChannelScan = self.parentAMC.lib.genChannelScan
         self.genChannelScan.restype = c_uint
         self.genChannelScan.argtypes = [c_uint, c_uint, c_uint, c_uint,
                                         c_uint, c_uint, c_bool, c_bool,
                                         c_uint, c_bool, c_char_p, c_bool,
-                                        POINTER(c_uint32)]
+                                        POINTER(c_uint32), c_uint]
 
         self.dacScan = self.parentAMC.lib.dacScan
         self.dacScan.restype = c_uint
-        self.dacScan.argtypes = [ c_uint, c_uint, c_uint, c_uint, c_bool, POINTER(c_uint32) ]
+        self.dacScan.argtypes = [ c_uint, c_uint, c_uint, c_uint, c_bool, POINTER(c_uint32), c_uint]
 
         # Define the known V2b electronics scan registers
         self.KnownV2bElScanRegs = [
@@ -454,9 +454,9 @@ class HwOptoHybrid(object):
             useExtTrig = kwargs["useExtTrig"]
 
         if chan < 0:
-            return self.genChannelScan(nevts, self.link, mask, dacMin, dacMax, stepSize, enableCal, currentPulse, calSF, useExtTrig, scanReg, useUltra, kwargs["outData"])
+            return self.genChannelScan(nevts, self.link, mask, dacMin, dacMax, stepSize, enableCal, currentPulse, calSF, useExtTrig, scanReg, useUltra, kwargs["outData"], self.nVFATs)
         else:
-            return self.genScan(nevts, self.link, dacMin, dacMax, stepSize, chan, enableCal, currentPulse, calSF, mask, scanReg, useUltra, useExtTrig, kwargs["outData"])
+            return self.genScan(nevts, self.link, dacMin, dacMax, stepSize, chan, enableCal, currentPulse, calSF, mask, scanReg, useUltra, useExtTrig, kwargs["outData"], self.nVFATs)
 
     def performDacScan(self, outData, dacSelect, dacStep=1, mask=0x0, useExtRefADC=False):
         """
@@ -488,7 +488,7 @@ class HwOptoHybrid(object):
             print("HwOptoHybrid::performDacScan(): I expected container of lenght {0} but provided 'outData' has length {1}",format(lenExpected, len(outData)))
             exit(os.EX_USAGE)
 
-        return self.dacScan(self.link, dacSelect, dacStep, mask, useExtRefADC, outData)
+        return self.dacScan(self.link, dacSelect, dacStep, mask, useExtRefADC, outData, self.nVFATs)
 
     def setDebug(self, debug):
         self.debug = debug

--- a/gempython/tools/optohybrid_user_functions_xhal.py
+++ b/gempython/tools/optohybrid_user_functions_xhal.py
@@ -163,7 +163,7 @@ class HwOptoHybrid(object):
         L1AInterval - Number of BX's inbetween L1A's
         mask        - VFAT mask to use for excluding vfats from the trigger
         nevts       - Number of events for each dac value in scan
-        outData     - Pointer to an array of size (self.parentAMC.nVFAT*128*8*nevts) which
+        outData     - Pointer to an array of size (self.nVFATs*128*8*nevts) which
                       stores the results of the scan:
                             bits [0,7] channel pulsed,
                             bits [8:15] sbit observed,
@@ -342,7 +342,7 @@ class HwOptoHybrid(object):
         """
         V3 electronics only
 
-        Returns a self.parentAMC.nVFAT bit number that should be used as the VFAT Mask
+        Returns a self.nVFATs bit number that should be used as the VFAT Mask
         """
 
         return self.parentAMC.getLinkVFATMask(self.link)
@@ -370,7 +370,7 @@ class HwOptoHybrid(object):
         mask        - VFAT mask to use
         nevts       - Number of events for each dac value in scan
         outData     - Array of type c_uint32, if chan >= 0 array size
-                      must be: ((dacMax - dacMin + 1) / stepSize) * self.parentAMC.nVFAT.
+                      must be: ((dacMax - dacMin + 1) / stepSize) * self.nVFATs.
                       The first ((dacMax - dacMin + 1) / stepSize)
                       array positions are for VFAT0, the next
                       ((dacMax - dacMin + 1) / stepSize) are for VFAT1,
@@ -483,7 +483,7 @@ class HwOptoHybrid(object):
             exit(os.EX_USAGE)
 
         #Check length of results container
-        lenExpected = (maxVfat3DACSize[dacSelect][0] - 0+1)*self.parentAMC.nVFAT / dacStep
+        lenExpected = (maxVfat3DACSize[dacSelect][0] - 0+1)*self.nVFATs / dacStep
         if (len(outData) != lenExpected):
             print("HwOptoHybrid::performDacScan(): I expected container of lenght {0} but provided 'outData' has length {1}",format(lenExpected, len(outData)))
             exit(os.EX_USAGE)

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -21,6 +21,8 @@ class HwVFAT(object):
         if detType not in gemVariants[gemType]:
             raise OHTypeException("HwVFAT: detType '{0}' not in the list of known detector types for gemType {1}; list of known detector types: {2}".format(detType, gemType, gemVariants[gemType]), os.EX_USAGE)
 
+        self.gemType = gemType
+
         # Optohybrid
         self.parentOH = HwOptoHybrid(cardName, link, debug, gemType, detType)
 
@@ -124,9 +126,9 @@ class HwVFAT(object):
         rawID - If true returns the rawID and does not apply the Reed-Muller decoding
         """
 
-        chipIDData = (c_uint32 * vfatsPerGemVariant[gemType])()
+        chipIDData = (c_uint32 * vfatsPerGemVariant[self.gemType])()
 
-        rpcResp = self.getVFAT3ChipIDs(chipIDData, self.parentOH.link, mask, rawID, vfatsPerGemVariant[gemType])
+        rpcResp = self.getVFAT3ChipIDs(chipIDData, self.parentOH.link, mask, rawID, vfatsPerGemVariant[self.gemType])
         if rpcResp != 0:
             raise Exception("RPC response was non-zero, failed to get chipID data for OH{0}".format(self.parentOH.link))
 

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -32,7 +32,7 @@ class HwVFAT(object):
         self.confDacMonitor.restype = c_uint
 
         self.readADCs = self.parentOH.parentAMC.lib.readVFAT3ADC
-        self.readADCs.argTypes = [ c_uint, POINTER(c_uint32), c_uint, c_uint ]
+        self.readADCs.argTypes = [ c_uint, POINTER(c_uint32), c_bool, c_uint, c_uint ]
         self.readADCs.restype = c_uint
 
         # Define VFAT3 Configuration
@@ -42,12 +42,12 @@ class HwVFAT(object):
 
         # Get all channel regs
         self.getChannelRegistersVFAT3 = self.parentOH.parentAMC.lib.getChannelRegistersVFAT3
-        self.getChannelRegistersVFAT3.argTypes = [ c_uint, c_uint, POINTER(c_uint32) ]
+        self.getChannelRegistersVFAT3.argTypes = [ c_uint, c_uint, POINTER(c_uint32), c_uint ]
         self.getChannelRegistersVFAT3.restype = c_uint
 
         # Get VFAT ChipID
         self.getVFAT3ChipIDs = self.parentOH.parentAMC.lib.getVFAT3ChipIDs
-        self.getVFAT3ChipIDs.argTypes = [ POINTER(c_uint32), c_uint, c_uint, c_bool ]
+        self.getVFAT3ChipIDs.argTypes = [ POINTER(c_uint32), c_uint, c_uint, c_bool, c_uint]
         self.getVFAT3ChipIDs.restype = c_uint
 
         # Turn off calpulses
@@ -57,7 +57,7 @@ class HwVFAT(object):
 
         # Write all channel regs
         self.setChannelRegistersVFAT3 = self.parentOH.parentAMC.lib.setChannelRegistersVFAT3
-        self.setChannelRegistersVFAT3.argTypes = [ c_uint, c_uint, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32) ]
+        self.setChannelRegistersVFAT3.argTypes = [ c_uint, c_uint, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), c_uint ]
         self.setChannelRegistersVFAT3.restype = c_uint
 
         # Set default parameters
@@ -137,7 +137,7 @@ class HwVFAT(object):
     def getAllChannelRegisters(self, mask=0x0):
         chanRegData = (c_uint32 * 3072)()
 
-        rpcResp = self.getChannelRegistersVFAT3(self.parentOH.link, mask, chanRegData)
+        rpcResp = self.getChannelRegistersVFAT3(self.parentOH.link, mask, chanRegData, vfatsPerGemVariant[self.gemType])
         if rpcResp != 0:
             raise Exception("RPC response was non-zero, failed to get channel data for OH{0}".format(self.parentOH.link))
         return chanRegData
@@ -151,7 +151,7 @@ class HwVFAT(object):
         mask - VFAT Mask
         """
 
-        return self.readADCs(self.parentOH.link, adcData, useExtRefADC, mask)
+        return self.readADCs(self.parentOH.link, adcData, useExtRefADC, mask, vfatsPerGemVariant[self.gemType])
 
     def readAllVFATs(self, reg, mask=0x0):
         vfatVals = self.parentOH.broadcastRead(reg,mask)
@@ -244,7 +244,7 @@ class HwVFAT(object):
         if trimZCCPol is None:
             trimZCCPol = (c_uint32 * 3072)()
 
-        return self.setChannelRegistersVFAT3(self.parentOH.link, vfatMask, pulse, chMask, trimARM, trimARMPol, trimZCC, trimZCCPol)
+        return self.setChannelRegistersVFAT3(self.parentOH.link, vfatMask, pulse, chMask, trimARM, trimARMPol, trimZCC, trimZCCPol, vfatsPerGemVariant[self.gemType])
 
     def setDebug(self, debug):
         self.debug = debug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implements GE2/1 compatibility. All new parameters are backed with default values set to GE1/1 defaults. Thus the rest of the software should be able to work unchanged. Requires https://github.com/cms-gem-daq-project/ctp7_modules/pull/132 to work with GE2/1
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Need to be able to use the current legacy software for GE2/1 integration stand
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with GE2/1 integration stand.
### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
