### PR TITLE
Addressing #299: Changing setDAQParamsPostConfigure.py to Take Sysadmin Configurable link enable mask

### DIFF
--- a/gempython/tools/xdaq/setDAQParamsPostConfigure.py
+++ b/gempython/tools/xdaq/setDAQParamsPostConfigure.py
@@ -7,20 +7,81 @@ def setDAQParams(args):
     from gempython.utils.gracefulKiller import GracefulKiller
     killer = GracefulKiller()
 
+    # Get ENV variable
+    from gempython.utils.wrappers import envCheck
+    envCheck("GEM_ADDRESS_TABLE_PATH")
+    import os
+    gemAddrPath = os.getenv("GEM_ADDRESS_TABLE_PATH")
+
+    # Determine INPUT_ENABLE_MASK
+    dict_ohMask = {}
+    import sys
+    if os.path.isfile("{}/gem-shelf{:02d}-input-en-mask.txt".format(gemAddrPath,args.shelf)):
+        printGreen("Loading existing input enable mask file at: $GEM_ADDRESS_TABLE_PATH/gem-shelf{:02d}-input-en-mask.txt".format(args.shelf))
+        # Load masks
+        inptEnMaskFile = open("{}/gem-shelf{:02d}-input-en-mask.txt".format(gemAddrPath,args.shelf),"r")
+        for row,line in enumerate(inptEnMaskFile):
+            # Skip commented lines
+            if line[0] == "#":
+                continue
+
+            # Parse line
+            line = line.strip("\n")
+            slotList = line.split(",")
+
+            # Get slot
+            try:
+                thisSlot = int(slotList[0],10)
+            except ValueError as err:
+                printRed("Reading $GEM_ADDRESS_TABLE_PATH/gem-shelf{:02d}-input-en-mask.txt: Invalid value given for AMC slot {}.  I was expecting an integer in [1,12] in decimal representation".format(args.shelf,slotList[0]))
+                inptEnMaskFile.close()
+                sys.exit(os.EX_DATAERR)
+
+            # Get ohMask
+            try:
+                dict_ohMask[thisSlot] = int(slotList[1],16)
+            except ValueError as err:
+                printRed("Reading $GEM_ADDRESS_TABLE_PATH/gem-shelf{:02d}-input-en-mask.txt: For AMC slot {} invalid value given for ohMask: {}.  I was expecting an integer [0x0,0xfff] in hexidecimal representation with a leading '0x'".format(args.shelf,thisSlot,slotList[1]))
+                inptEnMaskFile.close()
+                sys.exit(os.EX_DATAERR)
+                pass
+
+            if dict_ohMask[thisSlot] > 0xfff:
+                printYellow("OH Mask determined fro slot {} found to be greater than maximum allowed value 0xfff.  Reseting to 0xfff".format(thisSlot))
+                dict_ohMask[thisSlot] = 0xfff
+                pass
+            pass
+    else:
+        printYellow("No existing input enable mask file found, creating one with default settings at: $GEM_ADDRESS_TABLE_PATH/gem-shelf{:02d}-input-en-mask.txt".format(args.shelf))
+        inptEnMaskFile = open("{}/gem-shelf{:02d}-input-en-mask.txt".format(gemAddrPath,args.shelf),"w")
+        inptEnMaskFile.write("#slot,ohMask#\n")
+        inptEnMaskFile.write("#############\n")
+        for slot in range(1,13):
+            dict_ohMask[slot]=0xfff
+            inptEnMaskFile.write("{},{}\n".format(slot,dict_ohMask[slot]))
+            pass
+        pass
+
+    # Configure backend electronics
     for slot in range(0,12):
         # Skip unmasked slots
         if (not ((args.slotMask >> slot) & 0x1)):
             continue
+        thisSlot = slot+1
 
         # Make the AMC Object w/uhal
         global amc
-        amc = getAMCObject(slot+1,args.shelf,args.d)
+        amc = getAMCObject(thisSlot,args.shelf,args.d)
 
         # Get ohMask for this slot
         from gempython.tools.amc_user_functions_xhal import HwAMC
-        cardName = "gem-shelf%02d-amc%02d"%(args.shelf,slot+1)
+        cardName = "gem-shelf%02d-amc%02d"%(args.shelf,thisSlot)
         amcRPC = HwAMC(cardName,debug=args.d)
-        ohMask = amcRPC.getOHMask(raiseIfNoOHs=False)
+        try:
+            ohMask = dict_ohMask[thisSlot]
+        except KeyError as err:
+            printYellow("AMC Slot {} not found in $GEM_ADDRESS_TABLE_PATH/gem-shelf{:02d}-input-en-mask.txt. Defaulting to dynamically determined ohMask".format(thisSlot,args.shelf))
+            ohMask = amcRPC.getOHMask(raiseIfNoOHs=False)
 
         # Set the input enable mask
         amc.getNode("GEM_AMC.DAQ.CONTROL.INPUT_ENABLE_MASK").write(ohMask)


### PR DESCRIPTION
## Description
Fixes #299 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
Breaking because `LINK_ENABLE_MASK` will no longer be determined dynamically by default.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See discussion in #299.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On QC8 machine over weekend with runs 196-200; works like a charm.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
