### PR TITLE
Bug Fix: wrong RunType value assigned for latency scans

### DIFF
--- a/gempython/tools/xdaq/set_scanParams_latency.py
+++ b/gempython/tools/xdaq/set_scanParams_latency.py
@@ -71,7 +71,7 @@ def setScanParamsLatency(args):
         if sum(badreg) > 0:
             printRed("OH{} :: {} VFATs do not match expectation 0x{:02x}".format(ohN,sum(badreg),wval))
         
-    amc.getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE").write(0x3)
+    amc.getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE").write(0x2)
     amc.getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS").write((wval<<16)|(rparm&0xffff))
     rtype = amc.getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE").read()
     rparm = amc.getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS").read()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`RunType` should be `0x2` for latency scans as described in issue #230

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Fix the bug to match the convention.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
