### PR TITLE
New Feature: trackingDataCalibrationScan.py for calibration scans using full datapath (Addressing Issue #284)

### DIFF
--- a/gempython/Makefile
+++ b/gempython/Makefile
@@ -85,6 +85,7 @@ _rpmprep: _all
 	@cp -rf tests/*.py $(ScriptDir)
 	@cp -rf tools/xdaq/set_scanParams_latency.py $(ScriptDir)
 	@cp -rf tools/xdaq/setDAQParamsPostConfigure.py $(ScriptDir)
+	@cp -rf tools/xdaq/trackingDataCalibrationScan.py $(ScriptDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt $(PackageDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt pkg
 	@echo "__path__ = __import__('pkgutil').extend_path(__path__, __name__)" > pkg/$(Namespace)/__init__.py

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -212,6 +212,32 @@ class HwAMC(object):
         self.writeRegister("GEM_AMC.TTC.CTRL.L1A_ENABLE", 0x0)
         return
 
+    def configureCalMode(self, enable, pulseDelay=30):
+        """
+        Enable/disable calibration mode of this AMC.
+
+        enable     - True/False; places AMC into calibration mode if True; in
+                     calibration mode an incoming L1A will trigger a calpulse to 
+                     be sent to the frontend followed by an L1A after a fixed delay.
+        pulseDelay - Defines the fixed delay between calpulse and L1A; note a 
+                     value of zero is invalid.  If another L1A comes in before 
+                     pulseDelay has passed it will restart the delay and result in
+                     the previous L1A to the frontend being cancelled; e.g. do
+                     not set this delay longer than consecutive L1A's from the AMC13
+        """
+        if enable:
+            self.writeRegister("GEM_AMC.TTC.GENERATOR.ENABLE",0x0)
+            self.writeRegister("GEM_AMC.TTC.CTRL.CALIBRATION_MODE",0x1)
+            if not (pulseDelay > 0):
+                raise ValueError("AMC::configureCalMode() - pulseDelay must be greater than zero!")
+            else:
+                self.writeRegister("GEM_AMC.TTC.CTRL.CALPULSE_L1A_DELAY",pulseDelay)
+        else:
+            self.writeRegister("GEM_AMC.TTC.CTRL.CALIBRATION_MODE",0x0)
+            pass
+
+        return
+
     def configureTTC(self, pulseDelay, L1Ainterval, ohN=0, mode=0, t1type=0,  nPulses=0, enable=True):
         """
         Default values reflects v3 electronics behavior
@@ -984,6 +1010,14 @@ class HwAMC(object):
         """
 
         return self.ttcGenToggle(ohN, enable)
+
+    def ttcCmdCntReset(self,debug=False):
+        """
+        Resets the TTC Command Counters
+        """
+
+        self.writeRegister("GEM_AMC.TTC.CTRL.CNT_RESET",0x1,debug)
+        return
 
     def writeRegister(self, register, value, debug=False):
         """

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -925,6 +925,27 @@ class HwAMC(object):
 
         return scaMonData
 
+    def setRunType(self,runType,debug=False):
+        """
+        Set the RUN_TYPE word, using convention:
+            https://github.com/cms-gem-daq-project/cmsgemos/issues/230
+
+        runType = 0x1 - Physics (Normal Operation)
+        runType = 0x2 - CFG_LATENCY Scan
+        runType = 0x3 - CFG_THR_ARM_DAC Scan
+        runType = 0x4 - CFG_CAL_DAC Scan (e.g. scurve)
+        """
+
+        return self.writeRegister("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE",runType,debug)
+
+    def setRunParams(self,runParams,debug=False):
+        """
+        Set the RUN_PARAMS words with runParams, see convention:
+            https://github.com/cms-gem-daq-project/cmsgemos/issues/230
+        """
+
+        return self.writeRegister("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS",runParams,debug)
+
     def setShelf(self,shelf):
         self.shelf = shelf
         return
@@ -970,7 +991,6 @@ class HwAMC(object):
         """
         global gRetries
         nRetries = 0
-        #m_node = self.getNode(register)
         m_node = getNode(register)
         if m_node is None:
             print colors.MAGENTA,"NODE %s NOT FOUND"%(register),colors.ENDC

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -134,7 +134,7 @@ class HwVFAT(object):
         if ((calScaleFactor < 0x0) or (calScaleFactor > 0x3)):
             raise RuntimeError("HwVFAT::configureCalPulseAllVFATs - calScaleFactor argument must be in range [0x0,0x3]")
 
-        return self.confCalPulse(self.parentOH.link, ch, toggleOn, currentPulse, calScaleFactor)
+        return self.confCalPulse(self.parentOH.link, mask, ch, toggleOn, currentPulse, calScaleFactor)
 
     def configureDACMonitor(self, dacSelect, mask=0x0):
         """

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -40,6 +40,10 @@ class HwVFAT(object):
         self.confVFAT3s.argTypes = [ c_uint, c_uint ]
         self.confVFAT3s.restype = c_uint
 
+        self.confCalPulse = self.parentOH.parentAMC.lib.confCalPulse
+        self.confCalPulse.argTypes = [ c_uint, c_uint, c_uint, c_bool, c_bool, c_uint ]
+        self.confCalPulse.restype = c_uint 
+
         # Get all channel regs
         self.getChannelRegistersVFAT3 = self.parentOH.parentAMC.lib.getChannelRegistersVFAT3
         self.getChannelRegistersVFAT3.argTypes = [ c_uint, c_uint, POINTER(c_uint32), c_uint ]
@@ -110,6 +114,27 @@ class HwVFAT(object):
             self.writeAllVFATs(key,self.paramsDefVals[key],mask)
 
         return
+
+    def configureCalPulseAllVFATs(self, ch, toggleOn, mask=0x0, currentPulse=False,  calScaleFactor=0x0):
+        """
+        Configures calibration module for channel ch on all unmasked VFATs. If ch==128 and toggleOn == False this
+        will write the CALPULSE_ENABLE bit for all channels to 0x0 on all unmasked VFATs.
+
+        ch - VFAT channel of interest
+        toggleOn - If True (False) CALPULSE_ENABLE will be set to 0x1 (0x0)
+        mask - VFAT mask
+        currentPulse - If True (False) calibration module will perform current pulse (voltage step) injection
+        calScaleFactor - Scale factor for the calibration pulse in current pulse injection (0x0 = 25%, 0x1 = 50%, 0x2 = 75% and 0x3 = 100%)
+        """
+        
+        if ( ch == 128 and toggleOn == False):
+            print("HwVFAT::configureCalPulseAllVFATs - Disabling calpulse on all unmasked VFATs") 
+        elif ((ch < 0) or (ch > 127)):
+            raise RuntimeError("HwVFAT::configureCalPulseAllVFATs - ch argument must be in range [0,127] or ch argument must be 128 and toggleOn argument must be False")
+        if ((calScaleFactor < 0x0) or (calScaleFactor > 0x3)):
+            raise RuntimeError("HwVFAT::configureCalPulseAllVFATs - calScaleFactor argument must be in range [0x0,0x3]")
+
+        return self.confCalPulse(self.parentOH.link, ch, toggleOn, currentPulse, calScaleFactor)
 
     def configureDACMonitor(self, dacSelect, mask=0x0):
         """

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -64,6 +64,10 @@ class HwVFAT(object):
         self.setChannelRegistersVFAT3.argTypes = [ c_uint, c_uint, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), c_uint ]
         self.setChannelRegistersVFAT3.restype = c_uint
 
+        self.setChannelRegistersVFAT3Simple = self.parentOH.parentAMC.lib.setChannelRegistersVFAT3Simple
+        self.setChannelRegistersVFAT3Simple.argTypes = [ c_uint, c_uint, POINTER(c_uint32) ]
+        self.setChannelRegistersVFAT3Simple.restype = c_uint
+
         # Set default parameters
         self.paramsDefVals = {}
         if self.parentOH.parentAMC.fwVersion < 3:
@@ -250,7 +254,7 @@ class HwVFAT(object):
             self.setChannelRegister(vfat, chan, chMask, pulse, trimARM, trimARMPol, trimZCC, trimZCCPol, debug)
         return
 
-    def setAllChannelRegisters(self, chMask=None, pulse=None, trimARM=None, trimARMPol=None, trimZCC=None, trimZCCPol=None, vfatMask=0x0, debug=False):
+    def setAllChannelRegisters(self, chanRegData=None, chMask=None, pulse=None, trimARM=None, trimARMPol=None, trimZCC=None, trimZCCPol=None, vfatMask=0x0, debug=False):
         """
         Sets all channel registers for all VFAT3s on the detector
 
@@ -264,20 +268,26 @@ class HwVFAT(object):
         debug - print debug information
         """
 
-        if chMask is None:
-            chMask = (c_uint32 * 3072)()
-        if pulse is None:
-            pulse = (c_uint32 * 3072)()
-        if trimARM is None:
-            trimARM = (c_uint32 * 3072)()
-        if trimARMPol is None:
-            trimARMPol = (c_uint32 * 3072)()
-        if trimZCC is None:
-            trimZCC = (c_uint32 * 3072)()
-        if trimZCCPol is None:
-            trimZCCPol = (c_uint32 * 3072)()
+        if chanRegData is not None:
+            if len(chanRegData) != 3072:
+                raise RuntimeError("HwVFAT::setAllChannelRegisters - chanRegData is expected to be either None or a ctype array of c_uint32 objects 3072 in length; current length: {:d}".format(len(chanRegData)))
 
-        return self.setChannelRegistersVFAT3(self.parentOH.link, vfatMask, pulse, chMask, trimARM, trimARMPol, trimZCC, trimZCCPol, vfatsPerGemVariant[self.gemType])
+            return self.setChannelRegistersVFAT3Simple(self.parentOH.link, vfatMask, chanRegData)
+        else:
+            if chMask is None:
+                chMask = (c_uint32 * 3072)()
+            if pulse is None:
+                pulse = (c_uint32 * 3072)()
+            if trimARM is None:
+                trimARM = (c_uint32 * 3072)()
+            if trimARMPol is None:
+                trimARMPol = (c_uint32 * 3072)()
+            if trimZCC is None:
+                trimZCC = (c_uint32 * 3072)()
+            if trimZCCPol is None:
+                trimZCCPol = (c_uint32 * 3072)()
+
+            return self.setChannelRegistersVFAT3(self.parentOH.link, vfatMask, pulse, chMask, trimARM, trimARMPol, trimZCC, trimZCCPol, vfatsPerGemVariant[self.gemType])
 
     def setDebug(self, debug):
         self.debug = debug

--- a/gempython/tools/vfat_user_functions_xhal.py
+++ b/gempython/tools/vfat_user_functions_xhal.py
@@ -83,6 +83,11 @@ class HwVFAT(object):
                 "VThreshold2": 0x00,
                 "CalPhase":    0x00
                 }
+        else:
+            self.knownCalModes = { 0x0:"DISABLED",
+                                   0x1:"VOLTAGE_STEP_PULSE", 
+                                   0x2:"CURRENT_INJECTION"}
+            pass
 
         return
 
@@ -300,6 +305,20 @@ class HwVFAT(object):
 
         return self.stopCalPulses2AllChannels(self.parentOH.link, mask, chanMin, chanMax)
 
+    def setVFATCalDur(self, chip, calDur=0xA, debug=False):
+        if self.parentOH.parentAMC.fwVersion < 3:
+            raise RuntimeError("HwVFAT::setVFATCalDur not implemented for v2b electronics")
+
+        self.writeVFATRegisters(chip,{"CFG_CAL_DUR": (calDur)})
+        return
+
+    def setVFATCalDurAll(self, mask=0x0, calDur=0xA, debug=False):
+        if self.parentOH.parentAMC.fwVersion < 3:
+            raise RuntimeError("HwVFAT::setVFATCalDurAll not implemented for v2b electronics")
+
+        self.writeAllVFATs("CFG_CAL_DUR", calDur, mask)
+        return
+
     def setVFATCalHeight(self, chip, height, currentPulse=True, debug=False):
         if self.parentOH.parentAMC.fwVersion > 2:
             if currentPulse: #Current pulse, high CFG_CAL_DAC is a high injected charge amount
@@ -318,6 +337,26 @@ class HwVFAT(object):
                 self.writeAllVFATs("CFG_CAL_DAC", (256 - height), mask)
         else:
             self.writeAllVFATs("VCal", height, mask)
+        return
+
+    def setVFATCalMode(self, chip, calMode=0x1, debug=False):
+        if self.parentOH.parentAMC.fwVersion < 3:
+            raise RuntimeError("HwVFAT::setVFATCalMode not implemented for v2b electronics")
+
+        if calMode not in self.knownCalModes.keys():
+            raise RuntimeError("HwVFAT::setVFATCalMode - calMode 0x{:x} not recognized list of known modes are: {:s}".format([ "0x{:x}".format(mode) for mode in self.knownCalModes.keys()]))
+
+        self.writeVFATRegisters(chip,{"CFG_CAL_MODE": (calMode)})
+        return
+
+    def setVFATCalModeAll(self, mask=0x0, calMode=0x1, debug=False):
+        if self.parentOH.parentAMC.fwVersion < 3:
+            raise RuntimeError("HwVFAT::setVFATCalModeAll not implemented for v2b electronics")
+
+        if calMode not in self.knownCalModes.keys():
+            raise RuntimeError("HwVFAT::setVFATCalModeAll - calMode 0x{:x} not recognized list of known modes are: {:s}".format([ "0x{:x}".format(mode) for mode in self.knownCalModes.keys()]))
+
+        self.writeAllVFATs("CFG_CAL_MODE", calMode, mask)
         return
 
     def setVFATCalPhase(self, chip, phase, debug=False):

--- a/gempython/tools/xdaq/setDAQParamsPostConfigure.py
+++ b/gempython/tools/xdaq/setDAQParamsPostConfigure.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-s","--slotMask", help="Slot mask to apply, a 1 in the n^th bit indicates the n^th slot should be considered", type=parseInt)
+    parser.add_argument("-s","--slotMask", help="Slot mask to apply, a 1 in the N^th bit indicates the (N+1)^th slot should be considered", type=parseInt)
     parser.add_argument("--shelf", help="uTCA shelf number", type=int)
     parser.add_argument("-d", help="debug", action='store_true')
 

--- a/gempython/tools/xdaq/trackingDataCalibrationScan.py
+++ b/gempython/tools/xdaq/trackingDataCalibrationScan.py
@@ -1,0 +1,323 @@
+#!/bin/env python
+
+from gempython.utils.gemlogger import colors, printRed
+
+# FIXME place in a HwAMC class or HwVFAT?
+# FIXME place in hw_constants.py?
+# From https://github.com/cms-gem-daq-project/cmsgemos/issues/230
+dict_scanRegsByRunType = {
+            0x2:"CFG_LATENCY",
+            0x3:"CFG_THR_ARM_DAC",
+            0x4:"CFG_CAL_DAC"
+        }
+
+def toggleSettings4DAQ(amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMasks, runParams, runType, enableCal=True, enableRun=True):
+    """
+    Toggles both DAQ settings and calpulse settings of VFAT3s.
+    Triggers should be stopped before calling this method
+
+    amcMask         - 12 bit number specifying which AMC's to use, if the N^th bit is 1 this means use 
+                      the (N+1)^th AMC slot
+    chan            - VFAT Channel to configure calpulse for
+    dict_ohMasks    - dictionary of integers where the keys are AMC slot numbers and the values are
+                      a 12 bit number representing the ohMask; a 1 in the N^th bit means use the N^th
+                      optohybrid
+    dict_vfatBoards - dictionary of HwVFAT objects where the key values are AMC Slot Numbers 
+    dict_vfatMasks  - dictionary of ctype arrays; each ctype array has a size of 12 and each array 
+                      position stores the vfatmask values to use with the optohybrid at (slot,link).
+                      Here each vfatmask is a 24 bit number; if the N^th bit is 1 this means skip 
+                      the N^th VFAT.
+    runParams       - Run Parameters words to insert
+    runType         - Run Type word to insert
+    enableCal       - If True (False) enables (disables) the calibration pulse to chan on all unmasked VFATs
+    enableRun       - If True (False) places all unmasked VFATs into Run (Sleep) mode
+    """
+
+    # Loop over all AMCs
+    for amcN in range(12):
+        # Skip masked AMC's        
+        if( not ((amcMask >> amcN) & 0x1)):
+            continue
+
+        # Update the slot number
+        thisSlot = amcN+1
+
+        # Update RunParams and RunType words
+        dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunParams(runParams)
+        dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunType(runType)
+
+        # Loop Over OH's on this AMC and CalPulse to this chan and set VFATs to run mode
+        for ohN in range(dict_vfatBoards[thisSlot].parentOH.parentAMC.nOHs):
+            if ((dict_ohMasks[thisSlot] >> ohN) & 0x0):
+                continue
+
+            # Set the link in dict_vfatBoards[thisSlot]
+            dict_vfatBoards[thisSlot].parentOH.link = ohN
+
+            # Update the calibration pulse setting for this chan
+            dict_vfatBoards[thisSlot].configureCalPulseAllVFATs(chan,toggleOn=enableCal,mask=dict_vfatMasks[thisSlot][ohN])
+
+            # Place these VFATs into Run Mode?
+            dict_vfatBoards[thisSlot].setRunModeAll(mask=dict_vfatMasks[thisSlot][ohN], enable=enableRun)
+
+            ## Order Matters as SlowControl commands are not prioritized in run mode
+            #if enableRun: # Place VFATs into Run Mode, first perform slow control
+            #    # Update the calibration pulse setting for this chan
+            #    dict_vfatBoards[thisSlot].configureCalPulseAllVFATs(chan,toggleOn=enableCal,mask=dict_vfatMasks[thisSlot][ohN])
+            #    
+            #    # Place these VFATs into Run Mode
+            #    dict_vfatBoards[thisSlot].setRunModeAll(mask=dict_vfatMasks[thisSlot][ohN])
+            #else:         # Place VFATs into Sleep Mode, first do that then try other slow control cmds
+            #    # Take these VFATs out of Run Mode
+            #    dict_vfatBoards[thisSlot].setRunModeAll(mask=dict_vfatMasks[thisSlot][ohN],enable=False)
+            #    
+            #    # Update the calibration pulse setting for this chan
+            #    dict_vfatBoards[thisSlot].configureCalPulseAllVFATs(chan,toggleOn=enableCal,mask=dict_vfatMasks[thisSlot][ohN])
+            #    pass
+            pass # End Loop over OH's
+        pass # End Loop over AMCs
+    return
+
+def trackingDataScan(args, runType):
+    """
+    Notes
+
+    args needs to have:
+
+        args.amc13SendsCalPulses true/false, if true use BGO's if False use evka85's FW (3.8.4 or higher...?)
+        args.amcMask ... ? this should be a 12 bit number but the N^th bit corresponds to amc slot N+1
+        args.debug
+        ~~args.detType~~
+        ~~args.gemType~~
+        args.shelf
+
+        # VFAT Specific Parameters (should come from an argument group...?)
+        args.latency
+        args.pulseStretch (default 0x3)
+        args.calPhase (default 0x0)
+        args.ZSMode ...? Something about zero suppression?
+
+        # Scan settings
+        args.chMax, default 127
+        args.chMin, default 0
+        args.dacMax, default 255
+        args.dacMin, default 0
+        args.dacStep, default 1
+        args.nevts, default 100
+
+    Additional options:
+
+        runType - integer, see https://github.com/cms-gem-daq-project/cmsgemos/issues/230
+                  Maybe we should declare a class for the possibilities here...? 
+
+    """
+
+
+    from gempython.utils.gracefulKiller import GracefulKiller
+    killer = GracefulKiller()
+
+    # Check if GEM_ADDRESS_TABLE_PATH
+    from gempython.utils.wrappers import envCheck
+    envCheck('GEM_ADDRESS_TABLE_PATH')
+
+    import os
+    try:
+        scanReg = dict_scanRegsByRunType[runType]
+    except KeyError as err:
+        msg="trackingDataScan() - KeyError: RunType = {0} Not understood, possible values are:\n".format(runType)
+        for key,regName in dict_scanRegsByRunType.iteritems():
+            msg = "{0}\n{1}\t{2}".format(msg,key,regName)
+            pass
+        printRed(msg)
+        return os.EX_USAGE
+
+    # Declare the following dictionaries
+    from gempython.utils.nesteddict import nesteddict as ndict
+    dict_vfatBoards = ndict() # dict_vfatBoards[slot] = HwVFAT(args.shelf,slot, dummyLink) for this (args.shelf,slot)
+    dict_ohMasks = ndict() # dict_ohMasks[slot] = ohMask for this (args.shelf,slot)
+    dict_vfatMasks = ndict() #dict_vfatMasks[slot][link] = vfatmask for this (args.shelf,slot,link)
+
+    # Create an AMC13 class object and stop triggers
+    import amc13, os
+    connection_file = "%s/connections.xml"%(os.getenv("GEM_ADDRESS_TABLE_PATH"))
+    amc13base  = "gem.shelf%02d.amc13"%(args.shelf)
+    amc13board = amc13.AMC13(connection_file,"%s.T1"%(amc13base),"%s.T2"%(amc13base))
+    amc13board.enableLocalL1A(False)
+    amc13board.stopContinuousL1A()
+
+    # Declare all hardware connections and set initial register values
+    from gempython.tools.vfat_user_functions_xhal import HwVFAT
+    for amcN in range(12):
+        # Skip masked AMC's        
+        if( not ((args.amcMask >> amcN) & 0x1)):
+            continue
+        
+        # Open connection to the AMC
+        thisSlot = amcN+1
+        cardName = "gem-shelf%02d-amc%02d"%(args.shelf,thisSlot)
+        #dict_vfatBoards[thisSlot] = HwVFAT(cardName, -1, args.debug, args.gemType, args.detType) # Assign a dummy link for now
+        dict_vfatBoards[thisSlot] = HwVFAT(cardName, -1, args.debug) # Assign a dummy link for now
+
+        # Determine OH's present
+        dict_ohMasks[thisSlot] = dict_vfatBoards[thisSlot].parentOH.parentAMC.getOHMask()
+        
+        # Determine which VFATs to use for all OH's on this AMC
+        dict_vfatMasks[thisSlot] = dict_vfatBoards[thisSlot].parentOH.parentAMC.getMultiLinkVFATMask(dict_ohMasks[thisSlot])
+        for ohN in range(dict_vfatBoards[thisSlot].parentOH.parentAMC.nOHs):
+            if ((dict_ohMasks[thisSlot] >> ohN) & 0x0):
+                continue
+
+            # Set the link in dict_vfatBoards[thisSlot]
+            dict_vfatBoards[thisSlot].parentOH.link = ohN
+
+            # Ensure All Cal Pulses are OFF
+            dict_vfatBoards[thisSlot].stopCalPulses(mask=dict_vfatMasks[thisSlot][ohN])
+
+            # Set initial register parameters
+            dict_vfatBoards[thisSlot].setVFATLatencyAll(mask=dict_vfatMasks[thisSlot][ohN], lat=args.latency)
+            dict_vfatBoards[thisSlot].setVFATMSPLAll(mask=dict_vfatMasks[thisSlot][ohN], mspl=args.pulseStretch)
+            dict_vfatBoards[thisSlot].setVFATCalPhaseAll(mask=dict_vfatMasks[thisSlot][ohN], phase =args.calPhase)
+            if runType == 0x2: # Only for Latency scan
+                dict_vfatBoards[thisSlot].setVFATCalHeightAll(mask=dict_vfatMasks[thisSlot][ohN], currentPulse=False, height=250)
+                pass # End runType == 0x2 (latency scan)
+            pass # End loop over OH's on this AMC
+        pass # End loop over AMC's
+
+    # Configure AMC13 Trigger Mode
+    if (args.amc13SendsCalPulses):    # Calpulses sent by AMC13 as BGO commands
+        if ((runType == 0x2) or (runType == 0x4)):
+            # Configure BGO generator to send a CalPulse before the L1A
+            cmdCalPulse = 0x14
+            amc13board.configureBGOShort(0, cmdCalPulse, 450, 0, True) # Should send CalPulse at BX = 450; but might actually be 470 from debugging
+            pass
+
+        # Configure locally generated triggers for one L1A per orbit @ BX=500
+        amc13board.configureLocalL1A(True, 0, 1, 1, 0)
+    else:                           # Calpulses sent by CTP7 on receipt of L1A from AMC13
+        # place holder
+        # Here a higher frequency of L1A's can probably be used
+        # implement new features of: https://github.com/evka85/GEM_AMC/releases/tag/v3.8.4
+        raise RuntimeError("trackingDataScan(): Mode Not Implemented Yet")
+
+    # Perform the scan
+    for dacVal in range(args.dacMin,args.dacMax+args.dacStep,args.dacStep):
+        # stop triggers coming from AMC13
+        amc13board.stopContinuousL1A()
+
+        # Loop over all AMCs and mark data as bad with RUN_TYPE and RUN_PARAMS words
+        for amcN in range(12):
+            # Skip masked AMC's 
+            if( not ((args.amcMask >> amcN) & 0x1)):
+                continue
+
+            # Set the slot number as amcN+1
+            thisSlot = amcN+1
+
+            # Mark data as invalid
+            dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunParams(0x0)
+            dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunType(0xf)
+
+            # Loop Over OH's on this AMC and set the scanReg to the reg of interest
+            for ohN in range(dict_vfatBoards[thisSlot].parentOH.parentAMC.nOHs):
+                if ((dict_ohMasks[thisSlot] >> ohN) & 0x0):
+                    continue
+
+                # Set the link in dict_vfatBoards[thisSlot]
+                dict_vfatBoards[thisSlot].parentOH.link = ohN
+
+                # Write the DAC Value
+                dict_vfatBoards[thisSlot].writeAllVFATs(scanReg,dacVal,dict_vfatMasks[thisSlot][ohN])
+                pass # End Loop over all OH's on this slot
+            pass # End Loop over all AMC's on this shelf?
+
+        # Enable triggers from AMC13
+        amc13board.enableLocalL1A(True)
+
+        if runType == 0x3:  # Threshold Scan
+            # placeholder
+            raise RuntimeError("trackingDataScan(): Mode Not Implemented Yet")
+        elif ((runType == 0x2) or (runType == 0x4)): #Latency Scan or Scurve
+            # placeholder
+            for chan in range(args.chMin,args.chMax+1):
+                #FIXME might need amc13board.enableLocalL1A(True) here?
+
+                # Set this channel to pulse for all VFATs and place all VFATs into run mode
+                toggleSettings4DAQ(args.amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMasks, dacVal, runType, enableCal=True, enableRun=True)
+
+                # Send Triggers
+                for evt in range(args.nevts):
+                    amc13board.sendL1ABurst()
+                    pass # End Event loop
+                #FIXME might need amc13board.enableLocalL1A(False) here?
+
+                # Stop calpulse to this channel for all VFATs and take VFATs out of run mode
+                toggleSettings4DAQ(args.amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMasks, 0x0, 0xf, enableCal=False, enableRun=False)
+                pass # End Loop over VFAT Channels
+            pass # End if-elif statement
+        pass # End Loop over DAC Range
+
+    return
+
+if __name__ == '__main__':
+    from reg_utils.reg_interface.common.reg_xml_parser import parseInt
+    
+    import argparse
+    parser = argparse.ArgumentParser()
+
+    # Required Parameters
+    parser.add_argument("amcMask", help="Slot mask to apply, a 1 in the N^th bit indicates the (N+1)^th slot should be considered", type=parseInt)
+    runTypeGroup = parser.add_mutually_exclusive_group(required=True)
+    runTypeGroup.add_argument("--latScan", help="Perform a latency scan using the calibration module", action="store_true")
+    runTypeGroup.add_argument("--scurve", help="Take an scurve scan", action="store_true")
+    runTypeGroup.add_argument("--thrScan", help="Perform a scan of the CFG_THR_ARM_DAC register", action="store_true")
+
+    # Optional Parameters
+    parser.add_argument("-a","--amc13SendsCalPulses",help="If provided AMC13 will generate calpulse commands.  Otherwise the CTP7's will delay the original L1A received and generate a calpulse", action="store_true")
+    parser.add_argument("-d","--debug", help="prints additional debugging information", action="store_true")
+    #parser.add_argument("--gemType",type=str,help="String that defines the GEM variant, available from the list: {0}".format(gemVariants.keys()),default="ge11")
+    parser.add_argument("--shelf", help="uTCA shelf number", type=int, default=1)
+    # FIXME complete the parser
+
+    vfatParamsGroup = parser.add_argument_group(title="VFAT3 Parameters for Scan", description="Settings for the VFATs that need to be applied at runtime")
+    vfatParamsGroup.add_argument("-l","--latency", help="Value to write to CFG_LATENCY during an scurve", type=int, default=500) 
+    vfatParamsGroup.add_argument("-p","--pulseStretch", help="Value to write to CFG_PULSE_STRETCH", type=int, default=0x3)
+    vfatParamsGroup.add_argument("-c","--calPhase", help="Value to write to CFG_CAL_PHI", type=int, default=0x0)
+
+    scanParamsGroup = parser.add_argument_group(title="Scan Parameters", description="Settings that determine the range of channels and DACs for the scan")
+    scanParamsGroup.add_argument("--chMax", help="Maximum VFAT Channel to be scanned", type=int, default=127)
+    scanParamsGroup.add_argument("--chMin", help="Minimum VFAT Channel to be scanned", type=int, default=0)
+    scanParamsGroup.add_argument("--dacMax", help="Maximum DAC value the scan will reach", type=int, default=None)
+    scanParamsGroup.add_argument("--dacMin", help="Minimum DAC value the scan will reach", type=int, default=0)
+    scanParamsGroup.add_argument("--dacStep", help="Step size to move through the DAC in", type=int, default=1)
+    scanParamsGroup.add_argument("-n","--nevts", help="For {0}thrScan{1} this is the number of events that will be acquired per DAC value.  For {0}scurve{1} or {0}latScan{1} this is the number of events that will be acquired per DAC value per channel".format(colors.GREEN,colors.ENDC),type=int,default=100)
+
+    args = parser.parse_args()
+    
+    # Check validity of input arguments
+    if args.debug:
+        print("Running checks")
+    if args.amcMask < 0x0 or args.amcMask > 0xfff:
+        printRed("Invalid amcMask specified 0x{0:x}\namcMask must be in [0x0,0xfff]".format(args.amcMask))
+        exit(os.EX_USAGE)
+
+    # Determine run type
+    if args.latScan:
+        runType = 0x2
+        if args.dacMax is None:
+            args.dacMax = 1023
+    elif args.scurve:
+        runType = 0x4
+        if args.dacMax is None:
+            args.dacMax = 255
+    elif args.thrScan:
+        runType = 0x3
+        if args.dacMax is None:
+            args.dacMax = 255
+        pass
+
+    if args.debug:
+        print("Executing Scan:")
+
+    trackingDataScan(args, runType)
+
+    print("Scan finished. Goodbye")

--- a/gempython/tools/xdaq/trackingDataCalibrationScan.py
+++ b/gempython/tools/xdaq/trackingDataCalibrationScan.py
@@ -1,9 +1,7 @@
 #!/bin/env python
 
-from gempython.utils.gemlogger import colors, printRed
+from gempython.utils.gemlogger import colors, getGEMLogger, printRed
 
-# FIXME place in a HwAMC class or HwVFAT?
-# FIXME place in hw_constants.py?
 # From https://github.com/cms-gem-daq-project/cmsgemos/issues/230
 dict_scanRegsByRunType = {
             0x2:"CFG_LATENCY",
@@ -11,7 +9,38 @@ dict_scanRegsByRunType = {
             0x4:"CFG_CAL_DAC"
         }
 
-def toggleSettings4DAQ(amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMasks, runParams, runType, enableCal=True, enableRun=True):
+def buildRunParamRegV3(runType,scanReg,supportReg,pulseStretch=0x3,scanMode=0x0):
+    """
+    Builds the 24 bit number to be set to GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS
+    using the following rules:
+
+    runType = 0x2: Latency Scan
+        [23:21] scanMode - isCurrentPulse (0 = False, 1 = True)
+        [20:13] supportReg - CFG_CAL_DAC
+        [12:10] pulseStretch - CFG_PULSE_STRETCH
+        [9:0]   scanReg - CFG_LATENCY
+    
+    runType = 0x3: Threshold Scan
+        [23:21] scanMode - CFG_SEL_COMP_MODE (0 = CFG; 1 = ARM; 2 = ZCC)
+        [20:13] scanReg - CFG_THR_ARM_DAC
+        [12:10] pulseStretch - CFG_PULSE_STRETCH
+        [9:0]   supportReg - CFG_THR_ZCC_DAC
+
+    runType = 0x4: Scurve
+        [23:21] scanMode - isCurrentPulse (0 = False, 1 = True)
+        [20:13] scanReg - CFG_CAL_DAC
+        [12:10] pulseStretch - CFG_PULSE_STRETCH
+        [9:0]   supportReg - CFG_LATENCY
+    """
+
+    if runType == 0x2:
+        return ( ((scanMode&0x7)<<21) | ((supportReg&0xff)<<13) | ((pulseStretch&0x7)<<10) | (scanReg&0x3ff) )
+    elif runType == 0x3:
+        return ( ((scanMode&0x7)<<21) | ((scanReg&0xff)<<13) | ((pulseStretch&0x7)<<10) | (supportReg&0x3ff) )
+    elif runType == 0x4:
+        return ( ((scanMode&0x7)<<21) | ((scanReg&0xff)<<13) | ((pulseStretch&0x7)<<10) | (supportReg&0x3ff) )
+
+def toggleSettings4DAQ(amcMask, chan, dict_ohMasks, dict_amcBoards, dict_vfatBoards, dict_vfatMasks, runParams, runType, enableCal=True, enableRun=True):
     """
     Toggles both DAQ settings and calpulse settings of VFAT3s.
     Triggers should be stopped before calling this method
@@ -22,6 +51,7 @@ def toggleSettings4DAQ(amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMa
     dict_ohMasks    - dictionary of integers where the keys are AMC slot numbers and the values are
                       a 12 bit number representing the ohMask; a 1 in the N^th bit means use the N^th
                       optohybrid
+    dict_amcBoards  - dictionary of uhal._core.HwInterface objects where the key values are AMC Slot Numbers
     dict_vfatBoards - dictionary of HwVFAT objects where the key values are AMC Slot Numbers 
     dict_vfatMasks  - dictionary of ctype arrays; each ctype array has a size of 12 and each array 
                       position stores the vfatmask values to use with the optohybrid at (slot,link).
@@ -43,8 +73,9 @@ def toggleSettings4DAQ(amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMa
         thisSlot = amcN+1
 
         # Update RunParams and RunType words
-        dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunParams(runParams)
-        dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunType(runType)
+        dict_amcBoards[thisSlot].getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS").write(runParams)
+        dict_amcBoards[thisSlot].getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE").write(runType)
+        dict_amcBoards[thisSlot].dispatch()
 
         # Loop Over OH's on this AMC and CalPulse to this chan and set VFATs to run mode
         for ohN in range(dict_vfatBoards[thisSlot].parentOH.parentAMC.nOHs):
@@ -111,7 +142,7 @@ def trackingDataScan(args, runType):
                   Maybe we should declare a class for the possibilities here...? 
 
     """
-
+    from time import sleep
 
     from gempython.utils.gracefulKiller import GracefulKiller
     killer = GracefulKiller()
@@ -133,34 +164,46 @@ def trackingDataScan(args, runType):
 
     # Declare the following dictionaries
     from gempython.utils.nesteddict import nesteddict as ndict
+    dict_amcBoardsUHAL = ndict() # dict_amcBoardsUHAL[slot] = uhal._core.HwInterface(slot,args.shelf)
     dict_vfatBoards = ndict() # dict_vfatBoards[slot] = HwVFAT(args.shelf,slot, dummyLink) for this (args.shelf,slot)
     dict_ohMasks = ndict() # dict_ohMasks[slot] = ohMask for this (args.shelf,slot)
     dict_vfatMasks = ndict() #dict_vfatMasks[slot][link] = vfatmask for this (args.shelf,slot,link)
 
-    # Create an AMC13 class object and stop triggers
-    import amc13, os
+    # Create an AMC13 class object, stop triggers and reset counters
+    import amc13, os, uhal
+    uhal.setLogLevelTo( uhal.LogLevel.FATAL )
     connection_file = "%s/connections.xml"%(os.getenv("GEM_ADDRESS_TABLE_PATH"))
     amc13base  = "gem.shelf%02d.amc13"%(args.shelf)
     amc13board = amc13.AMC13(connection_file,"%s.T1"%(amc13base),"%s.T2"%(amc13base))
     amc13board.enableLocalL1A(False)
     amc13board.stopContinuousL1A()
+    amc13board.resetCounters()
 
-    # Declare all hardware connections and set initial register values
+    # Declare all hardware connections, reset TTC/DAQ counters and set initial register values
     from gempython.tools.vfat_user_functions_xhal import HwVFAT
+    from gempython.tools.amc_user_functions_uhal import getAMCObject
+    import logging
+    gemlogger = getGEMLogger(__name__)
+    gemlogger.setLevel(logging.ERROR)
     for amcN in range(12):
         # Skip masked AMC's        
         if( not ((args.amcMask >> amcN) & 0x1)):
             continue
-        
-        # Open connection to the AMC
         thisSlot = amcN+1
+       
+        # Open connection to the AMC - uHAL
+        dict_amcBoardsUHAL[thisSlot] = getAMCObject(thisSlot,args.shelf,args.debug)
+
+        # Open connection to the AMC - RPC
         cardName = "gem-shelf%02d-amc%02d"%(args.shelf,thisSlot)
-        #dict_vfatBoards[thisSlot] = HwVFAT(cardName, -1, args.debug, args.gemType, args.detType) # Assign a dummy link for now
-        dict_vfatBoards[thisSlot] = HwVFAT(cardName, -1, args.debug) # Assign a dummy link for now
+        dict_vfatBoards[thisSlot] = HwVFAT(cardName, -1, args.debug, args.gemType, args.detType) # Assign a dummy link for now
 
         # Determine OH's present
         dict_ohMasks[thisSlot] = dict_vfatBoards[thisSlot].parentOH.parentAMC.getOHMask()
-        
+       
+        # Reset TTC Command Counters
+        dict_vfatBoards[thisSlot].parentOH.parentAMC.ttcCmdCntReset()
+
         # Determine which VFATs to use for all OH's on this AMC
         dict_vfatMasks[thisSlot] = dict_vfatBoards[thisSlot].parentOH.parentAMC.getMultiLinkVFATMask(dict_ohMasks[thisSlot])
         for ohN in range(dict_vfatBoards[thisSlot].parentOH.parentAMC.nOHs):
@@ -183,7 +226,7 @@ def trackingDataScan(args, runType):
             pass # End loop over OH's on this AMC
         pass # End loop over AMC's
 
-    # Configure AMC13 Trigger Mode
+    # Configure AMC13 Trigger Mode and Calpulses (runType == 0x2 or 0x4 only)
     if (args.amc13SendsCalPulses):    # Calpulses sent by AMC13 as BGO commands
         if ((runType == 0x2) or (runType == 0x4)):
             # Configure BGO generator to send a CalPulse before the L1A
@@ -192,17 +235,48 @@ def trackingDataScan(args, runType):
             pass
 
         # Configure locally generated triggers for one L1A per orbit @ BX=500
-        amc13board.configureLocalL1A(True, 0, 1, 1, 0)
+        amc13board.configureLocalL1A(True, 0, args.nevts, 1, 0)
+        rate = int((1.0 / 0.0000909091)) # (1 / orbit period)
     else:                           # Calpulses sent by CTP7 on receipt of L1A from AMC13
-        # place holder
-        # Here a higher frequency of L1A's can probably be used
+        # Configure AMC's when receiving an L1A to delay the L1A and send a calpulse before the L1A
+        # Only valid for GEM_AMC FW >= 3.8.4
         # implement new features of: https://github.com/evka85/GEM_AMC/releases/tag/v3.8.4
-        raise RuntimeError("trackingDataScan(): Mode Not Implemented Yet")
+        if ((runType == 0x2) or (runType == 0x4)):
+            for amcN in range(12):
+                # Skip masked AMC's        
+                if( not ((args.amcMask >> amcN) & 0x1)):
+                    continue
+                
+                # Set the slot number as amcN+1
+                thisSlot = amcN+1
+
+                dict_vfatBoards[thisSlot].parentOH.parentAMC.configureCalMode(enable=True)
+                pass
+            pass
+
+        # Disable all BGO's
+        for chan in range(4):
+            amc13board.disableBGO(chan)
+
+        # Configure locally generated triggers for 4 L1A's per orbit
+        rate = int((1.0 / 0.0000909091) * 4) # (1 / orbit period) * N_L1A's/orbit
+        amc13board.configureLocalL1A(True, 1, args.nevts, rate, 0)
+        pass
 
     # Perform the scan
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    vfatList = [x for x in range(vfatsPerGemVariant[args.gemType])]
+    msg = "%11s:: fedID n_L1A slot ohN %s"%('','   '.join(map(str, vfatList)))
+    print(msg)
     for dacVal in range(args.dacMin,args.dacMax+args.dacStep,args.dacStep):
         # stop triggers coming from AMC13
         amc13board.stopContinuousL1A()
+
+        # Get the FED ID
+        sourceID = amc13board.read(amc13board.Board(1),"CONF.ID.SOURCE_ID") # readT1 in AMC13Tool
+
+        # Get Last L1A ID
+        lastL1A = amc13board.read(amc13board.Board(0),"STATUS.TTC.L1A_COUNTER") # readT2 in AMC13Tool
 
         # Loop over all AMCs and mark data as bad with RUN_TYPE and RUN_PARAMS words
         for amcN in range(12):
@@ -214,12 +288,13 @@ def trackingDataScan(args, runType):
             thisSlot = amcN+1
 
             # Mark data as invalid
-            dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunParams(0x0)
-            dict_vfatBoards[thisSlot].parentOH.parentAMC.setRunType(0xf)
+            dict_amcBoardsUHAL[thisSlot].getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS").write(0)
+            dict_amcBoardsUHAL[thisSlot].getNode("GEM_AMC.DAQ.EXT_CONTROL.RUN_TYPE").write(0xf)
+            dict_amcBoardsUHAL[thisSlot].dispatch()
 
             # Loop Over OH's on this AMC and set the scanReg to the reg of interest
             for ohN in range(dict_vfatBoards[thisSlot].parentOH.parentAMC.nOHs):
-                if ((dict_ohMasks[thisSlot] >> ohN) & 0x0):
+                if (not ((dict_ohMasks[thisSlot] >> ohN) & 0x1)):
                     continue
 
                 # Set the link in dict_vfatBoards[thisSlot]
@@ -227,6 +302,15 @@ def trackingDataScan(args, runType):
 
                 # Write the DAC Value
                 dict_vfatBoards[thisSlot].writeAllVFATs(scanReg,dacVal,dict_vfatMasks[thisSlot][ohN])
+                
+                # Print current status to user
+                readBackVals = dict_vfatBoards[thisSlot].readAllVFATs(scanReg,dict_vfatMasks[thisSlot][ohN])
+                badreg = map(lambda isbad: 0 if isbad == dacVal else 1, readBackVals)
+                perreg = "%s0x%02x%s"
+                regmap = map(lambda currentVal: perreg%((colors.GREEN,currentVal&0xffff,colors.ENDC) if currentVal&0xffff==dacVal else (colors.RED,currentVal&0xffff,colors.ENDC) ), readBackVals)
+                msg = "%11s:: 0x%x 0x%x %2d %2d  %s"%("CurrentStep",sourceID,lastL1A,thisSlot,ohN,'   '.join(map(str, regmap)))
+                print(msg)
+
                 pass # End Loop over all OH's on this slot
             pass # End Loop over all AMC's on this shelf?
 
@@ -237,24 +321,45 @@ def trackingDataScan(args, runType):
             # placeholder
             raise RuntimeError("trackingDataScan(): Mode Not Implemented Yet")
         elif ((runType == 0x2) or (runType == 0x4)): #Latency Scan or Scurve
-            # placeholder
             for chan in range(args.chMin,args.chMax+1):
-                #FIXME might need amc13board.enableLocalL1A(True) here?
-
                 # Set this channel to pulse for all VFATs and place all VFATs into run mode
-                toggleSettings4DAQ(args.amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMasks, dacVal, runType, enableCal=True, enableRun=True)
+                # FIXME RunParam value is not set correctly
+                toggleSettings4DAQ(args.amcMask, chan, dict_ohMasks, dict_amcBoardsUHAL, dict_vfatBoards, dict_vfatMasks, dacVal, runType, enableCal=True, enableRun=True)
 
                 # Send Triggers
-                for evt in range(args.nevts):
-                    amc13board.sendL1ABurst()
-                    pass # End Event loop
-                #FIXME might need amc13board.enableLocalL1A(False) here?
+                amc13board.sendL1ABurst()
+                # FIXME something not right about this sleep...? makes this take way longer than I thought
+                sleep(args.nevts/rate) # Sleep for the time it takes for the L1A's to be sent
+                #sleep(1.05 * (args.nevts/rate)) # Sleep for the time it takes for the L1A's to be sent plus 5% of that time
 
                 # Stop calpulse to this channel for all VFATs and take VFATs out of run mode
-                toggleSettings4DAQ(args.amcMask, chan, dict_ohMasks, dict_vfatBoards, dict_vfatMasks, 0x0, 0xf, enableCal=False, enableRun=False)
+                toggleSettings4DAQ(args.amcMask, chan, dict_ohMasks, dict_amcBoardsUHAL, dict_vfatBoards, dict_vfatMasks, 0x0, 0xf, enableCal=False, enableRun=False)
                 pass # End Loop over VFAT Channels
             pass # End if-elif statement
         pass # End Loop over DAC Range
+
+    # Turn off triggers
+    amc13board.stopContinuousL1A()
+    amc13board.enableLocalL1A(False)
+
+    # Take AMC's out of calibration mode if they where in calibration mode
+    if (args.amc13SendsCalPulses):    # Calpulses sent by AMC13 as BGO commands
+        if ((runType == 0x2) or (runType == 0x4)):
+            # Disable BGO for channel 0
+            amc13board.disableBGO(0)
+            pass
+    else:
+        for amcN in range(12):
+            # Skip masked AMC's        
+            if( not ((args.amcMask >> amcN) & 0x1)):
+                continue
+            
+            # Open connection to the AMC
+            thisSlot = amcN+1
+
+            dict_vfatBoards[thisSlot].parentOH.parentAMC.configureCalMode(enable=False)
+            pass
+        pass
 
     return
 
@@ -272,9 +377,11 @@ if __name__ == '__main__':
     runTypeGroup.add_argument("--thrScan", help="Perform a scan of the CFG_THR_ARM_DAC register", action="store_true")
 
     # Optional Parameters
+    from gempython.tools.hw_constants import gemVariants
     parser.add_argument("-a","--amc13SendsCalPulses",help="If provided AMC13 will generate calpulse commands.  Otherwise the CTP7's will delay the original L1A received and generate a calpulse", action="store_true")
     parser.add_argument("-d","--debug", help="prints additional debugging information", action="store_true")
-    #parser.add_argument("--gemType",type=str,help="String that defines the GEM variant, available from the list: {0}".format(gemVariants.keys()),default="ge11")
+    parser.add_argument("--detType",type=str,help="String that defines the detector type within the GEM variant, available from the list: {0}".format(gemVariants.values()),default="short")
+    parser.add_argument("--gemType",type=str,help="String that defines the GEM variant, available from the list: {0}".format(gemVariants.keys()),default="ge11")
     parser.add_argument("--shelf", help="uTCA shelf number", type=int, default=1)
     # FIXME complete the parser
 
@@ -316,7 +423,7 @@ if __name__ == '__main__':
         pass
 
     if args.debug:
-        print("Executing Scan:")
+        print("Executing Scan: {:s}".format(dict_scanRegsByRunType[runType]))
 
     trackingDataScan(args, runType)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses https://github.com/cms-gem-daq-project/cmsgemos/issues/284

Provided new tool for taking tracking data calibration scans.  Works with dedicated FM configuration "uFEDKit_noTCDS."

Additional changes:
- `HwAMC` now has method `configureCalMode` for toggling calibration mode.
- `HwAMC` now has method `setRunType ` for setting `GEM_AMC.DAQ.EXT_CONTROL.RUN_PARAMS`.
- `HwAMC` now has method `ttcCmdCntReset` for resetting all TTC command counters.
- `HwVFAT` now has method `configureCalPulseAllVFATs` for configuring the calibration pulse on all unmasked VFATs.
- `HwVFAT:: setAllChannelRegisters`, in addition to previous functionality, is now able to take an input array where the elements of the array specify the complete channel register. 
- `HwVFAT` now has several additional methods for configuring registers in the calibration module.
- Corrected a type in the help menu of `setDAQParamsPostConfigure.py` which lead to improper usage.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See #284.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Help menu of new tool `trackingDataCalibrationScan.py`:

```bash
% trackingDataCalibrationScan.py -h
usage: trackingDataCalibrationScan.py [-h] (--latScan | --scurve | --thrScan)
                                      [-a] [-d] [--detType DETTYPE]
                                      [--gemType GEMTYPE] [--shelf SHELF]
                                      [-c CALPHASE] [-l LATENCY]
                                      [-p PULSESTRETCH]
                                      [--compModeARM | --compModeZCC]
                                      [--chMax CHMAX] [--chMin CHMIN]
                                      [--dacMax DACMAX] [--dacMin DACMIN]
                                      [--dacStep DACSTEP] [-n NEVTS]
                                      amcMask
positional arguments:
  amcMask               Slot mask to apply, a 1 in the N^th bit indicates the
                        (N+1)^th slot should be considered

optional arguments:
  -h, --help            show this help message and exit
  --latScan             Perform a latency scan using the calibration module
  --scurve              Take an scurve scan
  --thrScan             Perform a scan of the CFG_THR_ARM_DAC register
  -a, --amc13SendsCalPulses
                        If provided AMC13 will generate calpulse commands.
                        Otherwise the CTP7's will delay the original L1A
                        received and generate a calpulse
  -d, --debug           prints additional debugging information
  --detType DETTYPE     String that defines the detector type within the GEM
                        variant, available from the list: [['m1', 'm2', 'm3',
                        'm4', 'm5', 'm6', 'm7', 'm8'], 'null', ['short',
                        'long']]
  --gemType GEMTYPE     String that defines the GEM variant, available from
                        the list: ['ge21', 'me0', 'ge11']
  --shelf SHELF         uTCA shelf number
VFAT3 Parameters for Scan:
  Settings for the VFATs that need to be applied at runtime

  -c CALPHASE, --calPhase CALPHASE
                        Value to write to CFG_CAL_PHI
  -l LATENCY, --latency LATENCY
                        Value to write to CFG_LATENCY during an scurve
  -p PULSESTRETCH, --pulseStretch PULSESTRETCH
                        Value to write to CFG_PULSE_STRETCH
  --compModeARM         Set the comparator mode on all VFATs to ARM Mode
                        (CFG_SEL_COMP_MODE = 0x1)
  --compModeZCC         Set the comparator mode on all VFATs to ZCC Mode
                        (CFG_SEL_COMP_MODE = 0x2)

Scan Parameters:
  Settings that determine the range of channels and DACs for the scan

  --chMax CHMAX         Maximum VFAT Channel to be scanned
  --chMin CHMIN         Minimum VFAT Channel to be scanned
  --dacMax DACMAX       Maximum DAC value the scan will reach
  --dacMin DACMIN       Minimum DAC value the scan will reach
  --dacStep DACSTEP     Step size to move through the DAC in
  -n NEVTS, --nevts NEVTS
                        For thrScan this is the number of events that
                        will be acquired per DAC value. For scurve or
                        latScan this is the number of events that
                        will be acquired per DAC value per channel
```

Example usage for taking a latency scan:

```bash
trackingDataCalibrationScan.py 0x2 --latScan -p 3 --chMax=1 --chMin=1 --dacMax=30 --dacMin=10 -n 10
```

Example usage for taking an scurve:

```bash
trackingDataCalibrationScan.py 0x2 --scurve -p 3 -l 23 --chMax=1 --chMin=1 --dacMax=255 --dacMin=0 --dacStep=2 -n 20
```

Example usage for taking a CFG_THR_ARM_DAC scan:

```bash
trackingDataCalibrationScan.py 0x2 --thrScan -p 3 --dacMax=100 --dacMin=0 --dacStep=2 -n 20
```

### Screenshots (if appropriate):

Latency scan:
<img width="530" alt="Screen Shot 2019-08-09 at 5 40 04 PM" src="https://user-images.githubusercontent.com/6432141/62858670-33992b00-bcfb-11e9-844d-1ab6c454f49a.png">

Scurve scan:
<img width="455" alt="Screen Shot 2019-08-09 at 6 37 40 PM" src="https://user-images.githubusercontent.com/6432141/62858614-106e7b80-bcfb-11e9-9878-06b180d5301b.png">

`CFG_THR_ARM_DAC` scan:
<img width="508" alt="Screen Shot 2019-08-12 at 11 52 55 AM" src="https://user-images.githubusercontent.com/6432141/62858640-1a907a00-bcfb-11e9-891d-9001a43573e4.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
