### PR TITLE
[New Feature] variable waitTime for parallel sbitrate scans

### DIFF
--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -696,7 +696,7 @@ class HwAMC(object):
 
         return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll, self.nVFATs)
 
-    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=None, scanReg="THR_ARM_DAC", waitTime=1000):
+    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=None, scanReg="THR_ARM_DAC", waitTime=1):
         """
         Measures the rate of sbits sent by all unmasked optobybrids on this AMC
         V3 electronics only.

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -165,7 +165,7 @@ class HwAMC(object):
         self.readSBits.restype = c_uint
 
         self.sbitRateScanMulti = self.lib.sbitRateScan
-        self.sbitRateScanMulti.argTypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), c_uint]
+        self.sbitRateScanMulti.argTypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), c_uint, c_uint]
         self.sbitRateScanMulti.restype = c_uint
 
         # Parse XML
@@ -696,7 +696,7 @@ class HwAMC(object):
 
         return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll, self.nVFATs)
 
-    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, waitTime=1000, ohMask=None, scanReg="THR_ARM_DAC"):
+    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=None, scanReg="THR_ARM_DAC", waitTime=1000):
         """
         Measures the rate of sbits sent by all unmasked optobybrids on this AMC
         V3 electronics only.
@@ -713,7 +713,7 @@ class HwAMC(object):
         dacMin                  - Starting dac value of the scan
         dacMax                  - Ending dac value of the scan
         dacStep                 - Step size for moving from dacMin to dacMax
-        waitTime                - Length of the time window within which the rate is measured, in milliseconds
+        waitTime                - Length of the time window within which the rate is measured, in seconds
         ohMask - Mask which defines which OH's to query; 12 bit number where
                  having a 1 in the N^th bit means to query the N^th optohybrid.
                  If None will be determined automatically using HwAMC::getOHMask()
@@ -751,7 +751,7 @@ class HwAMC(object):
             printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataTrigRatePerVFAT' has length {1}".format(self.nVFATs*lenExpected, len(outDataTrigRatePerVFAT)))
             exit(os.EX_USAGE)
 
-        return self.sbitRateScanMulti(ohMask, waitTime, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, self.nVFATs)
+        return self.sbitRateScanMulti(ohMask, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, self.nVFATs, waitTime)
 
     def programAllOptohybridFPGAs(self, maxIter=5, ohMask=None):
         """

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -165,7 +165,7 @@ class HwAMC(object):
         self.readSBits.restype = c_uint
 
         self.sbitRateScanMulti = self.lib.sbitRateScan
-        self.sbitRateScanMulti.argTypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), c_uint]
+        self.sbitRateScanMulti.argTypes = [c_uint, c_uint, c_uint, c_uint, c_uint, c_uint, c_char_p, POINTER(c_uint32), POINTER(c_uint32), POINTER(c_uint32), c_uint]
         self.sbitRateScanMulti.restype = c_uint
 
         # Parse XML
@@ -696,7 +696,7 @@ class HwAMC(object):
 
         return self.dacScanMulti(ohMask, self.nOHs, dacSelect, dacStep, useExtRefADC, dacDataAll, self.nVFATs)
 
-    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, ohMask=None, scanReg="THR_ARM_DAC"):
+    def performSBITRateScanMultiLink(self, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, chan=128, dacMin=0, dacMax=254, dacStep=1, waitTime=1000, ohMask=None, scanReg="THR_ARM_DAC"):
         """
         Measures the rate of sbits sent by all unmasked optobybrids on this AMC
         V3 electronics only.
@@ -713,6 +713,7 @@ class HwAMC(object):
         dacMin                  - Starting dac value of the scan
         dacMax                  - Ending dac value of the scan
         dacStep                 - Step size for moving from dacMin to dacMax
+        waitTime                - Length of the time window within which the rate is measured, in milliseconds
         ohMask - Mask which defines which OH's to query; 12 bit number where
                  having a 1 in the N^th bit means to query the N^th optohybrid.
                  If None will be determined automatically using HwAMC::getOHMask()
@@ -750,7 +751,7 @@ class HwAMC(object):
             printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataTrigRatePerVFAT' has length {1}".format(self.nVFATs*lenExpected, len(outDataTrigRatePerVFAT)))
             exit(os.EX_USAGE)
 
-        return self.sbitRateScanMulti(ohMask, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, self.nVFATs)
+        return self.sbitRateScanMulti(ohMask, waitTime, dacMin, dacMax, dacStep, chan, scanReg, outDataDacVal, outDataTrigRate, outDataTrigRatePerVFAT, self.nVFATs)
 
     def programAllOptohybridFPGAs(self, maxIter=5, ohMask=None):
         """


### PR DESCRIPTION
This is one of four pull requests to four repositories that make the data collection time for parallel sbitrate scans configurable.

## Description
Adds the `waitTime` argument to the relevant functions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This was requested in https://github.com/cms-gem-daq-project/ctp7_modules/issues/154


## How Has This Been Tested?
Yes, I performed an sbitThresh scan with the waitTime set to 1000 and the waitTime set to 10000, and found the rates were very close while the second scan took around 10 times longer.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
