### PR TITLE
[Bugfix] Fix incorrect array sizes leading to memory corruptions

### DIFF
--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -736,7 +736,7 @@ class HwAMC(object):
             exit(os.EX_USAGE)
 
         # Check length of results container - outDataDacVal
-        lenExpected = self.nOHs * (dacMax - dacMin + 1) / dacStep
+        lenExpected = 12 * (dacMax - dacMin + 1) / dacStep
         if (len(outDataDacVal) != lenExpected):
             printRed("HwAMC::performSBITRateScanMultiLink(): I expected container of length {0} but provided 'outDataDacVal' has length {1}".format(lenExpected, len(outDataDacVal)))
             exit(os.EX_USAGE)

--- a/gempython/tools/amc_user_functions_xhal.py
+++ b/gempython/tools/amc_user_functions_xhal.py
@@ -410,7 +410,7 @@ class HwAMC(object):
         if ohMask is None:
             ohMask = self.getOHMask(callingMthd="getMultiLinkVFATMask")
 
-        vfatMaskArray = (c_uint32 * self.nOHs)()
+        vfatMaskArray = (c_uint32 * 12)()
         rpcResp = self.getOHVFATMaskMultiLink(ohMask, vfatMaskArray)
 
         if rpcResp != 0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`cmsgemos` has been converted to use an arbitrary number of OH. However, `xHAL` and the `ctp7_modules` have not. Therefore, care must be taken in the array sizes passed from the Python tools to `xHAL` via the `CDLL` library in order to avoid any memory corruption.

Since this bugfix is targeting the legacy RPC call framework, the changes are as minimal as possible. The array sizes in the Python tools are changed to match the fixed sizes expected by `xHAL`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

While testing the GLIB, segmentation faults and double free errors occured in `testConnectivity.py` and `run_scans.py sbitThresh`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using seamlessly `testConnectivity.py` and `run_scans.py sbitThresh` for both electronics QC (CTP7/12 OHs) and GLIB testing (2 OHs).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
