### PR TITLE
Fix tests crashing on invalid XML files

### DIFF
--- a/gemonlinedb/.gitignore
+++ b/gemonlinedb/.gitignore
@@ -5,6 +5,7 @@
 !xml/schema/common.xsd
 !xml/schema/system-topology.xsd
 !xml/examples/*.xml
+!xml/tests/*.xml
 !xml/*.xml
 
 # Do ignore auto-generated files

--- a/gemonlinedb/src/common/XMLUtils.cc
+++ b/gemonlinedb/src/common/XMLUtils.cc
@@ -12,6 +12,9 @@ namespace gem {
 
             std::string transcode(const XMLCh * const xercesStr)
             {
+                if (__builtin_expect(xercesStr == nullptr, 0)) {
+                    return "";
+                }
                 char *transcoded = xercesc::XMLString::transcode(xercesStr);
                 std::string result(transcoded);
                 xercesc::XMLString::release(&transcoded);

--- a/gemonlinedb/test/testXMLConfigurationProvider.cc
+++ b/gemonlinedb/test/testXMLConfigurationProvider.cc
@@ -75,4 +75,13 @@ BOOST_AUTO_TEST_CASE(LoadVFAT3Channel)
     provider.getVFAT3ChannelConfiguration({ "2940" });
 }
 
+BOOST_AUTO_TEST_CASE(LoadNonCompliant)
+{
+    XMLConfigurationProvider provider;
+    // xml/tests/NonCompliantFile.xml doesn't comply with the schema
+    BOOST_CHECK_THROW(
+        provider.loadAMC13("xml/tests/NonCompliantFile.xml"),
+        exception::ParseError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/gemonlinedb/xml/tests/NonCompliantFile.xml
+++ b/gemonlinedb/xml/tests/NonCompliantFile.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!-- This file doesn't comply with the schema. It is used to test that trying to
+     load a non-compliant file throws an exception. -->
+<ROOT>
+    <NON_COMPLIANT/>
+</ROOT>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix #308. The errors were caused by:
1. Xerces exceptions leaking outside of `XercesGuard`ed areas: fixed by throwing `gem::onlinedb` exceptions from `XercesAlwaysThrowErrorManager`
2. Exceptions crossing thread boundaries: fixed by rethrowing from the main thread 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
#308 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test for point 1. and ran tests locally with and without a broken `AMC13Configuraiton.xml`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
