### PR TITLE
[release prep] v1.0.1

### DIFF
--- a/gempython/Makefile
+++ b/gempython/Makefile
@@ -20,7 +20,7 @@ $(info PythonModules=${PythonModules})
 
 GEMPYTHON_VER_MAJOR=1
 GEMPYTHON_VER_MINOR=0
-GEMPYTHON_VER_PATCH=0
+GEMPYTHON_VER_PATCH=1
 
 include $(BUILD_HOME)/$(Project)/config/mfDefsGEM.mk
 include $(BUILD_HOME)/$(Project)/config/mfPythonDefsGEM.mk

--- a/gempython/pkg/setup.py
+++ b/gempython/pkg/setup.py
@@ -36,9 +36,9 @@ def getreqs():
 def getVersion():
     __version__='___version___'
     __release__='___release___'
-    if __release__.split('.')[2]:
+    try:
         __prerel__='-{0:s}'.format(__release__.split('.')[2])
-    else:
+    except Exception as e:
         __prerel__=''
     __buildtag__='___buildtag___'
     __gitrev__='___gitrev___'


### PR DESCRIPTION
* Bump metadata for 1.0.1
* Fix python packaging consistency syntax

Once merged, merged commit should be tagged `v1.0.1`