### PR TITLE
Fix gemonlinedb tests

### DIFF
--- a/gemonlinedb/test/testSerializationData.cc
+++ b/gemonlinedb/test/testSerializationData.cc
@@ -11,7 +11,7 @@
 #include <xdaq/version.h>
 config::PackageInfo xdaq::getPackageInfo()
 {
-    return config::PackageInfo("", "", "", "", "", "", "", "");
+    return config::PackageInfo("", "", "", "", "", "", "", "", "");
 }
 
 using namespace gem::onlinedb;

--- a/gemonlinedb/test/testVFAT3ChipConfiguration.cc
+++ b/gemonlinedb/test/testVFAT3ChipConfiguration.cc
@@ -11,7 +11,7 @@
 #include <xdaq/version.h>
 config::PackageInfo xdaq::getPackageInfo()
 {
-    return config::PackageInfo("", "", "", "", "", "", "", "");
+    return config::PackageInfo("", "", "", "", "", "", "", "", "");
 }
 
 using namespace gem::onlinedb;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes compilation of gemonlinedb tests. There are two commits:

* Two tests were missed in #311 when updating arguments to `config::PackageInfo`
* `std::atomic` issue uncovered by upgrading the compiler as part of the XDAQ15 upgrade (also #311)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Better if tests compile. #312 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests compile and pass.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
