### PR TITLE
Reverts hacks introduced in HwGenericAMC::isHwConnected

### DIFF
--- a/gemhardware/devices/include/gem/hw/devices/GEMHwDevice.h
+++ b/gemhardware/devices/include/gem/hw/devices/GEMHwDevice.h
@@ -141,7 +141,11 @@ namespace gem {
       */
       virtual ~GEMHwDevice();
 
-      virtual bool isHwConnected() { return true; }; /*FIXME make pure virutal, non-virtual?*/
+      /* FIXME
+       * make pure virtual, non-virtual?
+       * check RPC connection?
+       */
+      virtual bool isHwConnected() { return true; };
 
       ///////////////////////////////////////////////////////////////////////////////////////
       //****************Methods implemented for convenience on uhal devices****************//

--- a/gemhardware/devices/include/gem/hw/devices/amc/HwGenericAMC.h
+++ b/gemhardware/devices/include/gem/hw/devices/amc/HwGenericAMC.h
@@ -754,8 +754,6 @@ namespace gem {
         uint32_t m_links;    ///< Connected links mask
         uint32_t m_maxLinks; ///< Maximum supported OptoHybrids as reported by the firmware
 
-        /* std::vector<linkStatus> v_activeLinks; ///< vector keeping track of the active links */
-
         /**
          * @brief sets the expected board ID string to be matched when reading from the firmware
          * @param boardID is the expected board ID

--- a/gemhardware/devices/src/common/amc/HwGenericAMC.cc
+++ b/gemhardware/devices/src/common/amc/HwGenericAMC.cc
@@ -88,15 +88,12 @@ bool gem::hw::HwGenericAMC::isHwConnected()
     return true;
   } else if (gem::hw::GEMHwDevice::isHwConnected()) {
     CMSGEMOS_INFO("basic check: HwGenericAMC pointer valid");
-    //FIXME apparently this->getSupportedOptoHybrids(); doesn't work!!!
-    m_maxLinks = 12;
-    //m_maxLinks = this->getSupportedOptoHybrids();
+    m_maxLinks = this->getSupportedOptoHybrids();
     // FIXME needs update for V3
     if (((this->getBoardIDString()).rfind("GLIB") != std::string::npos) ||
         ((this->getBoardIDString()).rfind("beef") != std::string::npos)) {
       CMSGEMOS_INFO("HwGenericAMC found boardID");
-//FIXME for whatever reason the following loop is endless. Can't get why :(
-/*
+
       for (int gtx = 0; gtx < 12; ++gtx) { //FIXME removed hardcode
         // FIXME OBSOLETE!!! somehow need to actually check that the specified link is present
         // check GBT status?
@@ -112,11 +109,7 @@ bool gem::hw::HwGenericAMC::isHwConnected()
         CMSGEMOS_INFO("m_links 0x" << std::hex <<std::setw(8) << std::setfill('0')
                       << m_links << std::dec);
       }
-*/
-//FIXME following lines till else added temporary
-      m_links = 0x1;
-      b_is_connected = true;
-      CMSGEMOS_DEBUG("checked gtxs: HwGenericAMC connection good");
+
       return true;
     } else {
       CMSGEMOS_WARN("Device not reachable (unable to find 'GLIB' in the board ID)"
@@ -124,17 +117,6 @@ bool gem::hw::HwGenericAMC::isHwConnected()
                     << " user firmware version " << this->getFirmwareVer());
       return false;
     }
-
-    // FIXME NEED TO PROPERLY OBTAIN THE ACTIVE LINKS
-    // v_activeLinks = tmp_activeLinks;
-    // if (!v_activeLinks.empty()) {
-    //   b_is_connected = true;
-    //   CMSGEMOS_DEBUG("checked gtxs: HwGenericAMC connection good");
-    //   return true;
-    // } else {
-    //   b_is_connected = false;
-    //   return false;
-    // }
   } else {
     return false;
   }

--- a/gemsupervisor/src/common/GEMSupervisor.cc
+++ b/gemsupervisor/src/common/GEMSupervisor.cc
@@ -1176,12 +1176,10 @@ public:
     else if (classname == "tcds::ici::ICIController")               priority = 101; // must be second of TCDS!
     else if (classname == "tcds::pi::PIController")                 priority = 100; // must be first!?
     else if (classname == "gem::hw::amc13::AMC13Manager")           priority =  95; // after AMCManagers but not last
-    // else if (classname == "gem::hw::optohybrid::OptoHybridManager") priority =  95; // before AMC managers and before  AMC13
     else if (classname == "gem::hw::glib::GLIBManager")             priority =  90; // before (or simultaneous with) OH manager and before AMC13
     else if (classname == "gem::hw::ctp7::CTP7Manager")             priority =  90; // before (or simultaneous with) OH manager and before AMC13
-    else if (classname == "gem::hw::AMCManager")                    priority =  90; // before (or simultaneous with) OH manager and before AMC13
+    else if (classname == "gem::hw::amc::AMCManager")               priority =  90; // before (or simultaneous with) OH manager and before AMC13
     else if (classname == "gem::hw::optohybrid::OptoHybridManager") priority =  55; // before AMC managers and before  AMC13
-    // else if (classname == "gem::hw::amc13::AMC13Manager")           priority =  35; // after AMCManagers but not last
     else if (classname == "gem::hw::amc13::AMC13Readout")           priority =  30; // after AMC13Manager
     else if (classname == "gem::hw::gemPartitionViewer")            priority =  10; //
     return priority;
@@ -1263,7 +1261,7 @@ public:
     if      (classname == "gem::hw::optohybrid::OptoHybridManager") priority = 105; // before AMC managers
     else if (classname == "gem::hw::glib::GLIBManager")             priority = 100; // after OH manager and before  AMC13
     else if (classname == "gem::hw::ctp7::CTP7Manager")             priority = 100; // after OH manager and before  AMC13
-    else if (classname == "gem::hw::AMCManager")                    priority = 100; // after OH manager and before  AMC13
+    else if (classname == "gem::hw::amc::AMCManager")               priority = 100; // after OH manager and before  AMC13
     else if (classname == "gem::hw::amc13::AMC13Readout")           priority =  90; // before AMC13Manager
     else if (classname == "gem::hw::amc13::AMC13Manager")           priority =  35; // after AMCManagers but not last
     else if (classname == "tcds::lpm::LPMController")               priority =  12; // must be first of TCDS!
@@ -1336,7 +1334,7 @@ public:
     else if (classname == "gem::hw::amc13::AMC13Manager")           priority =  95; // after AMCManagers but not last
     else if (classname == "gem::hw::glib::GLIBManager")             priority =  70; // before (or simultaneous with) OH manager and before  AMC13
     else if (classname == "gem::hw::ctp7::CTP7Manager")             priority =  70; // before (or simultaneous with) OH manager and before  AMC13
-    else if (classname == "gem::hw::AMCManager")                    priority =  70; // before (or simultaneous with) OH manager and before  AMC13
+    else if (classname == "gem::hw::amc::AMCManager")               priority =  70; // before (or simultaneous with) OH manager and before  AMC13
     else if (classname == "gem::hw::optohybrid::OptoHybridManager") priority =  65; // after (or simultaneous with) AMC managers and before  AMC13
     else if (classname == "gem::hw::amc13::AMC13Readout")           priority =  60; // after AMC13Manager but not last
     return priority;

--- a/setup/make_xdaq_softlinks.sh
+++ b/setup/make_xdaq_softlinks.sh
@@ -18,5 +18,5 @@ do
     then
         unlink ${base}/html
     fi
-    ln -s ${BUILD_HOME}/$pkg/html ${base}/html
+    ln -snf ${BUILD_HOME}/$pkg/html ${base}/html
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes #317, or rather reverts the related change introduced in #315, since I was unable not reproduce the issue.

Also, fixes the state transition priorities, incorrect since the `gem::hw::AMCManager` renaming to
`gem::hw::amc::AMCManager`.

[Please note that this PR is devised to be merged after #324.]

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

Trying to understand #317 and addressing concerns from #315.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All FSM state transitions, as well as data taking, work on the integration setup.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
