### PR TITLE
WIP: Calibration suite [latency scan]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ SUBPACKAGES := \
         gemreadout \
         gemsupervisor \
         gemdaqmonitor \
-        gemonlinedb
+        gemonlinedb \
+        gemcalibration 
+
+
 
 # SUBPACKAGES.DOC      := $(patsubst %,%.doc,    ${SUBPACKAGES})
 # SUBPACKAGES.CHECK    := $(patsubst %,%.check,    ${SUBPACKAGES})
@@ -154,6 +157,8 @@ gemonlinedb: gemutils gembase
 gemreadout: gemutils gembase gemhardware/devices
 
 gemdaqmonitor: gembase gemhardware/devices gemhardware/utils
+
+gemcalibration: gemutils gembase 
 
 print-env:
 	@echo BUILD_HOME    $(BUILD_HOME)

--- a/gembase/include/gem/base/GEMApplication.h
+++ b/gembase/include/gem/base/GEMApplication.h
@@ -53,6 +53,7 @@
 #include "gem/base/exception/Exception.h"
 #include "gem/base/utils/exception/Exception.h"
 #include "gem/base/utils/GEMInfoSpaceToolBox.h"
+#include "gem/utils/soap/GEMSOAPToolBox.h"
 
 namespace xdaq {
   class ApplicationStub;
@@ -193,7 +194,16 @@ namespace gem {
           xdata::UnsignedInteger32 scanMax;
           xdata::UnsignedInteger32 stepSize;
           xdata::UnsignedInteger64 nTriggers;
-
+          xdata::Boolean calMode;
+          xdata::UnsignedInteger32 trigType;          
+          xdata::UnsignedInteger32 l1aTime;
+          xdata::UnsignedInteger32 mspl;
+          xdata::UnsignedInteger32 vfatChMin;
+          xdata::UnsignedInteger32 vfatChMax;
+          xdata::UnsignedInteger32 signalSourceType;
+          xdata::UnsignedInteger32 pulseDelay;
+          xdata::UnsignedInteger32 latency;
+          
           inline std::string toString() {
             std::stringstream os;
             os << "scanType:" << scanType.toString() << std::endl
@@ -201,6 +211,14 @@ namespace gem {
                << "scanMax:"  << scanMax.toString()  << std::endl
                << "stepSize:" << stepSize.toString() << std::endl
                << "nTrigger:" << nTriggers.value_    << std::endl
+               << "trigType:" << trigType.value_     << std::endl
+               << "l1aTime:"  << l1aTime.value_     << std::endl
+               << "mspl:"     << mspl.value_        << std::endl
+               << "vfatChMin:"<< vfatChMin.value_     << std::endl
+               << "vfatChMax:"<< vfatChMax.value_     << std::endl
+               << "signalSourceType:" << signalSourceType.value_     << std::endl
+               << "pulseDelay:" << pulseDelay.value_     << std::endl
+               << "latency:" << latency.value_     << std::endl
                << std::endl;
             return os.str();
           };
@@ -220,6 +238,8 @@ namespace gem {
 
         uint32_t m_instance;
 
+        xoap::MessageReference calibParamRetrieve(xoap::MessageReference mns);
+        
       protected:
         xdata::Integer64 m_runNumber;
         xdata::String    m_runType;

--- a/gembase/src/common/GEMApplication.cc
+++ b/gembase/src/common/GEMApplication.cc
@@ -324,7 +324,6 @@ xoap::MessageReference gem::base::GEMApplication::calibParamRetrieve(xoap::Messa
     m_scanInfo.bag.scanMin = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"scanMin");;
     m_scanInfo.bag.scanMax = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"scanMax");
     m_scanInfo.bag.stepSize = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"stepSize");
-    if  (m_scanInfo.bag.stepSize.value_==(xdata::UnsignedInteger32) 0) m_scanInfo.bag.stepSize=(xdata::UnsignedInteger32)1;
     m_scanInfo.bag.nTriggers = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"nSamples");///TODO: change it everywhere?
     m_scanInfo.bag.trigType = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"trigType");          
     m_scanInfo.bag.l1aTime = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"l1aTime");          
@@ -334,7 +333,7 @@ xoap::MessageReference gem::base::GEMApplication::calibParamRetrieve(xoap::Messa
     m_scanInfo.bag.signalSourceType = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"signalSourceType");
     m_scanInfo.bag.pulseDelay = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"pulseDelay");
     m_scanInfo.bag.latency = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"latency");
-    m_scanInfo.bag.calMode = (xdata::Boolean)  true; // TODO: implement the selection in the calubration suite web interface
+    m_scanInfo.bag.calMode = (xdata::Boolean) false; // TODO: implement the selection in the calubration suite web interface
   
     return 
         gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "CalibrationParametersRetrieved");

--- a/gembase/src/common/GEMApplication.cc
+++ b/gembase/src/common/GEMApplication.cc
@@ -20,7 +20,14 @@ gem::base::GEMApplication::ScanInfo::ScanInfo()
   scanMax   = 0;
   stepSize  = 0;
   nTriggers = 0;
-
+  trigType = 0;          
+  l1aTime = 0;
+  mspl = 0;
+  vfatChMin = 0;
+  vfatChMax = 0;
+  signalSourceType = 0;
+  pulseDelay = 0;
+  calMode = false;
 }
 
 void gem::base::GEMApplication::ScanInfo::registerFields(xdata::Bag<gem::base::GEMApplication::ScanInfo>* bag)
@@ -154,6 +161,8 @@ gem::base::GEMApplication::GEMApplication(xdaq::ApplicationStub *stub) :
   p_appInfoSpace->addItemChangedListener( "ScanMin",       this);
   p_appInfoSpace->addItemChangedListener( "ScanMax",       this);
   p_appInfoSpace->addItemChangedListener( "StepSize",      this);
+
+  xoap::bind(this, &gem::base::GEMApplication::calibParamRetrieve, "calibParamRetrieve", XDAQ_NS_URI);
 
   CMSGEMOS_DEBUG("GEMApplication::gem::base::GEMApplication constructed");
 }
@@ -296,4 +305,39 @@ void gem::base::GEMApplication::xgiExpert(xgi::Input* in, xgi::Output* out)
 void gem::base::GEMApplication::jsonUpdate(xgi::Input* in, xgi::Output* out)
 {
   p_gemWebInterface->jsonUpdate(in, out);
+}
+
+
+xoap::MessageReference gem::base::GEMApplication::calibParamRetrieve(xoap::MessageReference msg) {
+    CMSGEMOS_INFO("GEMApplication::calibParamRetrieve activated");
+    //msg->writeTo(std::cout);
+ 
+    std::string commandName = "calibParamRetrieve";
+    if (msg.isNull()) {
+        CMSGEMOS_INFO("GEMApplication::calibParamRetrieve Null message received!");
+        XCEPT_RAISE(xoap::exception::Exception,"Null message received!");
+    }
+    CMSGEMOS_INFO("GEMApplication::calibParamRetrieve message received");
+
+ 
+    m_scanInfo.bag.scanType = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"calType");
+    m_scanInfo.bag.scanMin = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"scanMin");;
+    m_scanInfo.bag.scanMax = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"scanMax");
+    m_scanInfo.bag.stepSize = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"stepSize");
+    if  (m_scanInfo.bag.stepSize.value_==(xdata::UnsignedInteger32) 0) m_scanInfo.bag.stepSize=(xdata::UnsignedInteger32)1;
+    m_scanInfo.bag.nTriggers = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"nSamples");///TODO: change it everywhere?
+    m_scanInfo.bag.trigType = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"trigType");          
+    m_scanInfo.bag.l1aTime = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"l1aTime");          
+    m_scanInfo.bag.mspl = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"mspl");
+    m_scanInfo.bag.vfatChMin = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"vfatChMin");
+    m_scanInfo.bag.vfatChMax = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"vfatChMax");
+    m_scanInfo.bag.signalSourceType = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"signalSourceType");
+    m_scanInfo.bag.pulseDelay = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"pulseDelay");
+    m_scanInfo.bag.latency = gem::utils::soap::GEMSOAPToolBox::extractSOAPCommandParameterInteger(msg,"latency");
+    m_scanInfo.bag.calMode = (xdata::Boolean)  true; // TODO: implement the selection in the calubration suite web interface
+  
+    return 
+        gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "CalibrationParametersRetrieved");
+        
+    
 }

--- a/gemcalibration/Makefile
+++ b/gemcalibration/Makefile
@@ -1,0 +1,82 @@
+#
+# Makefile for gemcalibration package
+#
+
+
+BUILD_HOME:=$(shell pwd)/..
+
+ifndef BUILD_SUPPORT
+BUILD_SUPPORT=build
+endif
+
+ifndef PROJECT_NAME
+PROJECT_NAME=cmsgemos
+endif
+
+Project=$(PROJECT_NAME)
+ShortProject=gem
+Package=gemcalibration
+LongPackage=gemcalibration
+ShortPackage=calib
+PackageName=calib
+
+GEMSUPERVISOR_VER_MAJOR=1
+GEMSUPERVISOR_VER_MINOR=0
+GEMSUPERVISOR_VER_PATCH=1
+
+include $(BUILD_HOME)/config/mfDefsGEM.mk
+include $(BUILD_HOME)/config/mfPythonDefsGEM.mk
+
+Sources =CalibrationWeb.cc Calibration.cc
+
+Sources +=version.cc
+
+DynamicLibrary=gemcalibration
+
+IncludeDirs+=$(BUILD_HOME)/$(Package)/include
+IncludeDirs+=$(BUILD_HOME)/gembase/include
+IncludeDirs+=$(BUILD_HOME)/gemutils/include
+IncludeDirs+=$(BUILD_HOME)/gemsupervisor/include  #to get apps for SOAP
+IncludeDirs+=$(XHAL_ROOT)/include
+
+#DependentLibraryDirs+=/opt/xhal/lib
+UserCFlags  +=$(PYTHONCFLAGS)
+UserCCFlags +=$(PYTHONCFLAGS)
+
+#DependentLibraryDirs+=$(XHAL_ROOT)/lib
+#DependentLibraries+=xhal
+DependentLibraries+=boost_iostreams
+
+DependentLibraryDirs+=$(BUILD_HOME)/gemutils/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
+DependentLibraryDirs+=$(BUILD_HOME)/gembase/lib/$(XDAQ_OS)/$(XDAQ_PLATFORM)
+DependentLibraryDirs+=$(uHALROOT)/lib
+DependentLibraryDirs+=$(XHAL_ROOT)/lib
+
+DependentLibraries+=gemutils gembase
+
+Libraries =
+
+include $(XDAQ_ROOT)/$(BUILD_SUPPORT)/Makefile.rules
+include $(BUILD_HOME)/config/mfRPMDefsGEM.mk
+
+
+print-env:
+	@echo BUILD_HOME    $(BUILD_HOME)
+	@echo XDAQ_ROOT     $(XDAQ_ROOT)
+	@echo XDAQ_OS       $(XDAQ_OS)
+	@echo XDAQ_PLATFORM $(XDAQ_PLATFORM)
+	@echo LIBDIR        $(LIBDIR)
+	@echo ROOTCFLAGS    $(ROOTCFLAGS)
+	@echo ROOTLIBS      $(ROOTLIBS)
+	@echo ROOTGLIBS     $(ROOTGLIBS)
+	@echo GIT_VERSION   $(GIT_VERSION)
+	@echo GEMDEVELOPER  $(GEMDEVELOPER)
+	@echo CC            $(CC)
+	@echo CPP           $(CPP)
+	@echo CXX           $(CXX)
+	@echo LD            $(LD)
+	@echo AR            $(AR)
+	@echo NM            $(NM)
+	@echo RANLIB        $(RANLIB)
+	@echo GCCVERSION    $(GCCVERSION)
+	@echo CLANGVERSION  $(CLANGVERSION)

--- a/gemcalibration/html/scripts/cal_routines.js
+++ b/gemcalibration/html/scripts/cal_routines.js
@@ -1,0 +1,92 @@
+var actionURL = "";
+var cal_type = "";
+function store_actionURL(t_str)
+{
+  actionURL = t_str;
+};
+
+function selectCalType()
+{
+    $.ajax({
+        url: actionURL+"setCalType",
+        data: $('form#cal_select').serialize(),
+        type:  'GET',
+        dataType: 'html',
+        success: function(response)
+        {
+            var result = $('<div />').append(response).find("#cal_interface").html();
+            $('#cal_interface').html(result);
+        }
+    });
+};
+
+function apply_action()
+{
+    $.ajax({
+        url: actionURL+"applyAction",
+        data: $('form').serialize(),
+        type:  'POST',
+        success: function(data) {
+            if (data["status"] == 0) {
+                alert(data["alert"]);
+                $('#run_button').removeAttr('disabled');
+            } else {
+                alert(data["alert"]);
+            }
+        }
+    });
+};
+
+function select_links()
+{
+    var checkboxes = $('form#slot_and_masks_select').find(':checkbox');
+    checkboxes.prop('checked', true);
+    var masks = $('form#slot_and_masks_select').find(':input[type=text]');
+    masks.attr('value','0xFFC');
+};
+
+function deselect_links()
+{
+    var checkboxes = $('form#slot_and_masks_select').find(':checkbox');
+    checkboxes.prop('checked', false);
+    var masks = $('form#slot_and_masks_select').find(':input[type=text]')
+    masks.attr('value','0x000');
+};
+
+function select_dacscans()
+{
+    //$.event.preventDefault();
+    var checkboxes = $('form#dacScanV3_select').find(':checkbox');
+    checkboxes.prop('checked', true);
+};
+
+function deselect_dacscans()
+{
+    //$.event.preventDefault();
+    var checkboxes = $('form#dacScanV3_select').find(':checkbox');
+    checkboxes.prop('checked', false);  
+};
+
+function default_dacscans()
+{
+    //$.event.preventDefault();
+    var checkboxes = $('form#dacScanV3_select').find(':checkbox');
+    checkboxes.prop('checked', true);
+    document.getElementById("CFG_CAL_DAC").checked=false;
+    document.getElementById("CFG_VREF_ADC").checked=false;
+    if (window.jQuery) {
+        alert("Selecting all except CFG_CAL_DAC and CFG_VREF_ADC.");
+    }
+   
+};
+
+function run_scan()
+{
+    if (window.jQuery) {
+        alert("Well... This is still work in progress... But it should launch!");
+	//$.post(actionURL+"applyAction", $('form#scurve_input_params').serialize())
+	//    .done(alert("Applied"))
+    }
+};
+
+

--- a/gemcalibration/include/gem/calib/Calibration.h
+++ b/gemcalibration/include/gem/calib/Calibration.h
@@ -1,0 +1,266 @@
+/** @file Calibration.h */
+
+#ifndef GEM_CALIB_CALIBRATION_H
+#define GEM_CALIB_CALIBRATION_H
+
+#include <string>
+#include <vector>
+
+#include "gem/base/GEMApplication.h"
+#include "gem/utils/Lock.h"
+#include "gem/utils/LockGuard.h"
+
+//#include "gem/utils/exception/Exception.h"
+#include "gem/calib/GEMCalibEnums.h"
+
+#include "gem/utils/soap/GEMSOAPToolBox.h"
+
+#include "xdata/Bag.h"
+#include "xdata/Boolean.h"
+#include "xdata/Integer.h"
+#include "xdata/Integer32.h"
+#include "xdata/Integer64.h"
+#include "xdata/UnsignedShort.h"
+#include "xdata/UnsignedLong.h"
+#include "xdata/UnsignedInteger32.h"
+#include "xdata/UnsignedInteger64.h"
+#include "xdata/String.h"
+#include "xdata/Float.h"
+#include "xdata/Double.h"
+#include "xdata/Vector.h"
+
+
+
+namespace gem {
+    namespace calib {
+
+        class Calibration : public gem::base::GEMApplication
+        {
+
+        public:
+            XDAQ_INSTANTIATOR();
+
+            Calibration(xdaq::ApplicationStub* s);
+
+            virtual ~Calibration();
+
+            virtual void init();
+
+            virtual void actionPerformed(xdata::Event& event);
+
+
+            
+            void applyAction(xgi::Input *in, xgi::Output *out);
+
+            /**
+             * @brief Set the calibration routine to be perfomed from an initial dropdown menu and calls the appropriate selected interface
+             * @throws
+             */
+
+            void setCalType(xgi::Input *in, xgi::Output *out);
+
+            calType_t m_calType;
+
+            /**
+             *  map to link a particular calibration routine to the parameters needed for it.
+             *  parameters can be filled with a form  or a radio selector
+             */
+
+            std::map<calType_t, std::map<std::string, std::string /* uint32_t */>> m_scanParams{
+                {GBTPHASE  ,{{"nSamples","100"},{"phaseMin", "0"},{"phaseMax", "14"},{"stepSize", "1"},}},
+                {LATENCY,{
+                        {"nSamples"  , "100"},
+                        {"trigType"  , "0"},
+                        {"l1aTime"   , "250"},
+                        {"mspl"      , "4"},
+                        {"scanMin"   , "0"},
+                        {"scanMax"   , "300"},//"1023"},
+                        {"vfatChMin" , "0"},
+                        {"vfatChMax" , "1"},
+                            //{"vt2"       , 100},// TODO:need to be taken from DB
+                            // {"trigThrottle"  ,"0"},
+                        {"signalSourceType"       , "0"},
+                        {"pulseDelay" , "0"},//40
+                        {"stepSize"   , "1"},
+                }},
+                {SCURVE,{
+                        {"nSamples"  , "100"},
+                            //{"trigType"  , "0"}, // TODO: TTC local should be only possible one
+                        {"l1aTime"   , "250"},
+                        {"pulseDelay", "40"},
+                        {"latency"   , "33"},
+                        {"vfatChMin" , "0"},
+                        {"vfatChMax" , "127"},
+                        {"mspl"      , "4"},
+                        {"scanMin"   , "0"},
+                        {"scanMax"   , "255"},
+                       
+                 }},
+                 {SBITARMDACSCAN  ,{
+                        {"comparatorType","0"},
+                        {"perChannelType","0"},
+                        {"vfatChMin" , "0"},
+                        {"vfatChMax" , "127"},
+                        {"stepSize", "1"},
+                  }},
+                  {ARMDACSCAN  ,{
+                        {"nSamples"  , "1000"},
+                        {"trigType"  , "0"},
+                        {"vfatChMin" , "0"},
+                        {"vfatChMax" , "127"},
+                   }},
+                   {TRIMDAC  , {
+                        {"nSamples"   , "100"},
+                            // {"trigType"   , "0"}, // TODO: TTC local should be only possible one
+                        {"nSamples"   , "100"},
+                        {"l1aTime"    , "250"},
+                        {"pulseDelay" , "40"},
+                        {"latency"    , "33"},
+                        {"mspl"       , "4"},
+                        {"trimValues" , "-63,0,63"},
+                   
+                    }},
+                    {DACSCANV3  ,{
+                        {"adcType","0"},
+                    }},
+                    {CALIBRATEARMDAC,{
+                        {"nSamples"  , "100"},
+                            //  {"trigType"  , "0"}, // TODO: TTC local should be only possible one
+                        {"l1aTime"   , "250"},
+                        {"pulseDelay", "40"},
+                        {"latency"   , "33"},
+                        {"armDacPoins","17,20,23,25,30,40,50,60,70,80,100,125,150,175"},
+                    }}
+            };
+
+            struct scanParamsRadioSelector{
+                std::string label;
+                std::vector<std::string>  options;
+            };
+
+            /**
+             *  map of the parameters for which radio selector are used with relative viable options
+             */
+
+            std::map<std::string, scanParamsRadioSelector> m_scanParamsRadioSelector{
+                {"trigType",{"TriggerType", {"TTC input","Loopback","Lemo/T3"}}},
+                {"signalSourceType", {"Signal Source", {"Calibration Pulse","Particle"}}},
+                {"comparatorType", {"Coparator Type", {"CDF","Arming comparator"}}},
+                {"adcType", {"VFAT ADC reference", {"Internal","External"}}},
+                {"perChannelType", {"DAC scan per channel", {"False","True"}}},
+            };
+            /**
+             *  set of parameters not filled with form
+             */
+            std::set <std::string> m_scanParamsNonForm  {"trigType", "signalSourceType", "signalSourceType", "comparatorType", "adcType", "perChannelType", "dacScanType" };
+
+            /**
+             *  map of the routine parameters and relative labels to appear in the interface
+             */
+
+            std::map< std::string,std::string > m_scanParamsLabels{
+                {"nSamples"  , "Number of samples"},
+                {"l1aTime"   , "L1A period (BX)"},
+                {"mspl"      , "Pulse stretch (int)"},
+                {"scanMin"   , "Scan min"},
+                {"scanMax"   , "Scan max"},
+                {"vfatChMin" , "VFAT Ch min"},
+                {"vfatChMax" , "VFAT Ch max"},
+                    //{"vt2"       , "CFG_THR_ARM_DAC"},// TODO:need to be taken from DB
+                    //{"trigThrottle"  , "Trigger throttle (int)"},
+                {"pulseDelay", "Pulse delay (BX)"},
+                {"latency"   , "Latency (BX)"},
+                {"trimValues", "Points in dac range"}, // TODO:need to be implemented properly in the back end in order to get a given number of points {-63,0,63}
+                {"phaseMin"  , "Phase min (int)"  },  
+                {"phaseMax"  , "Phase max (int)"  },
+                {"stepSize", "Step size (int)"},
+                {"armDacPoins", "ARM DAC points"}, 
+            };
+
+            std::map<std::string, uint32_t> m_amcOpticalLinks;
+
+            dacScanType_t m_dacScanType;
+
+            struct dacFeature {
+                std::string label;
+                uint16_t min;
+                uint16_t max;
+                bool scan;
+            };
+
+            /**
+             *  map of selectable DAC scan for the VFAT3 parameters and relative labels and range limits
+             */
+            
+            std::map<dacScanType_t, dacFeature> m_dacScanTypeParams{
+                {CFG_CAL_DAC,{"CFG_CAL_DAC", 0, 255, false}},
+                {CFG_BIAS_PRE_I_BIT, {"CFG_BIAS_PRE_I_BIT", 0, 255, false}},
+                {CFG_BIAS_PRE_I_BLCC,{"CFG_BIAS_PRE_I_BLCC", 0, 63, false}},
+                {CFG_BIAS_PRE_I_BSF,{"CFG_BIAS_PRE_I_BSF", 0, 63, false}},
+                {CFG_BIAS_SH_I_BFCAS,{"CFG_BIAS_SH_I_BFCAS", 0, 255, false}},
+                {CFG_BIAS_SH_I_BDIFF,{"CFG_BIAS_SH_I_BDIFF", 0, 255, false}},
+                {CFG_BIAS_SD_I_BDIFF,{"CFG_BIAS_SD_I_BDIFF", 0, 255, false}},
+                {CFG_BIAS_SD_I_BFCAS,{"CFG_BIAS_SD_I_BFCAS", 0, 255, false}},
+                {CFG_BIAS_SD_I_BSF,{"CFG_BIAS_SD_I_BSF", 0, 63, false}},
+                {CFG_BIAS_CFD_DAC_1,{"CFG_BIAS_CFD_DAC", 0, 63, false}},
+                {CFG_BIAS_CFD_DAC_2,{"CFG_BIAS_CFD_DAC", 0, 63, false}},
+                {CFG_HYST,{"CFG_HYST", 0, 63, false}},
+                {CFG_THR_ARM_DAC,{"CFG_THR_ARM_DAC", 0, 255, false}},
+                {CFG_THR_ZCC_DAC,{"CFG_THR_ZCC_DAC", 0, 255, false}},
+                {CFG_BIAS_PRE_VREF,{"CFG_BIAS_PRE_VREF", 0, 255, false}},
+                {CFG_VREF_ADC,{"CFG_VREF_ADC", 0, 3, false}}
+            };
+
+            std::map<std::string,xdata::Integer> amcOpticalLinksMap ;
+            std::map<std::string,xdata::Integer> calibConfigMap ;
+            std::map<std::string,xdata::String> calibTypeConfigMap;
+            
+            void initializeCalibConfigMap(std::map<std::string, xdata::Integer>* calibConfigMap, std::map<std::string,xdata::String>* calibConfigTypeMap);
+            
+            void fillCalibConfigMap(calType_t calType,std::map<std::string,xdata::Integer>* calibConfigMap);
+            void printCalibConfigMap(std::map<std::string, xdata::Integer>* calibConfigMap);
+            
+            void fillCalibTypeConfigMap(calType_t calType,std::map<std::string,xdata::String>* calibConfigTypeMap);
+            
+            void fillBagFromConfigMap( std::unordered_map<std::string, xdata::Serializable*>* bag, std::map<std::string, xdata::Integer>* calibConfigMap, std::map<std::string, xdata::String>* calibTypeConfigMap);
+            
+            struct dacFeatureBag {
+                xdata::String label;
+                xdata::Integer min;
+                xdata::Integer max;
+                xdata::Boolean scan;
+            };
+            std::map<std::string, dacFeatureBag> dacScanConfigMap ;
+            void initializeAndFillDacScanConfigMap(std::map<std::string, dacFeatureBag>* dacScanConfigMap);
+            void fillDacScanBagFromConfigMap( std::unordered_map<std::string, xdata::Serializable*>* bag, std::map<std::string, dacFeatureBag>* dacScanConfigMap );
+
+            void initializeAndFillOpticalLinksMap(std::map<std::string, xdata::Integer>* OpticalLinksMap);
+            void fillBagFromOpticalLinksMap( std::unordered_map<std::string, xdata::Serializable*>* bag, std::map<std::string, xdata::Integer>* OpticalLinksMap);
+            
+        private:
+            xdata::Integer m_nShelves;
+            void sendSOAPMessageForDacScan();
+            void sendSOAPMessageForCalibration();
+             
+            const std::map<std::string, calType_t> m_calTypeSelector{
+                {"GBT Phase Scan"                , GBTPHASE},
+                    {"Latency Scan"                  , LATENCY},
+                        {"S-curve Scan"                  , SCURVE},
+                            {"S-bit ARM DAC Scan"            , SBITARMDACSCAN},
+                                {"ARM DAC Scan"                  , ARMDACSCAN},
+                                    {"Derive DAC Trim Registers"     , TRIMDAC},
+                                        {"DAC Scan on VFAT3"             , DACSCANV3},
+                                            {"Calibrate CFG_THR_ARM_DAC"     , CALIBRATEARMDAC},
+                                                };
+            
+            
+        protected:
+           
+        
+        };
+        
+        
+    }  // namespace gem::calib
+}  // namespace gem
+
+#endif  // GEM_CALIB_CALIBRATION_H

--- a/gemcalibration/include/gem/calib/CalibrationWeb.h
+++ b/gemcalibration/include/gem/calib/CalibrationWeb.h
@@ -1,0 +1,122 @@
+/** @file CalibrationWeb.h */
+
+#ifndef GEM_CALIB_CALIBRATIONWEB_H
+#define GEM_CALIB_CALIBRATIONWEB_H
+
+#include <memory>
+
+#include "gem/base/GEMWebApplication.h"
+#include "xdaq/WebApplication.h"
+
+
+#include "cgicc/HTMLClasses.h"
+
+#include "xdaq/WebApplication.h"
+#include "xgi/framework/Method.h"
+
+#include "gem/utils/soap/GEMSOAPToolBox.h"
+#include "gem/base/utils/GEMInfoSpaceToolBox.h"
+#include "gem/calib/Calibration.h"
+namespace gem {
+    namespace calib {
+
+        class Calibration;
+
+        class CalibrationWeb: public gem::base::GEMWebApplication
+        {
+        
+        public:
+            CalibrationWeb(Calibration *CalibrationApp);
+           
+
+            virtual ~CalibrationWeb();
+	
+            /**
+             * @brief Set the interface for the selected calibration routine
+             * @param calibration routine to be perfomed
+             * @param xgi output for the html 
+             * @param number of shelves taken from XML configuration file for the amc optical links
+             * @throws
+             */
+
+            void settingsInterface(calType_t m_calType, xgi::Output *out, xdata::Integer m_nShelves);
+
+            /**
+             * @brief Selector for the slot and OH mask 
+             * @param xgi output for the html 
+             * @param number of shelves taken from XML configuration file for the amc optical links
+             * @throws
+             */
+
+            void slotsAndMasksSelector(xgi::Output *out, xdata::Integer m_nShelves);
+
+            /**
+             * @brief Generic selector for a calibration routine parameter 
+             * @param label associated with the parameter
+             * @param parameter name
+             * @param parameter default value
+             * @param xgi output for the html 
+             * @throws
+             */
+	
+            void genericParamSelector(std::string labelName, std::string paramName, std::string defaultValue, xgi::Output *out);
+	
+            /**
+             * @brief Selector for the DAC scan calibration routine parameter with dropdown to select the parameter to scan on
+             * @param xgi output for the html 
+             * @throws
+             */
+	
+            void dacScanV3Selector(xgi::Output *out);
+	
+            /**
+             * @brief Form selector for the DAC scan calibration routine parameter
+             * @param parameter name 
+             * @param parameter default value 
+             * @param xgi output for the html 
+             * @throws
+             */
+	
+            void genericParamSelector_dacScan( std::string paramName, int defaultValue, xgi::Output *out);
+
+            /**
+             * @brief Radio selector for calibration routine parameter
+             * @param parameter name 
+             * @param parameter options 
+             * @param xgi output for the html 
+             * @throws
+             */
+	
+            void genericRadioSelector(std::string paramName, gem::calib::Calibration::scanParamsRadioSelector radio_param, xgi::Output *out);
+            //
+	
+
+        protected:
+            virtual void webDefault(  xgi::Input *in, xgi::Output *out );
+
+            virtual void calibrationPage(  xgi::Input *in, xgi::Output *out );
+
+            virtual void applicationPage(xgi::Input *in, xgi::Output *out);
+
+        private:
+            size_t level;
+            const std::map<calType_t, std::string> alertMap {
+                {GBTPHASE,"To run the routine select the cards, the optohybrids,the nuber of samples the phase maximum and minimu value and the step size for the scan."},
+                {LATENCY,"To run the routine  indicate the number of events, the  pulse stretch configuration, the minimum and maximum scan values, the step size, and the desired VFAT channels."},
+                {SCURVE,"To run the routine select the cards, the optohybrids, the VFATs and links. \
+                Indicate the number of events for each position and the latency and pulse stretch configuration."},
+                {SBITARMDACSCAN,"To run the routine select the cards, the optohybrids, the VFATs and links."},
+                {ARMDACSCAN,"To run the routine select the cards, the optohybrids, the VFATs and links, indicate the number of events \
+                for each position, the minimum and maximum scan values, and the CFG_THR_ARM_DAC."},
+                {TRIMDAC,"To run the routine select the cards, the optohybrids."},
+                {DACSCANV3,"To run the routine select the cards, and the optohybrids. Really?? //TODO: clarify!!"},
+                {CALIBRATEARMDAC,"To run the routine select the cards, the optohybrids. \
+                Indicate the number of events for each position and the latency and pulse stretch configuration."},
+        
+                };
+         
+        };  // class gem::calib::CalibrationWeb
+    }  // namespace gem::calib
+}  // namespace gem
+
+#endif  // GEM_CALIB_CALIBRATIONWEB_H

--- a/gemcalibration/include/gem/calib/GEMCalibEnums.h
+++ b/gemcalibration/include/gem/calib/GEMCalibEnums.h
@@ -1,0 +1,20 @@
+/** @file GEMCalibEnums.h */
+
+#ifndef GEM_CALIB_CALIBENUMS_H
+#define GEM_CALIB_CALIBENUMS_H
+
+namespace gem {
+    namespace calib {
+
+        enum calType {NDEF, GBTPHASE, LATENCY, SCURVE, SBITARMDACSCAN, ARMDACSCAN, TRIMDAC, DACSCANV3, CALIBRATEARMDAC};
+        
+        typedef enum calType calType_t;
+       
+        enum dacScanType {CFG_CAL_DAC, CFG_BIAS_PRE_I_BIT, CFG_BIAS_PRE_I_BLCC, CFG_BIAS_PRE_I_BSF, CFG_BIAS_SH_I_BFCAS, CFG_BIAS_SH_I_BDIFF, CFG_BIAS_SD_I_BDIFF, CFG_BIAS_SD_I_BFCAS, CFG_BIAS_SD_I_BSF, CFG_BIAS_CFD_DAC_1, CFG_BIAS_CFD_DAC_2, CFG_HYST, CFG_THR_ARM_DAC, CFG_THR_ZCC_DAC, CFG_BIAS_PRE_VREF, CFG_VREF_ADC};
+        
+        typedef enum dacScanType dacScanType_t;
+    }
+}
+
+
+#endif // GEM_CALIB_CALIBENUMS_H

--- a/gemcalibration/include/gem/calib/exception/Exception.h
+++ b/gemcalibration/include/gem/calib/exception/Exception.h
@@ -1,0 +1,39 @@
+/** @file Exception.h */
+
+#ifndef GEM_CALIB_EXCEPTION_EXCEPTION_H
+#define GEM_CALIB_EXCEPTION_EXCEPTION_H
+
+#include <string>
+
+#include "xcept/Exception.h"
+
+/***
+ // Macros defined in xdaq code that are useful to remember
+ //! Macro to throw an excpetion with line number and function name
+ #define XCEPT_RAISE( EXCEPTION, MSG )  throw EXCEPTION( #EXCEPTION, MSG, __FILE__, __LINE__, __FUNCTION__)
+
+ #define XCEPT_RETHROW( EXCEPTION, MSG, PREVIOUS )  throw EXCEPTION( #EXCEPTION, MSG, __FILE__, __LINE__, __FUNCTION__, PREVIOUS)
+
+ #define XCEPT_ASSERT(COND, EXCEPTION, MSG)  if (!(COND))  { XCEPT_RAISE(EXCEPTION, MSG); }
+
+ // Create a new exception and use
+ // it as a variable called VAR
+ #define XCEPT_DECLARE( EXCEPTION, VAR, MSG )				 EXCEPTION VAR( #EXCEPTION, MSG, __FILE__, __LINE__, __FUNCTION__)
+
+ // Create a new exception from a previous one and use
+ // it as a variable called VAR
+ #define XCEPT_DECLARE_NESTED( EXCEPTION, VAR, MSG, PREVIOUS )		 EXCEPTION VAR( #EXCEPTION, MSG, __FILE__, __LINE__, __FUNCTION__, PREVIOUS)
+***/
+
+#define GEM_CALIB_DEFINE_EXCEPTION(EXCEPTION_NAME)                        namespace gem {                                                           namespace calib {                                                         namespace exception {                                                     class EXCEPTION_NAME : virtual public xcept::Exception                    {                                                                       public :                                                                EXCEPTION_NAME(std::string name,                                                       std::string message,                                                    std::string module,                                                     int line,                                                               std::string function) :                                    xcept::Exception(name, message, module, line, function)                   {};                                                                 EXCEPTION_NAME(std::string name,                                                       std::string message,                                                    std::string module,                                                     int line,                                                               std::string function,                                                   xcept::Exception& err) :                                   xcept::Exception(name, message, module, line, function, err)               {};                                                                 };                                                                  }  /* namespace gem::calib::exception */                              }  /* namespace gem::calib            */                              }  /* namespace gem                   */
+
+// The gem::calib exceptions.
+GEM_CALIB_DEFINE_EXCEPTION(Exception)
+GEM_CALIB_DEFINE_EXCEPTION(SoftwareProblem)
+GEM_CALIB_DEFINE_EXCEPTION(ValueError)
+
+// The gem::calib alarms.
+#define GEM_CALIB_DEFINE_ALARM(ALARM_NAME) GEM_CALIB_DEFINE_EXCEPTION(ALARM_NAME)
+GEM_CALIB_DEFINE_ALARM(MonitoringFailureAlarm)
+
+#endif  // GEM_CALIB_EXCEPTION_EXCEPTION_H

--- a/gemcalibration/include/gem/calib/version.h
+++ b/gemcalibration/include/gem/calib/version.h
@@ -1,0 +1,42 @@
+/** @file version.h */
+
+#ifndef GEM_CALIB_VERSION_H
+#define GEM_CALIB_VERSION_H
+
+#ifndef DOXYGEN_IGNORE_THIS
+
+#include "config/PackageInfo.h"
+
+namespace gemcalibration {
+
+
+#define GEMCALIBRATION_VERSION_MAJOR 0
+#define GEMCALIBRATION_VERSION_MINOR 0
+#define GEMCALIBRATION_VERSION_PATCH 0
+#define GEMCALIBRATION_PREVIOUS_VERSIONS ""
+
+#define GEMCALIBRATION_VERSION_CODE PACKAGE_VERSION_CODE(GEMCALIBRATION_VERSION_MAJOR, GEMCALIBRATION_VERSION_MINOR, GEMCALIBRATION_VERSION_PATCH)
+
+#ifndef GEMCALIBRATION_PREVIOUS_VERSIONS
+#define GEMCALIBRATION_FULL_VERSION_LIST  PACKAGE_VERSION_STRING(GEMCALIBRATION_VERSION_MAJOR, GEMCALIBRATION_VERSION_MINOR, GEMCALIBRATION_VERSION_PATCH)
+#else
+#define GEMCALIBRATION_FULL_VERSION_LIST  GEMCALIBRATION_PREVIOUS_VERSIONS "," PACKAGE_VERSION_STRING(GEMCALIBRATION_VERSION_MAJOR, GEMCALIBRATION_VERSION_MINOR, GEMCALIBRATION_VERSION_PATCH)
+#endif
+
+      const std::string project     = "cmsgemos";
+      const std::string package     = "gemcalibration";
+      const std::string versions    = GEMCALIBRATION_FULL_VERSION_LIST;
+      const std::string summary     = "Calibration suite";
+      const std::string description = "";
+      const std::string authors     = "GEM Online Systems Group";
+      const std::string link        = "https://cms-gem-daq-project.github.io/cmsgemos/";
+
+      config::PackageInfo getPackageInfo();
+      void checkPackageDependencies();
+      std::set<std::string,std::less<std::string> > getPackageDependencies();
+  
+}
+
+#endif // DOXYGEN_IGNORE_THIS
+
+#endif // GEM_CALIB_VERSION_H

--- a/gemcalibration/src/common/Calibration.cc
+++ b/gemcalibration/src/common/Calibration.cc
@@ -1,0 +1,400 @@
+/**
+ * class: Calibration
+ * description: Calibration application for GEM system
+ *              structure borrowed from gemSupervisor
+ * author: 
+ * date:
+ */
+
+#include "gem/calib/Calibration.h"
+
+#include <cstdlib>
+#include <iomanip>
+
+#include <map>
+#include <set>
+#include <vector>
+#include <algorithm>
+
+#include <boost/algorithm/string.hpp>
+
+#include "gem/calib/CalibrationWeb.h"
+
+//#include "gem/utils/soap/GEMSOAPToolBox.h"
+//#include "gem/utils/exception/Exception.h"
+
+typedef gem::base::utils::GEMInfoSpaceToolBox::UpdateType GEMUpdateType;
+
+XDAQ_INSTANTIATOR_IMPL(gem::calib::Calibration);
+
+gem::calib::Calibration::Calibration(xdaq::ApplicationStub* stub) :
+    gem::base::GEMApplication(stub),
+    m_nShelves(0)
+{
+    CMSGEMOS_DEBUG("gem::calib::Calibration : Creating the CalibrationWeb interface");
+    CMSGEMOS_DEBUG("gem::calib::Calibration : Retrieving configuration");
+    p_appInfoSpace->fireItemAvailable("nShelves",     &m_nShelves);
+    p_appInfoSpace->addItemRetrieveListener("nShelves", this);
+    p_appInfoSpace->addItemChangedListener("nShelves", this);
+    CMSGEMOS_DEBUG("gem::calib::Calibration : configuration retrieved");
+    CMSGEMOS_INFO("gem::calib::Calibration:init() number of shelves: " << m_nShelves.value_);
+    p_gemWebInterface = new gem::calib::CalibrationWeb(this);
+    m_calType = NDEF;
+  
+    xgi::bind(this, &Calibration::applyAction, "applyAction");
+    xgi::bind(this, &Calibration::setCalType, "setCalType");
+
+   
+}
+
+gem::calib::Calibration::~Calibration()
+{
+    CMSGEMOS_DEBUG("gem::calib::Calibration : Destructor called");
+    // make sure to empty the v_supervisedApps  vector and free the pointers
+}
+
+void gem::calib::Calibration::actionPerformed(xdata::Event& event)
+{
+    if (event.type() == "setDefaultValues" || event.type() == "urn:xdaq-event:setDefaultValues") {
+        CMSGEMOS_DEBUG("gem::calib::Calibration::actionPerformed() setDefaultValues" <<
+                       "Default configuration values have been loaded from xml profile");
+        init();
+    }
+
+    // item is changed, update it
+    if (event.type() == "ItemChangedEvent" || event.type() == "urn:xdata-event:ItemChangedEvent") {
+        CMSGEMOS_DEBUG("gem::calib::Calibration::actionPerformed() ItemChangedEvent");
+    }
+    // update calibration variables
+    gem::base::GEMApplication::actionPerformed(event);
+}
+
+void gem::calib::Calibration::init()
+{
+    CMSGEMOS_INFO("gem::calib::Calibration:init() number of shelves: " << m_nShelves.value_);
+ 
+}
+
+void gem::calib::Calibration::applyAction(xgi::Input* in, xgi::Output* out)
+{
+    bool t_errorsOccured = false;
+    cgicc::Cgicc cgi(in);
+      
+    std::map<std::string, std::string >::iterator it = (m_scanParams.find(m_calType)->second).begin();
+    while (it!= (m_scanParams.find(m_calType)->second).end() ){
+        
+        it->second = cgi[it->first]->getValue();
+        CMSGEMOS_DEBUG("Calibration::applyAction for calibration "<< m_calType <<" : " << it->first << " = " << it->second);
+        it++;
+    }
+    
+    
+    
+    std::stringstream t_stream;
+    //for (unsigned int i = 0; i < NSHELF; ++i) {
+    for ( int i = 0; i < m_nShelves.value_; ++i) {
+        t_stream.clear();
+        t_stream.str(std::string());
+        t_stream << "shelf"<< std::setfill('0') << std::setw(2) << i+1;
+        bool checked = false;
+        checked = cgi.queryCheckbox(t_stream.str());
+        if (checked) {
+            for (unsigned int j = 0; j < gem::base::GEMApplication::MAX_AMCS_PER_CRATE; ++j) { //SHELF.AMC
+                t_stream.clear();
+                t_stream.str(std::string());
+                t_stream << "shelf"<< std::setfill('0') << std::setw(2) << i+1 << ".amc" << std::setfill('0') << std::setw(2) << j+1;
+                checked = cgi.queryCheckbox(t_stream.str());
+                if (checked) {
+                    std::string amc_id = t_stream.str();
+                    m_amcOpticalLinks.emplace(amc_id, 0);
+                    t_stream << ".ohMask";
+                    uint32_t ohMask = std::stoul(cgi[t_stream.str()]->getValue(), 0, 16);
+                    
+                    CMSGEMOS_DEBUG("Calibration::applyAction : OH mask for " << t_stream.str() << " ohMask is " << ohMask );
+                    if (ohMask > 0xffc) {
+                        t_errorsOccured = true;
+                        CMSGEMOS_ERROR("Calibration::applyAction : OH mask for " << t_stream.str() << " is out of allowed boundaries! Ignoring it");
+                    } else{
+                        m_amcOpticalLinks.find(amc_id)->second = ohMask;
+                    }
+                } else{// end if checked for amc
+                    std::string amc_id = t_stream.str();
+                    m_amcOpticalLinks.emplace(amc_id, 0);
+                    m_amcOpticalLinks.find(amc_id)->second = 0;
+                }
+            } // end loop over NAMC 
+        } // end if checked for shelf
+        else{ /// filling also the empty slot.amc with OHMask=0 
+           for (unsigned int j = 0; j < gem::base::GEMApplication::MAX_AMCS_PER_CRATE; ++j) { //SHELF.AMC
+                t_stream.clear();
+                t_stream.str(std::string());
+                t_stream << "shelf"<< std::setfill('0') << std::setw(2) << i+1 << ".amc" << std::setfill('0') << std::setw(2) << j+1;
+                std::string amc_id = t_stream.str();
+                m_amcOpticalLinks.emplace(amc_id, 0);
+                m_amcOpticalLinks.find(amc_id)->second = 0;
+                CMSGEMOS_DEBUG("Calibration::applyAction: ****Empty OH mask for " << t_stream.str() << " ohMask is 0");
+           } // end if checked for amc
+           
+        }
+            
+    } //end loop over shelves
+    //TODO: should we check if at least one link is selected??
+    
+
+    //DACSCAN type
+    if (m_calType==DACSCANV3) {
+        for (auto & it : m_dacScanTypeParams) {
+            t_stream.clear();
+            t_stream.str(std::string());
+            t_stream << it.second.label;
+            bool checked = false;
+            checked = cgi.queryCheckbox(t_stream.str());
+            if (checked) {
+                it.second.min = cgi[it.second.label+"_Min"]->getIntegerValue();
+                it.second.max = cgi[it.second.label+"_Max"]->getIntegerValue();
+                it.second.scan = true;
+                //CMSGEMOS_DEBUG("Calibration::applyAction DAC SCAN V3 for calibration: checked "<< it.second.label << " with par  min " << it.second.min << " max " << it.second.max);
+            } else {
+                it.second.scan = false;
+            }
+        }
+    }
+    //TODO: should we check the range of the parameters?
+
+    out->getHTTPResponseHeader().addHeader("Content-Type", "application/json");
+    if (t_errorsOccured) {
+        *out << "{\"status\":1,\"alert\":\"There was an error in the parameters retrieval. Please check the XDAQ log for more information\"}";
+    } else {
+        *out << "{\"status\":0,\"alert\":\"Parameters successfully applied. Now you can run the scan.\"}";
+    }
+    ///Just for debugging TODO:Remove
+    for (auto it: m_scanParams.find(m_calType)->second) {
+        CMSGEMOS_DEBUG("Calibration::end of applyAction for calibration "<< m_calType <<" : " << it.first << " = " << it.second);
+      
+    }
+      
+    if (m_calType==DACSCANV3){
+        sendSOAPMessageForDacScan();
+    } else {
+        sendSOAPMessageForCalibration();
+    }
+    
+}
+
+void gem::calib::Calibration::setCalType(xgi::Input* in, xgi::Output* out)
+{
+    CMSGEMOS_INFO("Calibration::setCalType");
+    out->getHTTPResponseHeader().addHeader("Content-Type", "text/html");
+    cgicc::Cgicc cgi(in);
+    m_calType = m_calTypeSelector.find(cgi["cal_type_select"]->getValue())->second;
+    switch (m_calType) {
+    case NDEF: 
+        CMSGEMOS_DEBUG("Calibration::setCalType : Selected Cal Type: NDEF");
+        break;
+    default: 
+        CMSGEMOS_DEBUG("Calibration::setCalType : Selected Cal Type: SCURVE");
+        dynamic_cast<gem::calib::CalibrationWeb*>(p_gemWebInterface)->settingsInterface(m_calType, out, m_nShelves); 
+        break;
+    }
+}
+
+
+void gem::calib::Calibration::initializeCalibConfigMap(std::map<std::string, xdata::Integer>* calibConfigMap, std::map<std::string,xdata::String>* calibTypeConfigMap) {
+    for (auto const  &element : m_scanParams ){
+        for (auto it : element.second) {
+            
+            if(it.first.find("armDac")!=std::string::npos || it.first.find("trimValues")!=std::string::npos) {
+                std::map<std::string,xdata::String>::iterator iterStr;
+                iterStr = calibTypeConfigMap->find(it.first);
+                if (iterStr==calibTypeConfigMap->end()){
+                    calibTypeConfigMap->insert( std::pair <std::string,xdata::String> (it.first, "") );
+                  
+                }else {
+                    calibTypeConfigMap->find(it.first)->second= "";
+                
+                }
+            }else{
+
+                std::map<std::string,xdata::Integer>::iterator iter;
+                iter = calibConfigMap->find(it.first);
+                if (iter==calibConfigMap->end()){
+                    calibConfigMap->insert( std::pair <std::string,xdata::Integer> (it.first, 0) );
+                    
+                }else {
+                    calibConfigMap->find(it.first)->second= 0;
+                }
+            }
+        }
+    }
+     
+}
+
+
+void gem::calib::Calibration::fillCalibConfigMap(calType_t cal, std::map<std::string, xdata::Integer>* calibConfigMap) {
+   
+    for ( auto it: m_scanParams.find(cal)->second ) {
+        if (it.first.find("armDac")!=std::string::npos || it.first.find("trimValues")!=std::string::npos) continue;
+        (calibConfigMap->find(it.first))->second =  std::stoi(it.second.c_str());
+        
+    }
+}
+
+void gem::calib::Calibration::fillCalibTypeConfigMap(calType_t cal, std::map<std::string, xdata::String>* calibTypeConfigMap) {
+    
+    for ( auto it: m_scanParams.find(cal)->second ) {
+        if (it.first.find("armDac")!=std::string::npos || it.first.find("trimValues")!=std::string::npos) {
+         calibTypeConfigMap->find(it.first)->second = it.second;
+        }
+    }
+}
+
+void gem::calib::Calibration::printCalibConfigMap(  std::map<std::string, xdata::Integer>* calibConfigMap ) {
+     std::map<std::string,xdata::Integer>::iterator iter;
+     std::cout <<" Printing CalibConfigMap "<< std::endl;
+     for ( iter = calibConfigMap->begin(); iter != calibConfigMap->end() ;++iter ) {
+         std::cout <<" iter->first "<<iter->first << " second " << iter->second.toString()<< std::endl;
+    }
+}
+       
+ void gem::calib::Calibration::fillBagFromConfigMap( std::unordered_map<std::string, xdata::Serializable*>* bag, std::map<std::string, xdata::Integer>* calibConfigMap, std::map<std::string, xdata::String>* calibTypeConfigMap) {
+    
+    std::map<std::string,xdata::Integer>::iterator iter;
+    for ( iter = calibConfigMap->begin(); iter != calibConfigMap->end() ;++iter ) {
+        bag->insert(std::make_pair(iter->first,    &(iter->second)));
+    }
+    std::map<std::string,xdata::String>::iterator iterStr;
+    for ( iterStr = calibTypeConfigMap->begin(); iterStr != calibTypeConfigMap->end() ;++iterStr ) {
+        bag->insert(std::make_pair(iterStr->first,    &(iterStr->second)));  
+    }
+}
+
+void gem::calib::Calibration::initializeAndFillDacScanConfigMap(std::map<std::string, dacFeatureBag>* dacScanConfigMap) {
+    for (auto it :  m_dacScanTypeParams ) {  
+            
+        
+        if (dacScanConfigMap->find(it.second.label)==dacScanConfigMap->end()) {
+            dacFeatureBag tmp;
+            tmp.label= it.second.label;
+            tmp.min=it.second.min;
+            tmp.max=it.second.max;
+            tmp.scan=it.second.scan;
+            dacScanConfigMap->insert( std::pair <std::string,dacFeatureBag> (it.second.label, tmp ) );
+            
+        }else{
+            dacScanConfigMap->find(it.second.label)->second.min = it.second.min;
+            dacScanConfigMap->find(it.second.label)->second.max = it.second.max;
+            dacScanConfigMap->find(it.second.label)->second.scan = it.second.scan;
+        }           
+        
+    }
+}
+
+void gem::calib::Calibration::fillDacScanBagFromConfigMap( std::unordered_map<std::string, xdata::Serializable*>* bag, std::map<std::string, dacFeatureBag>* dacScanConfigMap ) {
+    
+    std::map<std::string, dacFeatureBag>::iterator iter;
+    for ( iter = dacScanConfigMap->begin(); iter != dacScanConfigMap->end() ;++iter ) {
+        bag->insert(std::make_pair(iter->first,    &(iter->second.label)));
+        bag->insert(std::make_pair(iter->first+"_min",    &(iter->second.min)));
+        bag->insert(std::make_pair(iter->first+"_max",    &(iter->second.max)));
+        bag->insert(std::make_pair(iter->first+"_scan",    &(iter->second.scan)));
+        
+    }
+}
+void gem::calib::Calibration::sendSOAPMessageForCalibration() {
+
+   
+    
+    //std::set<xdaq::ApplicationDescriptor*> used;
+    std::set<std::string> groups = p_appZone->getGroupNames();
+    for (auto i =groups.begin(); i != groups.end(); ++i) {
+        CMSGEMOS_DEBUG("GEMCalibration:::init::xDAQ group: " << *i
+                      << " getApplicationGroup() " << p_appZone->getApplicationGroup(*i)->getName());
+        
+        xdaq::ApplicationGroup* ag = const_cast<xdaq::ApplicationGroup*>(p_appZone->getApplicationGroup(*i));
+        std::set<const xdaq::ApplicationDescriptor*> allApps = ag->getApplicationDescriptors();
+        for (auto j = allApps.begin(); j != allApps.end(); ++j) {
+            std::string classname = (*j)->getClassName();
+
+            CMSGEMOS_DEBUG("GEMCalibration:::init::xDAQ group: " << *i
+                      << " allApp class name " << (*j)->getClassName());
+                         
+                xdaq::ApplicationDescriptor* app=(xdaq::ApplicationDescriptor*) *j;
+                std::string command = "calibParamRetrieve";
+                
+                initializeCalibConfigMap( &calibConfigMap, &calibTypeConfigMap);
+                
+                fillCalibConfigMap(m_calType,&calibConfigMap);
+               
+                printCalibConfigMap(&calibConfigMap);
+                fillCalibTypeConfigMap(m_calType,&calibTypeConfigMap);
+                std::unordered_map<std::string, xdata::Serializable*> bagFromMap;
+                xdata::Integer calType= m_calType;
+                bagFromMap.insert(std::make_pair("calType",    &(calType)));        
+                fillBagFromConfigMap(&bagFromMap,&calibConfigMap,&calibTypeConfigMap);
+
+                initializeAndFillOpticalLinksMap( &amcOpticalLinksMap);
+                fillBagFromOpticalLinksMap(&bagFromMap,&amcOpticalLinksMap);
+                
+                CMSGEMOS_INFO("GEMCalibration::applying action sending SOAP message to GLIB Manager with unordered bag");
+                gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(command, bagFromMap, p_appContext, p_appDescriptor, app);
+                printCalibConfigMap(&calibConfigMap);
+                                   
+        }
+    }
+    
+}
+
+void gem::calib::Calibration::sendSOAPMessageForDacScan() {
+    
+    std::set<std::string> groups = p_appZone->getGroupNames();
+    for (auto i =groups.begin(); i != groups.end(); ++i) {
+        CMSGEMOS_INFO("GEMCalibration:::init::xDAQ group: " << *i
+                      << "getApplicationGroup() " << p_appZone->getApplicationGroup(*i)->getName());
+        
+        xdaq::ApplicationGroup* ag = const_cast<xdaq::ApplicationGroup*>(p_appZone->getApplicationGroup(*i));
+        std::set<const xdaq::ApplicationDescriptor*> allApps = ag->getApplicationDescriptors();
+        
+        for (auto j = allApps.begin(); j != allApps.end(); ++j) {
+            std::string classname = (*j)->getClassName();
+                             
+                xdaq::ApplicationDescriptor* app=(xdaq::ApplicationDescriptor*) *j;
+                std::string command = "calibrateAction"; 
+                initializeAndFillDacScanConfigMap( &dacScanConfigMap);
+                std::unordered_map<std::string, xdata::Serializable*> bagDacScanFromMap;
+                xdata::Integer calType= m_calType;
+                bagDacScanFromMap.insert(std::make_pair("calType",    &(calType)));        
+                fillDacScanBagFromConfigMap(&bagDacScanFromMap,&dacScanConfigMap);
+                initializeAndFillOpticalLinksMap( &amcOpticalLinksMap);
+                fillBagFromOpticalLinksMap(&bagDacScanFromMap,&amcOpticalLinksMap);
+                CMSGEMOS_INFO("GEMCalibration::applying action sending SOAP message to GLIB Manager with unordered bag");
+                gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(command, bagDacScanFromMap, p_appContext, p_appDescriptor, app);
+               
+        }
+    }
+    
+}
+
+void gem::calib::Calibration::initializeAndFillOpticalLinksMap(std::map<std::string, xdata::Integer>* amcOpticalLinksMap) {
+
+    for (auto it :  m_amcOpticalLinks ) {  
+        if (amcOpticalLinksMap->find(it.first)== amcOpticalLinksMap->end()) {
+            xdata::Integer tmp;
+            tmp = it.second;
+            amcOpticalLinksMap->insert( std::pair <std::string,xdata::Integer> (it.first, tmp ) );
+        
+        }else{
+            amcOpticalLinksMap->find(it.first)->second = it.second;
+        }              
+    }
+}
+
+void gem::calib::Calibration::fillBagFromOpticalLinksMap( std::unordered_map<std::string, xdata::Serializable*>* bag, std::map<std::string, xdata::Integer>* amcOpticalLinksMap ) {
+    
+     std::map<std::string,xdata::Integer>::iterator iter;
+     for ( iter = amcOpticalLinksMap->begin(); iter != amcOpticalLinksMap->end() ;++iter ) {
+         bag->insert(std::make_pair(iter->first,    &(iter->second)));
+         CMSGEMOS_DEBUG("GEMCalibration::fillBagFromOpticalLinksMap: mask " << iter->first << " value "<< iter->second );
+    }
+     
+    
+}

--- a/gemcalibration/src/common/Calibration.cc
+++ b/gemcalibration/src/common/Calibration.cc
@@ -250,9 +250,9 @@ void gem::calib::Calibration::fillCalibTypeConfigMap(calType_t cal, std::map<std
 
 void gem::calib::Calibration::printCalibConfigMap(  std::map<std::string, xdata::Integer>* calibConfigMap ) {
      std::map<std::string,xdata::Integer>::iterator iter;
-     std::cout <<" Printing CalibConfigMap "<< std::endl;
+     CMSGEMOS_DEBUG("Calibration::printCalibConfigMap  Printing CalibConfigMap");
      for ( iter = calibConfigMap->begin(); iter != calibConfigMap->end() ;++iter ) {
-         std::cout <<" iter->first "<<iter->first << " second " << iter->second.toString()<< std::endl;
+         CMSGEMOS_DEBUG(" iter->first "<<iter->first << " second " << iter->second.toString());
     }
 }
        
@@ -334,8 +334,7 @@ void gem::calib::Calibration::sendSOAPMessageForCalibration() {
 
                 initializeAndFillOpticalLinksMap( &amcOpticalLinksMap);
                 fillBagFromOpticalLinksMap(&bagFromMap,&amcOpticalLinksMap);
-                
-                CMSGEMOS_INFO("GEMCalibration::applying action sending SOAP message to GLIB Manager with unordered bag");
+               
                 gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(command, bagFromMap, p_appContext, p_appDescriptor, app);
                 printCalibConfigMap(&calibConfigMap);
                                    
@@ -348,7 +347,7 @@ void gem::calib::Calibration::sendSOAPMessageForDacScan() {
     
     std::set<std::string> groups = p_appZone->getGroupNames();
     for (auto i =groups.begin(); i != groups.end(); ++i) {
-        CMSGEMOS_INFO("GEMCalibration:::init::xDAQ group: " << *i
+        CMSGEMOS_DEBUG("GEMCalibration:::init::xDAQ group: " << *i
                       << "getApplicationGroup() " << p_appZone->getApplicationGroup(*i)->getName());
         
         xdaq::ApplicationGroup* ag = const_cast<xdaq::ApplicationGroup*>(p_appZone->getApplicationGroup(*i));
@@ -366,7 +365,6 @@ void gem::calib::Calibration::sendSOAPMessageForDacScan() {
                 fillDacScanBagFromConfigMap(&bagDacScanFromMap,&dacScanConfigMap);
                 initializeAndFillOpticalLinksMap( &amcOpticalLinksMap);
                 fillBagFromOpticalLinksMap(&bagDacScanFromMap,&amcOpticalLinksMap);
-                CMSGEMOS_INFO("GEMCalibration::applying action sending SOAP message to GLIB Manager with unordered bag");
                 gem::utils::soap::GEMSOAPToolBox::sendCommandWithParameterBag(command, bagDacScanFromMap, p_appContext, p_appDescriptor, app);
                
         }

--- a/gemcalibration/src/common/CalibrationWeb.cc
+++ b/gemcalibration/src/common/CalibrationWeb.cc
@@ -1,0 +1,310 @@
+#include "gem/calib/CalibrationWeb.h"
+#include <boost/algorithm/string.hpp>
+//#include "xcept/tools.h"
+
+#include "gem/calib/Calibration.h"
+#include <iomanip>
+
+gem::calib::CalibrationWeb::CalibrationWeb(gem::calib::Calibration* CalibrationApp) :
+    gem::base::GEMWebApplication(CalibrationApp)
+{
+    // default constructor
+}
+
+gem::calib::CalibrationWeb::~CalibrationWeb()
+{
+    // default destructor
+}
+
+void gem::calib::CalibrationWeb::webDefault(xgi::Input * in, xgi::Output * out)
+{
+   
+    *out << cgicc::script().set("type", "text/javascript")
+        .set("src", "/gemdaq/gemcalibration/html/scripts/cal_routines.js")
+         << cgicc::script() << std::endl;
+
+    *out << "<link  rel=\"stylesheet\" href=\"/gemdaq/gembase/html/css/bootstrap.css\" type=\"text/css\">" << std::endl;
+    *out << "<link  rel=\"stylesheet\" href=\"/gemdaq/gembase/html/css/bootstrap.min.css\" type=\"text/css\">" << std::endl;
+    *out << "<script src=\"/gemdaq/gembase/html/scripts/bootstrap.js\"></script>" << std::endl;
+    *out << "<script src=\"/gemdaq/gembase/html/scripts/jquery.min.js\"></script>" << std::endl;
+
+    *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
+    *out << "    <div class=\"xdaq-tab\" title=\"Calibration Control\">" << std::endl;
+    this->calibrationPage(in, out);
+    *out << "    </div>" << std::endl;
+    *out << "    <div class=\"xdaq-tab\" title=\"Monitoring page\">" << std::endl;
+    this->monitorPage(in, out);
+    *out << "    </div>" << std::endl;
+    *out << "    <div class=\"xdaq-tab\" title=\"Expert page\">" << std::endl;
+    this->expertPage(in, out);
+    *out << "    </div>" << std::endl;
+    *out << "</div>" << std::endl;
+
+    GEMWebApplication::webFooterGEM(in, out);
+
+    std::string updateLink = "/" + p_gemApp->m_urn + "/";
+
+    *out<<"<script type=\"text/javascript\">" <<std::endl
+        <<"store_actionURL(\""<<updateLink<<"\");"<<std::endl
+        <<"</script>"<<std::endl;
+    
+
+    
+}
+
+void gem::calib::CalibrationWeb::calibrationPage(xgi::Input* in, xgi::Output* out)
+{
+    CMSGEMOS_DEBUG("CalibrationWeb::calibrationPage");
+    *out << "<div class=\"xdaq-tab-wrapper\">" << std::endl;
+    *out << "    <div align=\"center\">" << std::endl;
+    *out << "        <form id=\"cal_select\">"<<std::endl;
+    *out << "            <div class=\"form-group row\">" << std::endl;
+    *out << "                <h2><span class=\"label label-info col-md-3\" id=\"cal_scurve\">Select calibration type:" << "</span></h2>" << std::endl;
+    *out << "                <div class=\"col-md-3\">" << std::endl;
+    *out << "                    <select class=\"form-control form-control-lg\" id=\"cal_type_select\" name=\"cal_type_select\" onChange=\"selectCalType()\">" << std::endl;
+    *out << "                        <option disabled selected value> -- select an option -- </option>" << std::endl;
+    *out << "                        <option>GBT Phase Scan</option>" << std::endl;
+    *out << "                        <option>Latency Scan</option>" << std::endl;
+    *out << "                        <option>S-curve Scan</option>" << std::endl;
+    *out << "                        <option>S-bit ARM DAC Scan</option>" << std::endl;
+    *out << "                        <option>ARM DAC Scan</option>" << std::endl;
+    *out << "                        <option>Derive DAC Trim Registers</option>" << std::endl;
+    *out << "                        <option>DAC Scan on VFAT3</option>" << std::endl;
+    *out << "                        <option>Calibrate CFG_THR_ARM_DAC</option>" << std::endl;
+    *out << "                        <option disabled value>Whatever else...</option>" << std::endl;
+    *out << "                    </select>" << std::endl;
+    *out << "                </div>" << std::endl; //<div class=\"col-md-6\">
+    *out << "            </div>" << std::endl; //<div class=\"form-group row\">
+    *out << "        </form>"<< std::endl;
+    *out << "    </div>" << std::endl;
+    *out << "</div>" << std::endl;
+
+    *out << "<div class=\"container col-md-12\" id=\"cal_interface\">" << std::endl;
+    *out << "</div>" << std::endl;
+    
+  
+} 
+
+void gem::calib::CalibrationWeb::applicationPage(xgi::Input* in, xgi::Output* out)
+{
+    CMSGEMOS_DEBUG("CalibrationWeb::applicationPage : Do nothing for the moment, will be eventually filled later");
+} ///CG : remove?
+
+
+void gem::calib::CalibrationWeb::genericRadioSelector( std::string paramName, gem::calib::Calibration::scanParamsRadioSelector radio_param  ,xgi::Output* out)
+{
+    
+    *out << "<h2><span class=\"label label-warning col-md-6\">"<< radio_param.label << "</span></h2>"<< std::endl;
+    *out << "<div class=\"col-md-6\">"<< std::endl;
+    *out << "    <div class=\"form-check\">" << std::endl;
+
+    for (unsigned int i=0; i< radio_param.options.size();++i) {
+        if (i==0) {
+            *out<<"<div class=\"form-check-input radio-inline\"> <label><input type=\"radio\" name=\""<<paramName<<"\" id=\""<<paramName<<"_radio_"<<i<<"\" value="<<i<<" checked>"<<radio_param.options[i]<<"</label></div>"<< std::endl;
+        } else {
+            *out<< "<div class=\"form-check-input radio-inline\"> <label><input type=\"radio\" name=\""<<paramName<<"\" id=\""<<paramName<<"_radio_"<<i<<"\" value="<<i<<">"<<radio_param.options[i]<<"</label></div>"<< std::endl;
+        }
+    }
+    *out << "    </div>"<< std::endl;
+    *out << "</div>" << std::endl;
+
+}
+
+void gem::calib::CalibrationWeb::genericParamSelector(std::string labelName, std::string paramName, std::string defaultValue, xgi::Output* out)
+{  
+    *out << "<h2><span class=\"label label-success col-md-6\">" << labelName << "</span></h2>"<< std::endl;
+    *out << "<div class=\"col-md-6\">"<< std::endl;
+    *out << "    <input type=\"text\" value=\"" << defaultValue << "\" class=\"form-control\" name=\"" << paramName << "\">"<< std::endl;
+    *out << "</div>" << std::endl;
+
+}
+
+void gem::calib::CalibrationWeb::genericParamSelector_dacScan( std::string paramName, int defaultValue, xgi::Output* out)
+{
+    std::string  labelName_tmp;
+    if (paramName.find("Max")!=std::string::npos) labelName_tmp="Max";
+    else if (paramName.find("Min")!=std::string::npos) labelName_tmp="Min";
+    else labelName_tmp=paramName;
+
+    *out << "<h4><span class=\"label label-success col-md-6\">" << labelName_tmp << "</span></h2>"<< std::endl;
+    *out << "<div class=\"col-md-6\">"<< std::endl;
+    *out << "    <input type=\"text\" value=\"" << defaultValue << "\" class=\"form-control\" name=\"" << paramName << "\">"<< std::endl;
+    *out << "</div>" << std::endl;
+        
+}
+
+void gem::calib::CalibrationWeb::slotsAndMasksSelector(xgi::Output* out,xdata::Integer m_nShelves)
+{
+    std::stringstream t_stream;
+    t_stream.clear();
+    t_stream.str(std::string());
+
+    *out << "<div class=\"panel panel-default\">" << std::endl;
+    *out << "    <div class=\"panel-heading\">" << std::endl;
+    *out << "        <div class=\"row\">" << std::endl;
+    *out << "            <div class=\"col-md-6\">" << std::endl;
+    *out << "            <h4>SHELF</h4>" << std::endl;
+    *out << "            </div>" << std::endl;
+    *out << "            <div class=\"col-md-6\">" << std::endl;
+    *out << "            <h4>AMC slot and OH mask</h4>" << std::endl;
+    *out << "            </div>" << std::endl;
+    *out << "        </div>"  << std::endl;
+    *out << "    </div>" << std::endl; // end panel heaing
+    // panel body
+    *out << "    <form id=\"slot_and_masks_select\">" << std::endl;
+    *out << "    <div class=\"container\" id=\"links_selection\">" << std::endl;
+    for ( int i = 0; i < m_nShelves; ++i) {
+        t_stream.clear();
+        t_stream.str(std::string());
+        t_stream << "shelf"<< std::setfill('0') << std::setw(2) << i+1;
+        *out << "        <div class=\"row\">" << std::endl;
+        *out << "            <div class=\"col-md-3\">" << std::endl;
+        *out << "                <div class=\"checkbox\">" << std::endl;
+        *out << "                <label> <input type=\"checkbox\" class=\"check\" name=\""<<  t_stream.str() << "\" id=\"" << t_stream.str() << "\">" << t_stream.str() << "</label>" << std::endl;
+        *out << "                </div>" << std::endl;
+        *out << "            </div>" << std::endl;
+        *out << "            <div class=\"col-md-9\">" << std::endl;
+        *out << "                <div class=\"dropdown\">" << std::endl;
+        *out << "                    <button id=\"amc_dropdown_button\" class=\"btn btn-lg btn-outline dropdown-toggle\" data-toggle=\"dropdown\">Select AMC and OH</button>" << std::endl;
+        *out << "                    <div class=\"dropdown-menu pre-scrollable\">" << std::endl;///qui
+        for (unsigned int j = 0; j < gem::base::GEMApplication::MAX_AMCS_PER_CRATE ; ++j) { //SHELF.AMC
+            t_stream.clear();
+            t_stream.str(std::string());
+            t_stream << "shelf"<< std::setfill('0') << std::setw(2) << i+1 << ".amc" << std::setfill('0') << std::setw(2) << j+1;
+            *out << "                        <span class =\"dropdown-item-text\">" << std::endl;
+            *out << "                            <div class=\"row\">" << std::endl;
+            *out << "                                <div class=\"col-md-3\">" << std::endl;
+            *out << "                                    <div class=\"checkbox\"><label><input type=\"checkbox\" class=\"check\" name=\""<< t_stream.str() << "\" id=\"" << t_stream.str() << "\">  AMC" << std::setfill('0') << std::setw(2) << j+1<< " </label> </div>" << std::endl;
+            *out << "                                </div>" << std::endl;
+            *out << "                                <div class=\"col-md-1\">" << std::endl;
+            *out << "                                </div>" << std::endl;
+            *out << "                                <div class=\"col-md-8\">" << std::endl;
+            t_stream << ".ohMask";
+            *out << "                                <input type=\"text\" value=\"0x000\" size=\"4\" name=\"" << t_stream.str() << "\" id =\"" << t_stream.str() << "\">OH mask </input>" << std::endl;
+            *out << "                                </div>" << std::endl;
+            *out << "                            </div>" << std::endl;
+            *out << "                        </span>" << std::endl;
+        } // end loop over NAMC
+        *out << "                    </div>" << std::endl;
+        *out << "                </div>" << std::endl; // end <div class="dropdown">
+        *out << "            </div>" << std::endl; // end <div class="col">
+        *out << "        </div>" << std::endl; // end <div class="row">
+    } // end loop over NSHELF
+    *out << "    </div>" << std::endl; // end container
+    *out << "    </form>"<< std::endl;
+    *out << "    <div align=\"center\">"<< std::endl;
+    *out << "        <button class=\"btn btn-lg btn-info\" onclick=\"select_links()\">SELECT ALL</button>" << std::endl;
+    *out << "        <button class=\"btn btn-lg btn-warning\" onclick=\"deselect_links()\">DESELECT ALL</button>" << std::endl;
+    *out << "    </div>"<< std::endl;
+    *out << "</div>" << std::endl; // end panel
+
+}
+
+void gem::calib::CalibrationWeb::dacScanV3Selector(xgi::Output* out)
+{
+    std::stringstream t_stream;
+
+    *out << "<div class=\"panel panel-default\">" << std::endl;
+    *out << "    <div class=\"panel-heading\">" << std::endl;
+    *out << "        <div class=\"row\">" << std::endl;
+    *out << "            <div class=\"col-md-12\">" << std::endl;
+    *out << "            <h4>DAC scan type</h4>" << std::endl;
+    *out << "            </div>" << std::endl;
+    *out << "        </div>"  << std::endl;
+    *out << "    </div>" << std::endl; // end panel heaing
+    // panel body
+    *out << "    <form id=\"dacScanV3_select\">" << std::endl;
+    *out << "        <div class=\"container\" id=\"dacScanV3_selection\">" << std::endl;
+    *out << "            <div class=\"dropdown\">" << std::endl;
+    *out << "                <button id=\"dacScan_dropdown_button\" class=\"btn btn-lg btn-outline dropdown-toggle\" data-toggle=\"dropdown\">Settings</button>" << std::endl;
+    *out << "                <div class=\"dropdown-menu pre-scrollable\">" << std::endl;
+    
+    for (auto & it : dynamic_cast<gem::calib::Calibration*>(p_gemApp)->m_dacScanTypeParams) {
+        t_stream.clear();
+        t_stream.str(std::string());
+        t_stream << it.second.label ;
+
+        *out << "                    <div class=\"row\">" << std::endl;
+        *out << "                        <div class=\"col-md-4\">"   << std::endl;
+        *out << "                            <div class=\"checkbox\">" << std::endl;
+        *out << "                                <label> <input type=\"checkbox\" class=\"check\" name=\""<<  t_stream.str() << "\" id=\"" << t_stream.str() << "\">" << t_stream.str() << "</label>"<< std::endl;
+        *out << "                            </div>" << std::endl;
+        *out << "                        </div>"<< std::endl;//end column
+       
+        *out << "                        <div class=\"col-md-4\">" <<std::endl;
+        this->genericParamSelector_dacScan(  it.second.label+"_Min", it.second.min, out);
+        *out << "                        </div>"<< std::endl;//end column
+        *out << "                        <div class=\"col-md-4\">" <<std::endl;
+        this->genericParamSelector_dacScan(  it.second.label+"_Max", it.second.max, out);
+        *out << "                        </div>"<< std::endl;//end column
+        *out << "                    </div>" << std::endl; // end <div class="row">
+    } // end loop over DAC scan type
+    *out << "                </div>" << std::endl; // end drop-down scrollable
+    *out << "            </div>" << std::endl; // end drop-down
+    *out << "        </div>" << std::endl; // end container
+    *out << "    </form>"<< std::endl;
+    *out << "    <div align=\"center\">"<< std::endl;
+    *out << "        <button class=\"btn btn-lg btn-info\" onclick=\"default_dacscans()\">SELECT DEFAULT</button>" << std::endl;
+    *out << "        <button class=\"btn btn-lg btn-info\" onclick=\"select_dacscans()\">SELECT ALL</button>" << std::endl;
+    *out << "        <button class=\"btn btn-lg btn-warning\" onclick=\"deselect_dacscans()\">DESELECT ALL</button>" << std::endl;
+    *out << "    </div>"<< std::endl;
+    *out << "</div>" << std::endl; // end panel
+}
+
+
+void gem::calib::CalibrationWeb::settingsInterface(calType_t m_calType, xgi::Output* out, xdata::Integer m_nShelves)
+{
+  
+    *out << "<div id=\"cal_interface\">" << std::endl;
+    *out << "    <div align=\"center\">" << std::endl;
+    *out << "        <div class=\"alert alert-warning\">" << std::endl;
+    *out << "            <button type=\"button\" class=\"close\" data-dismiss=\"alert\">&times;</button>" << alertMap.find(m_calType)->second << std::endl;
+    *out << "        </div>" << std::endl;
+    *out << "    </div>" << std::endl;
+    *out << "    <div class=\"row\">" << std::endl;
+    *out << "        <div class=\"col-md-6\">" << std::endl;
+    *out << "            <form id=\"settings_select\">" << std::endl;
+
+    // create a temporary parameters map,
+    // check whether requested calibration type needs a trigger selector
+    // if it is, create it and pop out the trigger setting
+    auto gemAppLocal = dynamic_cast<gem::calib::Calibration*>(p_gemApp);
+    std::map<std::string, std::string> t_parameters = gemAppLocal->m_scanParams.find(m_calType)->second; 
+
+    for (auto parameter: t_parameters) {
+        if (gemAppLocal->m_scanParamsNonForm.find(parameter.first) !=gemAppLocal->m_scanParamsNonForm.end()) {
+            this->genericRadioSelector( parameter.first, gemAppLocal->m_scanParamsRadioSelector.find(parameter.first)->second, out);
+            *out << "            <br>" << std::endl;
+            t_parameters.erase(parameter.first);
+        } else continue;
+
+    }
+    for (auto parameter: t_parameters) {
+        this->genericParamSelector(gemAppLocal->m_scanParamsLabels.find(parameter.first)->second, parameter.first, parameter.second, out);
+        *out << "            <br>" << std::endl;
+    }
+
+    *out << "            </form>" << std::endl;
+    *out << "            <br>" << std::endl;
+    if (m_calType == DACSCANV3) {
+        *out << "            <br>" << std::endl;
+        this->dacScanV3Selector(out);
+        *out << "            <br>" << std::endl;
+
+    }
+
+    *out << "        </div>" << std::endl; //end row
+    *out << "        <div class=\"col-md-6\">" << std::endl;
+    // *out << "            <br>" << std::endl;
+    // this->slotsAndMasksSelector(out, m_nShelves);
+    *out << "            <br><br><br>" << std::endl;
+    *out << "            <br><br><br>" << std::endl; //CG added  
+    *out << "            <div align=\"center\">" << std::endl;
+    *out << "                <button class=\"btn btn-lg btn-info\" type=\"button\" onclick=\"apply_action()\" id=\"apply\" name=\"apply_all\">APPLY SETTINGS</button>"<< std::endl;
+    // *out << "                <button class=\"btn btn-lg btn-success\" onclick=\"run_scan()\" id=\"run_button\" name=\"run_button\" disabled>RUN</button>"<< std::endl;
+    *out << "            </div>"<< std::endl;
+    *out << "        </div>" << std::endl;
+    *out << "    </div>" << std::endl;
+    *out << "</div>" << std::endl;
+
+}

--- a/gemcalibration/src/common/version.cc
+++ b/gemcalibration/src/common/version.cc
@@ -1,0 +1,30 @@
+#include "toolbox/version.h"
+#include "xdaq/version.h"
+#include "xoap/version.h"
+#include "gem/base/version.h"
+#include "gem/utils/version.h"
+#include "gem/calib/version.h"
+
+GETPACKAGEINFO(gemcalibration);
+
+
+void gemcalibration::checkPackageDependencies()
+{
+  CHECKDEPENDENCY(toolbox);
+  CHECKDEPENDENCY(xdaq);
+  CHECKDEPENDENCY(xoap);
+  CHECKDEPENDENCY(gem::base);
+  CHECKDEPENDENCY(gem::utils);
+ 
+}
+
+std::set<std::string, std::less<std::string> > gemcalibration::getPackageDependencies()
+{
+  std::set<std::string, std::less<std::string> > deps;
+  ADDDEPENDENCY(deps, toolbox);
+  ADDDEPENDENCY(deps, xoap);
+  ADDDEPENDENCY(deps, xdaq);
+  ADDDEPENDENCY(deps, gem::base);
+  ADDDEPENDENCY(deps, gem::utils);
+  return deps;
+}

--- a/gemhardware/devices/include/gem/hw/devices/GEMHwDevice.h
+++ b/gemhardware/devices/include/gem/hw/devices/GEMHwDevice.h
@@ -159,7 +159,7 @@ namespace gem {
        * @param index selects which of XX, YY, ZZ to return
        **/
       static uint8_t extractDeviceID(std::string const& deviceName, uint8_t const& index);
-
+      
     private:
       // Do Not use default constructor. GEMHwDevice object should only be made using
       // either connection file method or with a list of URIs and Address Tables

--- a/gemhardware/devices/include/gem/hw/devices/amc/HwGenericAMC.h
+++ b/gemhardware/devices/include/gem/hw/devices/amc/HwGenericAMC.h
@@ -424,6 +424,11 @@ namespace gem {
            */
           void setDAQLinkRunParameter(uint8_t const& parameter, uint8_t const& value);
 
+          /**
+           *@brief Set calibration data format on VFAT data
+           */
+          void configureAMCCalDataFormat(bool en);
+
 
           /**************************/
           /** TTC module information **/

--- a/gemhardware/devices/include/gem/hw/devices/optohybrid/HwOptoHybrid.h
+++ b/gemhardware/devices/include/gem/hw/devices/optohybrid/HwOptoHybrid.h
@@ -428,8 +428,8 @@ namespace gem {
            * @brief Returns the slot number and chip IDs for connected VFATs
            * @returns a std::vector of pairs of uint8_t and uint32_t words, one response for each VFAT
            */
-          std::vector<std::pair<uint8_t, uint32_t> > getConnectedVFATs(bool update=false);
-
+          
+          std::vector<std::pair<uint8_t, uint32_t> > getConnectedVFATs(bool update=false, uint32_t mask=0x0);
           /**
            * @brief Uses a broadcast read to determine which slots are occupied and returns the
            *        corresponding broadcast mask
@@ -462,6 +462,13 @@ namespace gem {
            */
 
           void configureGBT(uint8_t const& gbtID, const gbt::config_t& gbtcfg);
+          
+          /**
+           * @brief Sets the VFAT calibration format data control mask
+           * @param mask is the mask to apply
+           */
+          void configureOHCalDataFormat(uint32_t const mask);
+          
 
           /**
            * @brief Sends a write request for all configuration registers on all GBTx chips

--- a/gemhardware/devices/src/common/amc/HwGenericAMC.cc
+++ b/gemhardware/devices/src/common/amc/HwGenericAMC.cc
@@ -742,3 +742,9 @@ void gem::hw::amc::HwGenericAMC::linkReset(uint8_t const& gtx)
   CMSGEMOS_WARN("HwGenericAMC::linkReset: not yet implemented");
   return;
 }
+
+void gem::hw::amc::HwGenericAMC::configureAMCCalDataFormat(bool en)
+{   
+    writeReg("GAM_AMC.DAQ.CONTROL.CALIBRATION_MODE_EN", uint32_t(en));
+    return;
+}

--- a/gemhardware/managers/include/gem/hw/managers/amc/AMCManager.h
+++ b/gemhardware/managers/include/gem/hw/managers/amc/AMCManager.h
@@ -106,10 +106,14 @@ namespace gem {
           xdata::Boolean m_bc0LockPhaseShift;  ///< Use BC0 to find the best phase during the phase shifting procedure
           xdata::Boolean m_relockPhase;        ///< Relock the phase during phase shifting
 
-	  uint32_t m_lastLatency;         ///< Special variable for latency scan mode
+          uint32_t m_lastLatency;         ///< Special variable for latency scan mode
           uint32_t m_lastVT1, m_lastVT2;  ///< Special variable for threshold scan mode 
-        };  // class AMCManager
 
+          xoap::MessageReference setRunParamInterCalib(xoap::MessageReference msg);
+          //xoap::MessageReference calibParamPrint(xoap::MessageReference msg);
+          xoap::MessageReference updateRunParamCalib(xoap::MessageReference msg);
+ 
+        };  // class AMCManager
     }  // namespace gem::hw::amc
   }  // namespace gem::hw
 }  // namespace gem

--- a/gemhardware/managers/include/gem/hw/managers/amc13/AMC13Manager.h
+++ b/gemhardware/managers/include/gem/hw/managers/amc13/AMC13Manager.h
@@ -78,7 +78,8 @@ namespace gem {
           xoap::MessageReference sendTriggerBurst(xoap::MessageReference mns);
           xoap::MessageReference enableTriggers(xoap::MessageReference mns);
           xoap::MessageReference disableTriggers(xoap::MessageReference mns);
-
+          xoap::MessageReference restartAMC13Counts(xoap::MessageReference mns);
+        
 	  void endScanPoint();
 
 	  virtual void timeExpired(toolbox::task::TimerEvent& event);
@@ -237,8 +238,8 @@ namespace gem {
 
           xdata::Bag<AMC13Info>               m_amc13Params;
           xdata::Vector<xdata::Bag<BGOInfo> > m_bgoConfig;
-	  xdata::Bag<L1AInfo>                 m_localTriggerConfig;
-	  xdata::Bag<TTCInfo>                 m_amc13TTCConfig;
+          xdata::Bag<L1AInfo>                 m_localTriggerConfig;
+          xdata::Bag<TTCInfo>                 m_amc13TTCConfig;
 
 
           //seems that we've duplicated the members of the m_amc13Params as class variables themselves
@@ -251,14 +252,15 @@ namespace gem {
 	    m_bgoRepeat, m_bgoIsLong, m_enableLEMO;
           int m_localTriggerMode, m_localTriggerPeriod, m_localTriggerRate, m_L1Amode, m_L1Arules;
           int m_prescaleFactor, m_bcOffset, m_bgoChannel;
-	  uint8_t m_bgoCMD;
-	  uint16_t m_bgoBX, m_bgoPrescale;
+          uint8_t m_bgoCMD;
+          uint16_t m_bgoBX, m_bgoPrescale;
           uint32_t m_ignoreAMCTTS, m_fedID, m_sfpMask, m_slotMask,
             m_internalPeriodicPeriod, m_L1Aburst;
           //uint64_t m_localL1AMask;
-	  uint64_t m_updatedL1ACount;
+          uint64_t m_updatedL1ACount;
           ////counters
-
+          uint32_t m_scanParameter;
+          
         protected:
 
         };  // class AMC13Manager

--- a/gemhardware/managers/include/gem/hw/managers/optohybrid/OptoHybridManager.h
+++ b/gemhardware/managers/include/gem/hw/managers/optohybrid/OptoHybridManager.h
@@ -54,6 +54,8 @@ namespace gem {
 
           virtual void resetAction(toolbox::Event::Reference e) override;
 
+          xoap::MessageReference updateScanValueCalib(xoap::MessageReference msg);
+ 
         protected:
           class OptoHybridInfo
           {
@@ -111,7 +113,7 @@ namespace gem {
           HWMapMatrix<std::vector<std::pair<uint8_t, uint32_t> >, MAX_OPTOHYBRIDS_PER_AMC, MAX_AMCS_PER_CRATE>
             m_vfatMapping;  ///< VFAT mapping
 
-	  uint32_t m_lastLatency;         ///< Special variable for latency scan mode
+          uint32_t m_lastLatency;         ///< Special variable for latency scan mode
           uint32_t m_lastVT1, m_lastVT2;  ///< Special variable for threshold scan mode
 
           std::map<int,std::set<int> > m_hwMapping;        ///< FIXME UNUSED

--- a/gemhardware/managers/src/common/optohybrid/OptoHybridManager.cc
+++ b/gemhardware/managers/src/common/optohybrid/OptoHybridManager.cc
@@ -59,7 +59,7 @@ gem::hw::optohybrid::OptoHybridManager::OptoHybridManager(xdaq::ApplicationStub*
   CMSGEMOS_DEBUG("OptoHybridManager::Connecting to the OptoHybridManagerWeb interface");
   p_gemWebInterface = new gem::hw::optohybrid::OptoHybridManagerWeb(this);
   CMSGEMOS_DEBUG("OptoHybridManager::done");
-
+  xoap::bind(this, &gem::hw::optohybrid::OptoHybridManager::updateScanValueCalib, "updateScanValueCalib",  XDAQ_NS_URI);
   // set up the info hwCfgInfoSpace
   init();
 
@@ -177,8 +177,64 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
       auto&& optohybrid = m_optohybrids.at(slot).at(link);
 
       if (optohybrid->isHwConnected()) {
+
         CMSGEMOS_INFO("OptoHybridManager::configureAction:: configuring VFATs");
         optohybrid->configureVFATs();
+
+        uint32_t vfatMask = m_broadcastList.at(slot).at(link);
+        
+        
+        if (m_scanInfo.bag.scanType.value_ == 2) {
+            //TODO:set calibration mode (atm set to false)
+            if (m_scanInfo.bag.calMode.value_)
+                optohybrid->configureOHCalDataFormat(vfatMask);
+            
+            CMSGEMOS_DEBUG("OptoHybridManager::configureAction configureAction: Latency scan with value " << m_scanInfo.bag.scanMin.value_);
+            optohybrid->broadcastWrite("CFG_LATENCY", m_scanInfo.bag.scanMin.value_,vfatMask, false);
+            optohybrid->broadcastWrite("CFG_PULSE_STRETCH", m_scanInfo.bag.mspl.value_,vfatMask, false);
+            
+            if(  m_scanInfo.bag.signalSourceType.value_<1) {//CG: Cal pulse
+                optohybrid->broadcastWrite("CFG_CAL_MODE", 0x1 ,vfatMask, false);
+            }///for latency scans use the Voltage pulse(CAL_MODE 0x1), low CFG_CAL_DAC is a high injected charge amount  
+            optohybrid->broadcastWrite("CFG_CAL_DAC", 6, vfatMask, false);
+            CMSGEMOS_DEBUG("OptoHybridManager::configureAction: reading  specifics for latency on OH0VFAT23 MPSL " <<  m_scanInfo.bag.mspl.value_ << " reg " << optohybrid->readReg("GEM_AMC.OH.OH0.GEB.VFAT23.CFG_PULSE_STRETCH") << " CAL_DAC " <<  (uint32_t) optohybrid->readReg("GEM_AMC.OH.OH0.GEB.VFAT23.CFG_CAL_DAC"));
+        
+          // enabling and disabling calpulse for channels on vfat 
+          for (int ch=0; ch< 128 ; ++ch){
+              char reg [100] ;
+              if (ch < m_scanInfo.bag.vfatChMin.value_ || ch >  m_scanInfo.bag.vfatChMax.value_) { 
+                  sprintf(reg, "VFAT_CHANNELS.CHANNEL%i.CALPULSE_ENABLE", ch);
+                  optohybrid->broadcastWrite(reg, 0, vfatMask, false);
+              } else {
+                  sprintf(reg, "VFAT_CHANNELS.CHANNEL%i.CALPULSE_ENABLE", ch);
+                  optohybrid->broadcastWrite(reg, 1, vfatMask, false);
+              }
+          }
+          
+          CMSGEMOS_INFO("OptoHybridManager::configureAction: ending  specifics for latency ");   
+
+    
+        } else if (m_scanInfo.bag.scanType.value_ == 3) { //S-curve
+            // FIXME OBSOLETE
+
+            optohybrid->broadcastWrite("CFG_LATENCY", m_scanInfo.bag.latency.value_, vfatMask, false);  
+            optohybrid->broadcastWrite("CFG_PULSE_STRETCH", m_scanInfo.bag.mspl.value_, vfatMask, false);
+            optohybrid->broadcastWrite("CFG_CAL_PHI", m_scanInfo.bag.pulseDelay.value_, vfatMask, false);
+            ///for Scurve scans use Current pulse, high CFG_CAL_DAC is a high injected charge amount
+            int caldac = 250;
+            optohybrid->broadcastWrite("CFG_CAL_DAC", caldac, vfatMask, false);
+
+            uint32_t initialVT1 =  m_scanInfo.bag.scanMin.value_; //m_scanMin.value_;
+         
+            uint32_t initialVT2 = 0; //std::max(0,(uint32_t)m_scanMax.value_);
+
+            
+        } else {
+          // FIXME:should configure VFATbefore and not here.
+            CMSGEMOS_INFO("OptoHybridManager::configureAction configureVFATs()");
+            optohybrid->configureVFATs(); ///CG;
+        }
+
         // what else is required for configuring the OptoHybrid?
         // need to reset optical links?
         // reset counters?
@@ -197,6 +253,15 @@ void gem::hw::optohybrid::OptoHybridManager::configureAction()
 
 void gem::hw::optohybrid::OptoHybridManager::startAction()
 {
+    
+  if (m_scanType.value_ == 2) {
+    m_lastLatency = m_scanInfo.bag.scanMin.value_;
+    m_lastVT1 = 0;
+  } else if (m_scanType.value_ == 3) {
+    m_lastLatency = 0;
+    m_lastVT1 = m_scanInfo.bag.scanMin.value_ ;
+  }
+
   CMSGEMOS_DEBUG("OptoHybridManager::startAction");
   // will the manager operate for all connected optohybrids, or only those connected to certain AMCs?
   // FIXME make me more streamlined
@@ -230,9 +295,83 @@ void gem::hw::optohybrid::OptoHybridManager::startAction()
   CMSGEMOS_INFO("OptoHybridManager::startAction end");
 }
 
+xoap::MessageReference gem::hw::optohybrid::OptoHybridManager::updateScanValueCalib(xoap::MessageReference msg){
+    std::string commandName = "updateScanValueCalib";
+    CMSGEMOS_DEBUG("OptohybridManager::updateScanValueCalib");
+    try {
+        CMSGEMOS_INFO("Optohybrid::updateScanValueCalib trying");
+        for (size_t slot = 0; slot < MAX_AMCS_PER_CRATE; ++slot) {
+
+            for (size_t link = 0; link < MAX_OPTOHYBRIDS_PER_AMC; ++link) {
+                size_t index = (slot*MAX_OPTOHYBRIDS_PER_AMC)+link;
+                
+                OptoHybridInfo& info = m_optohybridInfo[index].bag;
+
+                if (!info.present)
+                    continue;
+                
+                auto&& optohybrid = m_optohybrids.at(slot).at(link);
+
+                if (optohybrid->isHwConnected()) {
+                    // turn on all VFATs? or should they always be on?
+                    uint32_t vfatMask = m_broadcastList.at(slot).at(link);
+                    if (m_scanInfo.bag.scanType.value_ == 2) { 
+                        uint32_t updatedLatency = m_lastLatency + m_stepSize.value_;
+                        CMSGEMOS_DEBUG("OptoHybridManager::updateScanValueCalib LatencyScan OptoHybrid on link " << static_cast<uint32_t>(link)
+                                      << " AMC slot " << (slot+1) << " Latency  " << static_cast<uint32_t>(updatedLatency));
+                        
+                        optohybrid->broadcastWrite("CFG_LATENCY", updatedLatency, vfatMask);
+                    } else if (m_scanInfo.bag.scanType.value_ == 3) { // FIXME OBSOLETE
+                        uint8_t updatedVT1 = m_lastVT1 + m_scanInfo.bag.stepSize.value_;
+                        uint8_t VT2 = 0;  // std::max(0,static_cast<uint32_t>(m_scanMax.value_));
+                        CMSGEMOS_INFO("OptoHybridManager::ThresholdScan OptoHybrid on link " << static_cast<uint32_t>(link)
+                                      << " AMC slot " << (slot+1) << " VT1 " << static_cast<uint32_t>(updatedVT1)
+                                      << " VT2 " << VT2 << " StepSize " << m_scanInfo.bag.stepSize.value_);
+
+                        // optohybrid->broadcastWrite("CFG_THR_ARM_DAC", updatedVT1, vfatMask);
+                        // optohybrid->broadcastWrite("CFG_THR_ZCC_DAC", VT2, vfatMask);
+                    }
+                    // what resets to do
+                } else {
+                    std::stringstream errmsg;
+                    errmsg << "OptoHybridManager::updateScanValueCalib OptoHybrid connected on link " << static_cast<uint32_t>(link)
+                           << " to AMC in slot " << static_cast<uint32_t>(slot+1) << " is not responding";
+                    CMSGEMOS_ERROR(errmsg.str());
+                    // fireEvent("Fail");
+                    XCEPT_RAISE(gem::hw::managers::optohybrid::exception::Exception, errmsg.str());
+                }
+            }
+        }
+        // Update the scan parameters
+        if (m_scanInfo.bag.scanType.value_ == 2) {
+            CMSGEMOS_INFO("OptoHybridManager::pauseAction LatencyScan old Latency " << static_cast<uint32_t>(m_lastLatency));
+            m_lastLatency += m_scanInfo.bag.stepSize.value_;
+            CMSGEMOS_INFO("OptoHybridManager::pauseAction LatencyScan new Latency " << static_cast<uint32_t>(m_lastLatency));
+        } else if (m_scanInfo.bag.scanType.value_ == 3) {
+            CMSGEMOS_INFO("OptoHybridManager::pauseAction ThresholdScan old VT1 " << static_cast<uint32_t>(m_lastVT1));
+            m_lastVT1 += m_scanInfo.bag.stepSize.value_;
+            CMSGEMOS_INFO("OptoHybridManager::pauseAction ThresholdScan new VT1 " << static_cast<uint32_t>(m_lastVT1));
+        }
+        CMSGEMOS_INFO("OptoHybridManager::updateScanValueCalib end");
+        
+        return
+            gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "Done");
+        
+    } catch(xcept::Exception& err) {
+        std::string msgBase = toolbox::toString("Failed to create SOAP reply for command '%s'",
+                                                commandName.c_str());
+        CMSGEMOS_ERROR(toolbox::toString("%s: %s.", msgBase.c_str(), xcept::stdformat_exception_history(err).c_str()));
+    }
+    return
+        gem::utils::soap::GEMSOAPToolBox::makeSOAPReply(commandName, "NotDone");
+    
+}
+    
 void gem::hw::optohybrid::OptoHybridManager::pauseAction()
 {
-  // FIXME put all connected VFATs into run mode?
+
+  // FIXME put all connected VFATs into run/pause  mode?
+
   CMSGEMOS_INFO("OptoHybridManager::pauseAction end");
 }
 
@@ -264,6 +403,7 @@ void gem::hw::optohybrid::OptoHybridManager::stopAction()
         uint32_t vfatMask = m_broadcastList.at(slot).at(link);
         optohybrid->broadcastWrite("CFG_RUN", 0x0, vfatMask);
         // FIXME what resets to do
+
       }
     }
   }
@@ -339,7 +479,7 @@ void gem::hw::optohybrid::OptoHybridManager::createOptoHybridInfoSpaceItems(is_t
   // probably want this to be a set of 8?
   // is_optohybrid->createUInt32("HDMI SBitsOut", optohybrid->getHDMISBitSource(),  NULL, GEMUpdateType::HW32);
   // is_optohybrid->createUInt32("HDMI SBitMode", optohybrid->getHDMISBitMode(),    NULL, GEMUpdateType::HW32);
-  is_optohybrid->createUInt32("CLK_STATUS",       optohybrid->getClockStatus(),  NULL, GEMUpdateType::HW32);
+  is_optohybrid->createUInt32("CLK_STATUS",       optohybrid->getClockStatus(),  NULL, GEMUpdateType::HW32); //CG FIXME supposed to work on xdaq15 and coffin but FW not wired up correctly, register not set.
 
   is_optohybrid->createUInt32("FIRMWARE_DATE", optohybrid->getFirmwareDate(),
                               NULL, GEMUpdateType::PROCESS, "docstring", "fwdateoh");

--- a/gemsupervisor/include/gem/supervisor/GEMSupervisor.h
+++ b/gemsupervisor/include/gem/supervisor/GEMSupervisor.h
@@ -59,7 +59,7 @@ namespace gem {
 
         virtual void resetAction(toolbox::Event::Reference e);
 
-	xoap::MessageReference EndScanPoint(xoap::MessageReference mns);
+        xoap::MessageReference EndScanPointCalib(xoap::MessageReference mns);
 
         std::vector<xdaq::ApplicationDescriptor*> getSupervisedAppDescriptors() {
           return v_supervisedApps; };

--- a/gemsupervisor/xml/gemsupervisor.xml
+++ b/gemsupervisor/xml/gemsupervisor.xml
@@ -3,50 +3,41 @@
 	      xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
 	      xmlns:xc="http://xdaq.web.cern.ch/xdaq/xsd/2004/XMLConfiguration-30">
 
-  <xc:Context url="http://gem904daq04:25050">
-    <xc:Application class="gem::hw::glib::GLIBManager" id="30" instance="0" network="local">
-      <properties xmlns="urn:xdaq-application:gem::hw::glib::GLIBManager"
+  <xc:Context url="http://gem904daq04:20516">
+    <xc:Application class="gem::hw::amc::AMCManager" id="30" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:gem::hw::amc::AMCManager"
 		  xsi:type="soapenc:Struct">
 	<DisableMonitoring xsi:type="xsd:boolean">true</DisableMonitoring>
 	<AMCSlots       xsi:type="xsd:string">2</AMCSlots>
 	<ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
-	<AllGLIBsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]">
-          <GLIBInfo   xsi:type="soapenc:Struct" soapenc:position="1"> <!--  position must be slot-1  -->
+	<AllAMCsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[12]">
+          <AMCInfo   xsi:type="soapenc:Struct" soapenc:position="1"> <!--  position must be slot-1  -->
             <crateID  xsi:type="xsd:integer">1</crateID>
             <slot     xsi:type="xsd:integer">2</slot>
             <present  xsi:type="xsd:boolean">true</present>
             <sbitSource    xsi:type="xsd:integer">5</sbitSource>
-          </GLIBInfo>
-	</AllGLIBsInfo>
+            <enableZS  xsi:type="xsd:boolean">false</enableZS>
+          </AMCInfo>
+	</AllAMCsInfo>
       </properties>
     </xc:Application>
 
-    <xc:Application class="gem::hw::optohybrid::OptoHybridManager" id="50" instance="0" network="local">
-      <properties xmlns="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager"
-		  xsi:type="soapenc:Struct">
-	<ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
-	<AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[144]"><!-- MAX_OH_PER_AMC(12) * MAX_AMC_PER_UTCA(12)-->
-          <OptoHybridInfo   xsi:type="soapenc:Struct" soapenc:position="21"> <!-- position must be (slot-1)*MAX_OH_PER_AMC(12)+link -->
-            <present xsi:type="xsd:boolean">true</present>
-            <crateID xsi:type="xsd:integer">1</crateID>
-            <slot    xsi:type="xsd:integer">2</slot>
-            <link    xsi:type="xsd:integer">9</link>
-          </OptoHybridInfo>
-
-	</AllOptoHybridsInfo>
-      </properties>
-    </xc:Application>
+   
 
     <xc:Application class="gem::hw::amc13::AMC13Manager" id="255" instance="3" network="local">
       <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Manager"
         	  xsi:type="soapenc:Struct">
         <amc13ConfigParams xsi:type="soapenc:Struct">
           <ConnectionFile     xsi:type="xsd:string">connections.xml</ConnectionFile>
-	  <CardName           xsi:type="xsd:string">gem.shelf01.amc13</CardName>
+	      <CardName           xsi:type="xsd:string">gem.shelf01.amc13</CardName>
+          <!--<AMCInputEnableList xsi:type="xsd:string">2</AMCInputEnableList>-->
           <AMCInputEnableList xsi:type="xsd:string">2</AMCInputEnableList>
           <AMCIgnoreTTSList   xsi:type="xsd:string">1,3-12</AMCIgnoreTTSList>
 
-          <EnableDAQLink       xsi:type="xsd:boolean">true</EnableDAQLink>
+          <!--<EnableDAQLink       xsi:type="xsd:boolean">true</EnableDAQLink>
+          <EnableFakeData      xsi:type="xsd:boolean">false</EnableFakeData>
+          <MonitorBackPressure xsi:type="xsd:boolean">false</MonitorBackPressure>-->
+          <EnableDAQLink       xsi:type="xsd:boolean">false</EnableDAQLink>
           <EnableFakeData      xsi:type="xsd:boolean">false</EnableFakeData>
           <MonitorBackPressure xsi:type="xsd:boolean">false</MonitorBackPressure>
           <EnableLocalTTC      xsi:type="xsd:boolean">true</EnableLocalTTC>
@@ -56,8 +47,8 @@
 	  <!-- LEMO TRIGGERS  = enableLocalL1A = true, LEMO true, EnableLocalTTC true -->
 	  <!-- EXTERNAL TRIGGERS (TTC) = enableLocalL1A = false, LEMO false, EnableLocalTTC false -->
 
-          <LocalTriggerConfig xsi:type="soapenc:Struct">
-            <EnableLocalL1A         xsi:type="xsd:boolean">false</EnableLocalL1A>
+      <!--<LocalTriggerConfig xsi:type="soapenc:Struct">
+        <EnableLocalL1A         xsi:type="xsd:boolean">false</EnableLocalL1A>
 	    <EnableLEMO             xsi:type="xsd:boolean">false</EnableLEMO>
 
             <InternalPeriodicPeriod xsi:type="xsd:unsignedInt">1500</InternalPeriodicPeriod>
@@ -66,7 +57,24 @@
             <L1Arules               xsi:type="xsd:integer">0</L1Arules>
 	    <sendL1ATriburst        xsi:type="xsd:boolean">false</sendL1ATriburst>
 	    <startL1ATricont        xsi:type="xsd:boolean">false</startL1ATricont>
-          </LocalTriggerConfig>
+        </LocalTriggerConfig>-->
+      <LocalTriggerConfig xsi:type="soapenc:Struct">
+             <EnableLocalL1A         xsi:type="xsd:boolean">true</EnableLocalL1A>
+             <EnableLEMO             xsi:type="xsd:boolean">false</EnableLEMO>
+             <!--<StartL1AGen            xsi:type="xsd:boolean">false</StartL1AGen>-->
+
+             <!--  L1Amode: Select the mode of the local trigger generator
+                  0 - per N orbit (N specified by period), always at BX 500
+                  1 - per N BX (N specified by period)
+                  2 - random (rate specified by period, in 2Hz units)
+                  InternalPeriodicPeriod: frequency of trigger  -->
+             <InternalPeriodicPeriod xsi:type="xsd:unsignedInt">100</InternalPeriodicPeriod>
+             <L1Aburst               xsi:type="xsd:unsignedInt">1</L1Aburst>
+             <L1Amode                xsi:type="xsd:integer">0</L1Amode>
+             <L1Arules               xsi:type="xsd:integer">0</L1Arules>
+             <sendL1ATriburst        xsi:type="xsd:boolean">false</sendL1ATriburst>
+             <startL1ATricont        xsi:type="xsd:boolean">false</startL1ATricont>
+           </LocalTriggerConfig>
 
           <AMC13TTCConfig xsi:type="soapenc:Struct">
             <RESYNC_CMD  xsi:type="xsd:unsignedInt">0x04</RESYNC_CMD>
@@ -76,15 +84,15 @@
           </AMC13TTCConfig>
 
           <BGOConfig xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[4]">
-            <!--
-                <BGOInfo xsi:type="soapenc:Struct" soapenc:position="0">
+            
+            <BGOInfo xsi:type="soapenc:Struct" soapenc:position="0">
 	        <BGOChannel  xsi:type="xsd:integer">0</BGOChannel>
 	        <BGOcmd      xsi:type="xsd:unsignedInt">0x14</BGOcmd>
-	        <BGObx       xsi:type="xsd:unsignedInt">0x1</BGObx>
+	        <BGObx       xsi:type="xsd:unsignedInt">450</BGObx><!--450default should be 50 after the bx of L1A, that forL1Amode=1 happens at 500-->  <!--0x1-->
 	        <BGOprescale xsi:type="xsd:unsignedInt">0x1</BGOprescale>
 	        <BGOrepeat   xsi:type="xsd:boolean">true</BGOrepeat>
-                </BGOInfo>
-            -->
+        </BGOInfo>
+          
           </BGOConfig>
           <PrescaleFactor xsi:type="xsd:integer">1</PrescaleFactor>
           <BCOffset       xsi:type="xsd:integer">1</BCOffset>
@@ -95,13 +103,14 @@
         </amc13ConfigParams>
       </properties>
     </xc:Application>
-
+    
     <xc:Application class="gem::hw::amc13::AMC13Readout" id="260" instance="0" network="local">
       <properties xmlns="urn:xdaq-application:gem::hw::amc13::AMC13Readout"
-		  xsi:type="soapenc:Struct">
-        <ConnectionFile  xsi:type="xsd:string">connections.xml</ConnectionFile>
+	  xsi:type="soapenc:Struct">
+        <ConnectionFile     xsi:type="xsd:string">connections.xml</ConnectionFile>
+        <CardName           xsi:type="xsd:string">gem.shelf01.amc13</CardName>
+        
         <DeviceName      xsi:type="xsd:string">AMC13</DeviceName>
-        <CardName        xsi:type="xsd:string">gem.shelf01.amc13</CardName>
         <crateID         xsi:type="xsd:integer">1</crateID>
         <slot            xsi:type="xsd:integer">13</slot>
         <ReadoutSettings xsi:type="soapenc:Struct">
@@ -113,8 +122,8 @@
         </ReadoutSettings>
       </properties>
     </xc:Application>
-
-    <xc:Application class="gem::supervisor::GEMSupervisor" id="254" instance="0" network="local">
+   
+    <xc:Application class="gem::supervisor::GEMSupervisor" id="16" instance="0" network="local">
       <properties xmlns="urn:xdaq-application:GEMSupervisor"
 		  xsi:type="soapenc:Struct">
         <HandleTCDS        xsi:type="xsd:boolean">false</HandleTCDS>
@@ -127,7 +136,7 @@
           <ScanMax    xsi:type="xsd:unsignedInt">101</ScanMax>
           <StepSize   xsi:type="xsd:unsignedInt">1</StepSize>
           <NTriggers  xsi:type="xsd:unsignedLong">10000</NTriggers>
-        </ScanInfo>
+        </ScanInfo>-->
 
         <TCDSConfig xsi:type="soapenc:Struct">
           <HandleTCDS         xsi:type="xsd:boolean">false</HandleTCDS>
@@ -138,35 +147,54 @@
           <CPMHardwareConfig  xsi:type="xsd:string">${HOME}/config/tcds/CPM.txt</CPMHardwareConfig>
         </TCDSConfig>
 
-	<rcmsStateListener xsi:type="soapenc:Struct">
-          <classname xsi:type="xsd:string">RCMSStateListener</classname>
-          <instance  xsi:type="xsd:unsignedInt">0</instance>
-        </rcmsStateListener>
+
       </properties>
     </xc:Application>
+   
+    <xc:Application class="gem::calib::Calibration" id="17" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:gem::calib::Calibration"
+                   xsi:type="soapenc:Struct">
+         <nShelves  xsi:type="xsd:integer">2</nShelves>
+       </properties>
+    </xc:Application> 
 
+
+
+ <xc:Application class="gem::hw::optohybrid::OptoHybridManager" id="50" instance="0" network="local">
+      <properties xmlns="urn:xdaq-application:gem::hw::optohybrid::OptoHybridManager"
+        	  xsi:type="soapenc:Struct">
+        <!--AMCSlots       xsi:type="xsd:string">10</AMCSlots-->
+        <ConnectionFile xsi:type="xsd:string">connections.xml</ConnectionFile>
+        <AllOptoHybridsInfo xsi:type="soapenc:Array"  soapenc:arrayType="xsd:ur-type[108]">
+          <OptoHybridInfo   xsi:type="soapenc:Struct" soapenc:position="12"> <!-- position must be (slot-1)*12+link -->
+            <crateID xsi:type="xsd:integer">1</crateID>
+            <slot    xsi:type="xsd:integer">2</slot>
+            <link    xsi:type="xsd:integer">0</link>
+            <present xsi:type="xsd:boolean">true</present>
+           <!-- <CardName xsi:type="xsd:string">gem.shelf01.ctp7-02.optohybrid00</CardName>-->
+
+            <!--<triggerSource xsi:type="xsd:integer">0</triggerSource>-->
+            <!--<sbitSource    xsi:type="xsd:integer">5</sbitSource>-->
+          </OptoHybridInfo>
+        </AllOptoHybridsInfo>
+      </properties>
+ </xc:Application>
+
+
+    
+    
     <xc:Module>${XDAQ_ROOT}/lib/libxdaq2rc.so</xc:Module>
 
-    <xc:Module>${BUILD_HOME}/${GEM_OS_PROJECT}/gemutils/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemutils.so</xc:Module>
-    <xc:Module>${BUILD_HOME}/${GEM_OS_PROJECT}/gembase/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgembase.so</xc:Module>
-    <xc:Module>${BUILD_HOME}/${GEM_OS_PROJECT}/gemsupervisor/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemsupervisor.so</xc:Module>
-    <xc:Module>${BUILD_HOME}/${GEM_OS_PROJECT}/gemreadout/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemreadout.so</xc:Module>
-    <xc:Module>${BUILD_HOME}/${GEM_OS_PROJECT}/gemhardware/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemhardware_devices.so</xc:Module>
-    <xc:Module>${BUILD_HOME}/${GEM_OS_PROJECT}/gemhardware/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemhardware_managers.so</xc:Module>
-
+    <xc:Module>${BUILD_HOME}/gemutils/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemutils.so</xc:Module>
+    <xc:Module>${BUILD_HOME}/gembase/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgembase.so</xc:Module>
+    <xc:Module>${BUILD_HOME}/gemsupervisor/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemsupervisor.so</xc:Module>
+    <xc:Module>${BUILD_HOME}/gemreadout/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemreadout.so</xc:Module>
+    <xc:Module>${BUILD_HOME}/gemhardware/devices/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemhwdevices.so</xc:Module>
+    <xc:Module>${BUILD_HOME}/gemhardware/utils/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemhwutils.so</xc:Module>
+    <xc:Module>${BUILD_HOME}/gemhardware/managers/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemhwmanagers.so</xc:Module>
+    <xc:Module>${BUILD_HOME}/gemcalibration/lib/${XDAQ_OS}/${XDAQ_PLATFORM}/libgemcalibration.so</xc:Module>
   </xc:Context>
 
-  <xc:Context url="http://gem904daq01:10000/rcms">
-    <xc:Application class="RCMSStateListener" id="50" instance="0" network="local" path="/services/replycommandreceiver" />
-    <xc:Module>${XDAQ_ROOT}/lib/libxdaq2rc.so</xc:Module>
-  </xc:Context>
-
-  <xc:Context url="http://localhost:2104">
-    <xc:Application class="tcds::ici::ICIController" id="301" instance="0" network="local" >
-    </xc:Application>
-
-    <xc:Application class="tcds::pi::PIController"   id="501" instance="0" network="local" >
-    </xc:Application>
-  </xc:Context>
+ 
 
 </xc:Partition>

--- a/gemutils/include/gem/utils/soap/GEMSOAPToolBox.h
+++ b/gemutils/include/gem/utils/soap/GEMSOAPToolBox.h
@@ -30,6 +30,21 @@
 #include <gem/utils/exception/Exception.h>
 #include <gem/utils/GEMLogging.h>
 
+#include "xdata/Bag.h"
+#include "xdata/Boolean.h"
+#include "xdata/Integer.h"
+#include "xdata/Integer32.h"
+#include "xdata/Integer64.h"
+#include "xdata/UnsignedShort.h"
+#include "xdata/UnsignedLong.h"
+#include "xdata/UnsignedInteger32.h"
+#include "xdata/UnsignedInteger64.h"
+#include "xdata/String.h"
+#include "xdata/Float.h"
+#include "xdata/Double.h"
+#include "xdata/Vector.h"
+#include "xdata/soap/Serializer.h"
+
 namespace gem {
   namespace utils {
     namespace soap {
@@ -249,6 +264,16 @@ namespace gem {
          */
         static std::string getXSDType(xdata::Serializable const& item);
 
+        
+        static int extractSOAPCommandParameterInteger(xoap::MessageReference const& msg,   std::string const& parameterName);
+        static std::string extractSOAPCommandParameterString(xoap::MessageReference const& msg, std::string const& parameterName);
+        static bool extractSOAPCommandParameterBoolean(xoap::MessageReference const& msg,   std::string const& parameterName);
+
+        
+         
+        static xoap::SOAPElement extractSOAPCommandParameterElement(xoap::MessageReference const& msg, std::string const& parameterName);
+
+        
         // methods copied from emu/soap/toolbox
         /*
           xoap::MessageReference createMessage( const gem::utils::soap::QualifiedName &command,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR include the preliminary version of the calibration suite web intereface for the configuration of some of the parameters for the calibration scans and the implementation of the latency scan with cal pulses. 

## Description
<!--- Describe your changes in detail -->
- Re-implementation of the calibration web interface  some scans have place holders and some parameters needs to be removed/changed)
- For a given scan, the run type is assigned and the parameters are sent with soap messages to the relevan hw managers.
- For each scan point, the parameters are updated in order on the varous hw managers through soap messages .
- The `RUNPARAMS` register is filled with the format correponding to issue #230. 

The configuration of the detector still needs to be fixed in `cmsgemos`, so atm the configuration is done with `confChamber.py`.

The code will still need to be cleaned up a bit and rebased to the latest develop branch version.
In the meanwhile, I can start addressing comments.  Thanks in advance!


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Introduction of the calibration suite web interface. 
Data format compatible with  Issue #230

## How Has This Been Tested?
The code has been tested on `gem904daq04` and the cofin setup with:
```
cd gemsupervisor
/opt/xdaq/bin/xdaq.exe -lINFO -p20516 -c $PWD/xml/gemsupervisor.xml 
```
 - In the web  [page](http://gem904daq04.cern.ch:20516/urn:xdaq-application:lid=16), then one has to initialize. 
 - On `gem904daq01`, as `gemuser` run the configuration of the detector with `confChamber.py --shelf=1 --slot=2 -g0  --vfatmask 0x1000 --run --gemType ge11 --detType short`.
 - On the calibration page, select the latency scan and choose the parameters (see screenshot below), click on `apply settings`.
 - On the supervisor web interface, click on `configure` and `start`.

The output result has been checked with the `ldqm`, but some more testing are required as soon as the issues with coffin setup get solved.


### Screenshots (if appropriate):

![Calibration web interface](https://user-images.githubusercontent.com/6152470/78270822-a0239d00-750b-11ea-8561-dd1fa902b024.png)
![list of applications](https://user-images.githubusercontent.com/6152470/78270833-a44fba80-750b-11ea-9c36-995d9522e630.png)
![Latency scan web interface](https://user-images.githubusercontent.com/6152470/78270892-bc273e80-750b-11ea-89df-dcb8d4b01204.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
